### PR TITLE
fix rapport de synchronisation des conventions avec pe

### DIFF
--- a/back/src/adapters/primary/scripts/triggerResyncOldConventionsToPe.ts
+++ b/back/src/adapters/primary/scripts/triggerResyncOldConventionsToPe.ts
@@ -67,7 +67,7 @@ handleEndOfScriptNotification(
 
     return [
       `Total of convention to sync : ${
-        report.success + errors.length + errors.length
+        report.success + errors.length + skips.length
       }`,
       `Number of successfully sync convention : ${report.success}`,
       `Number of failures : ${errors.length}`,


### PR DESCRIPTION
# Description

Corriger l'erreur de calcul sur le total des conventions à synchroniser dans le rapport de synchronisation des conventions avec PE.