### PR TITLE
typo dans des mails remonté par arnaud

### DIFF
--- a/front/src/app/components/search/ContactByEmail.tsx
+++ b/front/src/app/components/search/ContactByEmail.tsx
@@ -25,9 +25,11 @@ type ContactByEmailProps = {
   onClose: () => void;
 };
 
+const motivationPlaceholder =
+  "***Rédigez ici votre email de motivation en suivant nos conseils.***";
 const initialMessage = `Bonjour, \n\n\
 J’ai trouvé votre entreprise sur le site https://immersion-facile.beta.gouv.fr\n\
-***Rédigez ici votre email de motivation en suivant nos conseils.***\n\
+${motivationPlaceholder}
   \n\
 Pourriez-vous me contacter par mail ou par téléphone pour me proposer un rendez-vous ? \n\
 Je pourrais alors vous expliquer directement mon projet. \n\
@@ -74,7 +76,10 @@ export const ContactByEmail = ({
   const getFieldError = makeFieldError(formState);
 
   const onFormValid = async (values: ContactEstablishmentByMailDto) => {
-    await immersionSearchGateway.contactEstablishment(values);
+    await immersionSearchGateway.contactEstablishment({
+      ...values,
+      message: removeMotivationPlaceholder(values.message),
+    });
     onSuccess();
   };
   return (
@@ -212,3 +217,5 @@ const immersionObjectiveListOfOptions = conventionObjectiveOptions.map(
     label: immersionObjective,
   }),
 );
+const removeMotivationPlaceholder = (message: string) =>
+  message.replace(`\n${motivationPlaceholder}`, "");

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -896,7 +896,7 @@ export const emailTemplatesByName =
         subject: `${potentialBeneficiaryFirstName} ${potentialBeneficiaryLastName} vous contacte pour une demande d'immersion sur le métier de ${appellationLabel}`,
         greetings: `Bonjour ${contactFirstName} ${contactLastName},`,
         content: `
-        Un candidat souhaite faire une immersion pour ${immersionObject} sur le métier de ${appellationLabel} dans votre entreprise ${businessName} (${businessAddress}).
+        Un candidat souhaite faire une immersion pour "${immersionObject?.toLowerCase()}" sur le métier de ${appellationLabel} dans votre entreprise ${businessName} (${businessAddress}).
 
         Voici son message:
 

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -896,7 +896,7 @@ export const emailTemplatesByName =
         subject: `${potentialBeneficiaryFirstName} ${potentialBeneficiaryLastName} vous contacte pour une demande d'immersion sur le métier de ${appellationLabel}`,
         greetings: `Bonjour ${contactFirstName} ${contactLastName},`,
         content: `
-        Un candidat souhaite faire une immersion pour "${immersionObject?.toLowerCase()}" sur le métier de ${appellationLabel} dans votre entreprise ${businessName} (${businessAddress}).
+        Un candidat souhaite faire une immersion pour "${immersionObject?.toLowerCase()}" sur le métier de <strong>${appellationLabel}</strong> dans votre entreprise ${businessName} (${businessAddress}).
 
         Voici son message:
 


### PR DESCRIPTION
## ℹ️  Description

Retours sur les mails:

- [X] La ligne `Rédigez ici votre email de motivation en suivant nos conseils` qui apparait dans le mail final
- [X] Une majuscule de trop à "Confirmer[...]"
- [ ] Le nom de l'entreprise est pas le bon "Les services publics numériques de l'inclusion et de l'emploi" au lieu de "GIP Plateforme de l'inclusion"
- [X] Mettre en gras le nom du métier dans le corps du mail

## 🌈  Remarques

**Le nom de l'entreprise est pas le bon** --> dans l'exemple "Plateforme de l'inclusion" est celui renseigné dans le champ `name` et "Les services publics numériques de l'inclusion et de l'emploi" est celui renseigné dans le champ `customized_name` de la table `establishments` 
--> prévenir Arnaud
