### PR TITLE
Insert ou update lors du PgConventionsToSyncRepository.save

### DIFF
--- a/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.integration.test.ts
+++ b/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.integration.test.ts
@@ -69,6 +69,23 @@ describe("PgConventionsRepository", () => {
     },
   );
 
+  it(`save updated conventionToSync`, async () => {
+    const initialConventionToSync: ConventionToSync = conventionsToSync[0];
+    await conventionsToSyncRepository.save(initialConventionToSync);
+
+    const updatedConventionToSync: ConventionToSync = {
+      ...conventionsToSync[0],
+      status: "SUCCESS",
+      processDate: new Date(),
+    };
+    await conventionsToSyncRepository.save(updatedConventionToSync);
+
+    expectToEqual(
+      await conventionsToSyncRepository.getById(initialConventionToSync.id),
+      updatedConventionToSync,
+    );
+  });
+
   describe("getNotProcessedAndErrored", () => {
     beforeEach(() =>
       Promise.all(

--- a/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.ts
+++ b/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.ts
@@ -55,22 +55,21 @@ type PgConventionToSync = {
   reason: string | null;
 };
 
-function pgResultToConventionToSync(
+const pgResultToConventionToSync = (
   pgConventionToSync: PgConventionToSync,
-): ConventionToSync {
-  return {
+): ConventionToSync =>
+  ({
     id: pgConventionToSync.id,
     status: pgConventionToSync.status,
     processDate: pgConventionToSync.process_date ?? undefined,
     reason: pgConventionToSync.reason ?? undefined,
-  } as ConventionToSync;
-}
+  } as ConventionToSync);
 
-async function isConventionToSyncAlreadyExists(
+const isConventionToSyncAlreadyExists = async (
   client: PoolClient,
   conventionId: ConventionId,
-): Promise<boolean> {
-  return (
+): Promise<boolean> =>
+  (
     await client.query(
       `SELECT EXISTS(SELECT 1
                      FROM ${conventionsToSyncTableName}
@@ -78,12 +77,11 @@ async function isConventionToSyncAlreadyExists(
       [conventionId],
     )
   ).rows.at(0).exists;
-}
 
-async function updateConventionToSync(
+const updateConventionToSync = async (
   client: PoolClient,
   conventionToSync: ConventionToSync,
-): Promise<void> {
+): Promise<void> => {
   await client.query(
     `
         UPDATE ${conventionsToSyncTableName}
@@ -103,12 +101,12 @@ async function updateConventionToSync(
         : null,
     ],
   );
-}
+};
 
-async function insertConventionToSync(
+const insertConventionToSync = async (
   client: PoolClient,
   conventionToSync: ConventionToSync,
-): Promise<void> {
+): Promise<void> => {
   await client.query(
     `
         INSERT INTO ${conventionsToSyncTableName} (id,
@@ -128,20 +126,19 @@ async function insertConventionToSync(
         : null,
     ],
   );
-}
+};
 
-async function selectConventionToSyncById(
+const selectConventionToSyncById = async (
   client: PoolClient,
   conventionId: ConventionId,
-): Promise<PgConventionToSync | undefined> {
-  return (
+): Promise<PgConventionToSync | undefined> =>
+  (
     await client.query<PgConventionToSync>(
       `
-        SELECT id, status, process_date, reason
-        FROM ${conventionsToSyncTableName}
-        WHERE id = $1
-    `,
+          SELECT id, status, process_date, reason
+          FROM ${conventionsToSyncTableName}
+          WHERE id = $1
+      `,
       [conventionId],
     )
   ).rows.at(0);
-}

--- a/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.ts
+++ b/back/src/adapters/secondary/pg/PgConventionsToSyncRepository.ts
@@ -29,38 +29,19 @@ export class PgConventionsToSyncRepository
   }
 
   async save(conventionToSync: ConventionToSync): Promise<void> {
-    await this.client.query(
-      `
-          INSERT INTO ${conventionsToSyncTableName} (id,
-                                                     status,
-                                                     process_date,
-                                                     reason)
-          VALUES ($1, $2, $3, $4)
-      `,
-      [
-        conventionToSync.id,
-        conventionToSync.status,
-        conventionToSync.status !== "TO_PROCESS"
-          ? conventionToSync.processDate
-          : null,
-        conventionToSync.status === "ERROR" ||
-        conventionToSync.status === "SKIP"
-          ? conventionToSync.reason
-          : null,
-      ],
-    );
+    return (await isConventionToSyncAlreadyExists(
+      this.client,
+      conventionToSync.id,
+    ))
+      ? updateConventionToSync(this.client, conventionToSync)
+      : insertConventionToSync(this.client, conventionToSync);
   }
 
   async getById(id: ConventionId): Promise<ConventionToSync | undefined> {
-    const queryResult = await this.client.query<PgConventionToSync>(
-      `
-          SELECT id, status, process_date, reason
-          FROM ${conventionsToSyncTableName}
-          WHERE id = $1
-      `,
-      [id],
+    const pgConventionToSync = await selectConventionToSyncById(
+      this.client,
+      id,
     );
-    const pgConventionToSync = queryResult.rows.at(0);
     return pgConventionToSync
       ? pgResultToConventionToSync(pgConventionToSync)
       : undefined;
@@ -83,4 +64,84 @@ function pgResultToConventionToSync(
     processDate: pgConventionToSync.process_date ?? undefined,
     reason: pgConventionToSync.reason ?? undefined,
   } as ConventionToSync;
+}
+
+async function isConventionToSyncAlreadyExists(
+  client: PoolClient,
+  conventionId: ConventionId,
+): Promise<boolean> {
+  return (
+    await client.query(
+      `SELECT EXISTS(SELECT 1
+                     FROM ${conventionsToSyncTableName}
+                     WHERE id = $1)`,
+      [conventionId],
+    )
+  ).rows.at(0).exists;
+}
+
+async function updateConventionToSync(
+  client: PoolClient,
+  conventionToSync: ConventionToSync,
+): Promise<void> {
+  await client.query(
+    `
+        UPDATE ${conventionsToSyncTableName}
+        SET status       = $2,
+            process_date = $3,
+            reason       = $4
+        WHERE id = $1
+    `,
+    [
+      conventionToSync.id,
+      conventionToSync.status,
+      conventionToSync.status !== "TO_PROCESS"
+        ? conventionToSync.processDate
+        : null,
+      conventionToSync.status === "ERROR" || conventionToSync.status === "SKIP"
+        ? conventionToSync.reason
+        : null,
+    ],
+  );
+}
+
+async function insertConventionToSync(
+  client: PoolClient,
+  conventionToSync: ConventionToSync,
+): Promise<void> {
+  await client.query(
+    `
+        INSERT INTO ${conventionsToSyncTableName} (id,
+                                                   status,
+                                                   process_date,
+                                                   reason)
+        VALUES ($1, $2, $3, $4)
+    `,
+    [
+      conventionToSync.id,
+      conventionToSync.status,
+      conventionToSync.status !== "TO_PROCESS"
+        ? conventionToSync.processDate
+        : null,
+      conventionToSync.status === "ERROR" || conventionToSync.status === "SKIP"
+        ? conventionToSync.reason
+        : null,
+    ],
+  );
+}
+
+async function selectConventionToSyncById(
+  client: PoolClient,
+  conventionId: ConventionId,
+): Promise<PgConventionToSync | undefined> {
+  return (
+    await client.query<PgConventionToSync>(
+      `
+        SELECT id, status, process_date, reason
+        FROM ${conventionsToSyncTableName}
+        WHERE id = $1
+    `,
+      [conventionId],
+    )
+  ).rows.at(0);
 }


### PR DESCRIPTION
# Problème

L'appel à `PgConventionsToSyncRepository.save()` ne fait qu'un `INSERT` en DB.  
Or on voudrait aussi pouvoir mettre à jour une convention.