### PR TITLE
375 mettre un minimum dâge pour la demande de mini stage cci

### DIFF
--- a/back/src/adapters/primary/scripts/seed.ts
+++ b/back/src/adapters/primary/scripts/seed.ts
@@ -80,16 +80,16 @@ const agencySeed = async (uow: UnitOfWork, client: PoolClient) => {
 
   const cciAgency = new AgencyDtoBuilder()
     .withId(cciAgencyId)
-    .withName("CCI Bordeaux")
+    .withName("CCI Carnac")
     .withQuestionnaireUrl("https://questionnaire.seed")
     .withSignature("Seed signature")
     .withKind("cci")
     .withStatus("active")
     .withAddress({
-      city: "Paris",
-      departmentCode: "75",
-      postcode: "75001",
-      streetNumberAndAddress: "1 rue de Rivoli",
+      city: "Plouharnel",
+      departmentCode: "56",
+      postcode: "56340",
+      streetNumberAndAddress: "5 Kerhueno",
     })
     .build();
 

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -417,26 +417,51 @@ describe("conventionDtoSchema", () => {
     });
   });
 
-  it("rejects when beneficiary age is under 16yr with internship kind 'immersion'", () => {
-    const immersionStartDate = new Date("2022-01-01");
-    const beneficiary: Beneficiary<"immersion"> = {
-      birthdate: addDays(subYears(immersionStartDate, 16), 1).toISOString(),
-      email: "a@a.com",
-      firstName: "sdfgf",
-      lastName: "sdfs",
-      phone: "0011223344",
-      role: "beneficiary",
-      isRqth: false,
-    };
+  describe("when beneficiary is too young", () => {
+    it('rejects when beneficiary age is under 16yr with internship kind "immersion"', () => {
+      const immersionStartDate = new Date("2022-01-01");
+      const beneficiary: Beneficiary<"immersion"> = {
+        birthdate: addDays(subYears(immersionStartDate, 16), 1).toISOString(),
+        email: "a@a.com",
+        firstName: "sdfgf",
+        lastName: "sdfs",
+        phone: "0011223344",
+        role: "beneficiary",
+        isRqth: false,
+      };
 
-    const convention = new ConventionDtoBuilder()
-      .withInternshipKind("immersion")
-      .withDateStart(immersionStartDate.toISOString())
-      .withDateEnd(new Date("2022-01-02").toISOString())
-      .withBeneficiary(beneficiary)
-      .build();
+      const convention = new ConventionDtoBuilder()
+        .withInternshipKind("immersion")
+        .withDateStart(immersionStartDate.toISOString())
+        .withDateEnd(new Date("2022-01-02").toISOString())
+        .withBeneficiary(beneficiary)
+        .build();
 
-    expectConventionDtoToBeInvalid(convention);
+      expectConventionDtoToBeInvalid(convention);
+    });
+
+    it('rejects when beneficiary age is under 14yr with internship kind "mini-stage-cci"', () => {
+      const immersionStartDate = new Date("2022-01-01");
+      const beneficiary: Beneficiary<"mini-stage-cci"> = {
+        levelOfEducation: "Terminale",
+        birthdate: addDays(subYears(immersionStartDate, 14), 1).toISOString(),
+        email: "a@a.com",
+        firstName: "sdfgf",
+        lastName: "sdfs",
+        phone: "0011223344",
+        role: "beneficiary",
+      };
+
+      const convention = new ConventionDtoBuilder()
+        .withInternshipKind("mini-stage-cci")
+        .withDateStart(immersionStartDate.toISOString())
+        .withDateEnd(new Date("2022-01-02").toISOString())
+        .withSchedule(reasonableSchedule)
+        .withBeneficiary(beneficiary)
+        .build();
+
+      expectConventionDtoToBeInvalid(convention);
+    });
   });
 });
 

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -1,5 +1,6 @@
 import { addDays, subYears } from "date-fns";
 import { keys } from "ramda";
+import { z, ZodError } from "zod";
 import { reasonableSchedule } from "../schedule/ScheduleUtils";
 import { splitCasesBetweenPassingAndFailing } from "../test.helpers";
 import {
@@ -20,6 +21,7 @@ import {
   conventionSchema,
 } from "./convention.schema";
 import { ConventionDtoBuilder, DATE_START } from "./ConventionDtoBuilder";
+import { getConventionTooLongMessageAndPath } from "./conventionRefinements";
 
 const currentEmployer: BeneficiaryCurrentEmployer = {
   role: "beneficiary-current-employer",
@@ -76,38 +78,68 @@ describe("conventionDtoSchema", () => {
     });
 
     it("rejects equal beneficiary and establishment tutor emails", () => {
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder()
           .withBeneficiaryEmail("demandeur@mail.fr")
           .withEstablishmentTutorEmail("demandeur@mail.fr")
           .build(),
+        [
+          "Le mail du tuteur doit être différent des mails du bénéficiaire, de son représentant légal et de son employeur actuel.",
+        ],
       );
     });
 
     it("rejects equal beneficiary and establishment representative emails", () => {
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder()
           .withBeneficiaryEmail("demandeur@mail.fr")
           .withEstablishmentRepresentativeEmail("demandeur@mail.fr")
           .build(),
+        [
+          "Les emails des signataires doivent être différents.",
+          "Les emails des signataires doivent être différents.",
+        ],
       );
     });
 
     it("rejects equal beneficiary and beneficiary representative emails", () => {
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder()
           .withBeneficiaryEmail("demandeur@mail.fr")
           .withBeneficiaryRepresentative(beneficiaryRepresentative)
           .build(),
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Les emails des signataires doivent être différents.",
+          "Les emails des signataires doivent être différents.",
+        ],
       );
     });
 
     it("rejects equal beneficiary representative and establishment tutor emails", () => {
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder()
           .withEstablishmentTutorEmail(beneficiaryRepresentative.email)
           .withBeneficiaryRepresentative(beneficiaryRepresentative)
           .build(),
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Le mail du tuteur doit être différent des mails du bénéficiaire, de son représentant légal et de son employeur actuel.",
+        ],
       );
     });
 
@@ -115,23 +147,77 @@ describe("conventionDtoSchema", () => {
       const convention = new ConventionDtoBuilder()
         .withBeneficiaryCurrentEmployer(currentEmployer)
         .build();
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder(convention)
           .withBeneficiaryEmail(currentEmployer.email)
           .build(),
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "SIRET doit être composé de 14 chiffres",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Les emails des signataires doivent être différents.",
+          "Les emails des signataires doivent être différents.",
+        ],
       );
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder(convention)
           .withBeneficiaryRepresentative({
             ...currentEmployer,
             role: "beneficiary-representative",
           })
           .build(),
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "SIRET doit être composé de 14 chiffres",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Les emails des signataires doivent être différents.",
+          "Les emails des signataires doivent être différents.",
+        ],
       );
-      expectConventionDtoToBeInvalid(
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
         new ConventionDtoBuilder(convention)
           .withEstablishmentRepresentativeEmail(currentEmployer.email)
           .build(),
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "SIRET doit être composé de 14 chiffres",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Les emails des signataires doivent être différents.",
+          "Les emails des signataires doivent être différents.",
+        ],
       );
     });
 
@@ -155,14 +241,28 @@ describe("conventionDtoSchema", () => {
         agencyDepartment: "90",
         externalId: "sdfsdff",
       };
-      expect(() => conventionReadSchema.parse(invalidConventionRead)).toThrow();
+      expectConventionInvalidWithIssueMessages(
+        conventionReadSchema,
+        invalidConventionRead,
+        [
+          "Obligatoire",
+          "Numéro de téléphone incorrect",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Obligatoire",
+          "Le mail du tuteur doit être différent des mails du bénéficiaire, de son représentant légal et de son employeur actuel.",
+        ],
+      );
     });
   });
 
   it("rejects when string with spaces are provided", () => {
     const convention = new ConventionDtoBuilder().withId("  ").build();
 
-    expectConventionDtoToBeInvalid(convention);
+    expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+      "Le format de l'identifiant est invalide",
+    ]);
   });
 
   it("rejects when phone is not a valid number", () => {
@@ -170,13 +270,17 @@ describe("conventionDtoSchema", () => {
       .withBeneficiaryPhone("wrong")
       .build();
 
-    expectConventionDtoToBeInvalid(convention);
+    expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+      "Numéro de téléphone incorrect",
+    ]);
 
     const convention2 = new ConventionDtoBuilder()
       .withBeneficiaryPhone("0203stillWrong")
       .build();
 
-    expectConventionDtoToBeInvalid(convention2);
+    expectConventionInvalidWithIssueMessages(conventionSchema, convention2, [
+      "Numéro de téléphone incorrect",
+    ]);
   });
 
   it("rejects when establishmentTutorPhone is not a valid number", () => {
@@ -184,7 +288,9 @@ describe("conventionDtoSchema", () => {
       .withEstablishementTutorPhone("wrong")
       .build();
 
-    expectConventionDtoToBeInvalid(convention);
+    expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+      "Numéro de téléphone incorrect",
+    ]);
   });
 
   describe("constraint on dates", () => {
@@ -193,7 +299,9 @@ describe("conventionDtoSchema", () => {
         .withDateSubmission("not-a-date")
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "Le format de la date saisie est invalide",
+      ]);
     });
 
     it("rejects misformatted start dates", () => {
@@ -201,7 +309,11 @@ describe("conventionDtoSchema", () => {
         .withDateStart("not-a-date")
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "Le format de la date de début est invalide",
+        "La date de fin doit être après la date de début.",
+        "La durée maximale calendaire d'une immersion est de 30 jours.",
+      ]);
     });
 
     it("rejects misformatted end dates", () => {
@@ -209,7 +321,11 @@ describe("conventionDtoSchema", () => {
         .withDateEnd("not-a-date")
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "Le format de la date de fin est invalide",
+        "La date de fin doit être après la date de début.",
+        "La durée maximale calendaire d'une immersion est de 30 jours.",
+      ]);
     });
 
     it("rejects start dates that are after the end date", () => {
@@ -218,7 +334,9 @@ describe("conventionDtoSchema", () => {
         .withDateEnd("2021-01-03")
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "La date de fin doit être après la date de début.",
+      ]);
     });
 
     it("accept start dates that are tuesday if submitting on previous friday", () => {
@@ -234,36 +352,46 @@ describe("conventionDtoSchema", () => {
     describe("Correctly handles max authorized number of days", () => {
       const calendarDayAndInternShips = keys(
         maximumCalendarDayByInternshipKind,
-      ).map((intershipKind) => ({
-        intershipKind,
-        maxCalendarDays: maximumCalendarDayByInternshipKind[intershipKind],
+      ).map((internshipKind) => ({
+        internshipKind,
+        maxCalendarDays: maximumCalendarDayByInternshipKind[internshipKind],
       }));
 
       it.each(calendarDayAndInternShips)(
         "for $intershipKind rejects when it is more than $maxCalendarDays",
-        ({ intershipKind, maxCalendarDays }) => {
+        ({ internshipKind, maxCalendarDays }) => {
           const convention = new ConventionDtoBuilder()
-            .withInternshipKind(intershipKind)
+            .withInternshipKind(internshipKind)
             .withDateStart(DATE_START)
             .withDateEnd(
               addDays(new Date(DATE_START), maxCalendarDays + 1).toISOString(),
             )
             .build();
 
-          expectConventionDtoToBeInvalid(convention);
+          expectConventionInvalidWithIssueMessages(
+            conventionSchema,
+            convention,
+            [
+              getConventionTooLongMessageAndPath({
+                internshipKind,
+                dateEnd: "",
+                dateStart: "",
+              }).message,
+            ],
+          );
         },
       );
 
       it.each(calendarDayAndInternShips)(
         "for $intershipKind accepts end date that are <= $maxCalendarDays calendar days after the start date",
-        ({ intershipKind, maxCalendarDays }) => {
+        ({ internshipKind, maxCalendarDays }) => {
           const dateStart = DATE_START;
           const dateEnd = addDays(
             new Date(DATE_START),
             maxCalendarDays,
           ).toISOString();
           const convention = new ConventionDtoBuilder()
-            .withInternshipKind(intershipKind)
+            .withInternshipKind(internshipKind)
             .withDateStart(dateStart)
             .withDateEnd(dateEnd)
             .build();
@@ -282,7 +410,7 @@ describe("conventionDtoSchema", () => {
           .withDateEnd(dateEnd)
           .withSchedule(reasonableSchedule)
           .withBeneficiary({
-            birthdate: new Date("2008-05-26").toISOString(),
+            birthdate: new Date("2006-05-26").toISOString(),
             firstName: "Jean",
             lastName: "Bono",
             role: "beneficiary",
@@ -292,7 +420,9 @@ describe("conventionDtoSchema", () => {
             isRqth: false,
           })
           .build();
-        expectConventionDtoToBeInvalid(convention);
+        expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+          "La durée maximale hebdomadaire pour un mini-stage d'une personne de moins de 16 ans est de 30h",
+        ]);
       });
     });
     describe("status that are available without signatures", () => {
@@ -324,7 +454,11 @@ describe("conventionDtoSchema", () => {
             .withStatus(status)
             .notSigned()
             .build();
-          expectConventionDtoToBeInvalid(convention);
+          expectConventionInvalidWithIssueMessages(
+            conventionSchema,
+            convention,
+            ["La confirmation de votre accord est obligatoire."],
+          );
         },
       );
     });
@@ -409,11 +543,11 @@ describe("conventionDtoSchema", () => {
             establishmentRepresentative,
           },
         };
-      expect(() =>
-        conventionInternshipKindSpecificSchema.parse(
-          badConventionInternshipKindSpecific,
-        ),
-      ).toThrow();
+      expectConventionInvalidWithIssueMessages(
+        conventionInternshipKindSpecificSchema,
+        badConventionInternshipKindSpecific,
+        ["Votre niveau d'étude est obligatoire."],
+      );
     });
   });
 
@@ -437,7 +571,9 @@ describe("conventionDtoSchema", () => {
         .withBeneficiary(beneficiary)
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "L'âge du bénéficiaire doit être au minimum de 16ans",
+      ]);
     });
 
     it('rejects when beneficiary age is under 14yr with internship kind "mini-stage-cci"', () => {
@@ -460,7 +596,9 @@ describe("conventionDtoSchema", () => {
         .withBeneficiary(beneficiary)
         .build();
 
-      expectConventionDtoToBeInvalid(convention);
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "L'âge du bénéficiaire doit être au minimum de 14ans",
+      ]);
     });
   });
 });
@@ -470,5 +608,21 @@ const expectConventionDtoToBeValid = (validConvention: ConventionDto): void => {
   expect(conventionSchema.parse(validConvention)).toBeTruthy();
 };
 
-const expectConventionDtoToBeInvalid = (conventionDto: ConventionDto) =>
-  expect(() => conventionSchema.parse(conventionDto)).toThrow();
+const expectConventionInvalidWithIssueMessages = <T>(
+  schema: z.Schema<T>,
+  convention: T,
+  issueMessages: string[],
+) => {
+  expect(() => schema.parse(convention)).toThrow();
+  try {
+    schema.parse(convention);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      error.issues.forEach((issue, index) => {
+        expect(issue.message).toEqual(issueMessages[index]);
+      });
+      return;
+    }
+    throw new Error("Error expected when parsing convention");
+  }
+};

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -58,6 +58,7 @@ export const maximumCalendarDayByInternshipKind: Record<
   "mini-stage-cci": 5,
 };
 export const IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT = 16;
+export const MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT = 14;
 export const CCI_WEEKLY_LIMITED_SCHEDULE_HOURS = 30;
 export const CCI_WEEKLY_LIMITED_SCHEDULE_AGE = 16;
 
@@ -161,14 +162,14 @@ type StudentProperties = {
 //prettier-ignore
 export type Beneficiary<T extends InternshipKind> =
   GenericSignatory<"beneficiary"> & {
-    emergencyContact?: string;
-    emergencyContactPhone?: string;
-    emergencyContactEmail?: Email;
-    federatedIdentity?: PeConnectIdentity;
-    financiaryHelp?:string;
-    birthdate: string; // Date iso string
-    isRqth?: boolean;
-  } 
+  emergencyContact?: string;
+  emergencyContactPhone?: string;
+  emergencyContactEmail?: Email;
+  federatedIdentity?: PeConnectIdentity;
+  financiaryHelp?: string;
+  birthdate: string; // Date iso string
+  isRqth?: boolean;
+}
   & (T extends "mini-stage-cci" ? StudentProperties : {});
 /* eslint-enable @typescript-eslint/ban-types */
 

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -47,6 +47,7 @@ import {
   InternshipKind,
   internshipKinds,
   levelsOfEducation,
+  MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT,
   RenewMagicLinkRequestDto,
   Signatories,
   UpdateConventionRequestDto,
@@ -278,6 +279,16 @@ export const conventionWithoutExternalIdSchema: z.Schema<ConventionDtoWithoutExt
       )
         addIssue(
           `L'âge minimum du bénéficiaire est de ${IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT}ans`,
+          getConventionFieldName("signatories.beneficiary.birthdate"),
+        );
+
+      if (
+        convention.internshipKind === "mini-stage-cci" &&
+        beneficiaryAgeAtConventionStart <
+          MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT
+      )
+        addIssue(
+          `L'âge minimum du bénéficiaire est de ${MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT}ans`,
           getConventionFieldName("signatories.beneficiary.birthdate"),
         );
     })

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -224,73 +224,34 @@ export const conventionWithoutExternalIdSchema: z.Schema<ConventionDtoWithoutExt
           path: [path],
         });
       };
-
-      const signatoriesWithEmail = Object.entries(convention.signatories)
-        .filter(([_, value]) => !!value)
-        .map(([key, value]) => ({
-          key: key as keyof Signatories,
-          email: value.email,
-        }));
-      signatoriesWithEmail.forEach((signatory) => {
-        if (
-          signatoriesWithEmail
-            .filter((otherSignatory) => otherSignatory.key !== signatory.key)
-            .some((otherSignatory) => otherSignatory.email === signatory.email)
-        )
-          addIssue(
-            localization.signatoriesDistinctEmails,
-            getConventionFieldName(`signatories.${signatory.key}.email`),
-          );
-      });
-
-      if (
-        !isTutorEmailDifferentThanBeneficiaryRelatedEmails(
-          convention.signatories,
-          convention.establishmentTutor,
-        )
-      )
-        addIssue(
-          localization.beneficiaryTutorEmailMustBeDistinct,
-          getConventionFieldName("establishmentTutor.email"),
-        );
-
       const beneficiaryAgeAtConventionStart = differenceInYears(
         new Date(convention.dateStart),
         new Date(convention.signatories.beneficiary.birthdate),
       );
-      const weeklyHours = calculateWeeklyHoursFromSchedule(convention.schedule);
-      if (
-        convention.internshipKind === "mini-stage-cci" &&
-        beneficiaryAgeAtConventionStart < CCI_WEEKLY_LIMITED_SCHEDULE_AGE &&
-        weeklyHours.some(
-          (weeklyHourSet) => weeklyHourSet > CCI_WEEKLY_LIMITED_SCHEDULE_HOURS,
-        )
-      ) {
-        addIssue(
-          `La durée maximale hebdomadaire pour un mini-stage d'une personne de moins de ${CCI_WEEKLY_LIMITED_SCHEDULE_AGE} ans est de ${CCI_WEEKLY_LIMITED_SCHEDULE_HOURS}h`,
-          getConventionFieldName("schedule.totalHours"),
+
+      addIssuesIfDuplicateSignatoriesEmails(convention, addIssue);
+      addIssueIfDuplicateEmailsBetweenSignatoriesAndTutor(convention, addIssue);
+
+      if (convention.internshipKind === "mini-stage-cci") {
+        addIssueIfLimitedScheduleHoursExceeded(
+          convention,
+          addIssue,
+          beneficiaryAgeAtConventionStart,
+        );
+        addIssueIfAgeLessThanMinimumAge(
+          addIssue,
+          beneficiaryAgeAtConventionStart,
+          MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT,
         );
       }
 
-      if (
-        beneficiaryAgeAtConventionStart <
-          IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT &&
-        convention.internshipKind === "immersion"
-      )
-        addIssue(
-          `L'âge minimum du bénéficiaire est de ${IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT}ans`,
-          getConventionFieldName("signatories.beneficiary.birthdate"),
+      if (convention.internshipKind === "immersion") {
+        addIssueIfAgeLessThanMinimumAge(
+          addIssue,
+          beneficiaryAgeAtConventionStart,
+          IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT,
         );
-
-      if (
-        convention.internshipKind === "mini-stage-cci" &&
-        beneficiaryAgeAtConventionStart <
-          MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT
-      )
-        addIssue(
-          `L'âge minimum du bénéficiaire est de ${MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT}ans`,
-          getConventionFieldName("signatories.beneficiary.birthdate"),
-        );
+      }
     })
     .refine(mustBeSignedByEveryone, {
       message: localization.mustBeSignedByEveryone,
@@ -349,3 +310,73 @@ export const renewMagicLinkRequestSchema: z.Schema<RenewMagicLinkRequestDto> =
     originalUrl: z.string(),
     expiredJwt: z.string(),
   });
+
+const addIssuesIfDuplicateSignatoriesEmails = (
+  convention: ConventionDtoWithoutExternalId,
+  addIssue: (message: string, path: string) => void,
+) => {
+  const signatoriesWithEmail = Object.entries(convention.signatories)
+    .filter(([_, value]) => !!value)
+    .map(([key, value]) => ({
+      key: key as keyof Signatories,
+      email: value.email,
+    }));
+  signatoriesWithEmail.forEach((signatory) => {
+    if (
+      signatoriesWithEmail
+        .filter((otherSignatory) => otherSignatory.key !== signatory.key)
+        .some((otherSignatory) => otherSignatory.email === signatory.email)
+    )
+      addIssue(
+        localization.signatoriesDistinctEmails,
+        getConventionFieldName(`signatories.${signatory.key}.email`),
+      );
+  });
+};
+
+const addIssueIfDuplicateEmailsBetweenSignatoriesAndTutor = (
+  convention: ConventionDtoWithoutExternalId,
+  addIssue: (message: string, path: string) => void,
+) => {
+  if (
+    !isTutorEmailDifferentThanBeneficiaryRelatedEmails(
+      convention.signatories,
+      convention.establishmentTutor,
+    )
+  )
+    addIssue(
+      localization.beneficiaryTutorEmailMustBeDistinct,
+      getConventionFieldName("establishmentTutor.email"),
+    );
+};
+
+const addIssueIfLimitedScheduleHoursExceeded = (
+  convention: ConventionDtoWithoutExternalId,
+  addIssue: (message: string, path: string) => void,
+  beneficiaryAgeAtConventionStart: number,
+) => {
+  const weeklyHours = calculateWeeklyHoursFromSchedule(convention.schedule);
+  if (
+    beneficiaryAgeAtConventionStart < CCI_WEEKLY_LIMITED_SCHEDULE_AGE &&
+    weeklyHours.some(
+      (weeklyHourSet) => weeklyHourSet > CCI_WEEKLY_LIMITED_SCHEDULE_HOURS,
+    )
+  ) {
+    addIssue(
+      `La durée maximale hebdomadaire pour un mini-stage d'une personne de moins de ${CCI_WEEKLY_LIMITED_SCHEDULE_AGE} ans est de ${CCI_WEEKLY_LIMITED_SCHEDULE_HOURS}h`,
+      getConventionFieldName("schedule.totalHours"),
+    );
+  }
+};
+
+const addIssueIfAgeLessThanMinimumAge = (
+  addIssue: (message: string, path: string) => void,
+  beneficiaryAgeAtConventionStart: number,
+  miniumAgeRequirement: number,
+) => {
+  if (beneficiaryAgeAtConventionStart < miniumAgeRequirement)
+    addIssue(
+      `L'âge du bénéficiaire doit être au minimum de ${miniumAgeRequirement}ans`,
+      getConventionFieldName("signatories.beneficiary.birthdate"),
+    );
+};


### PR DESCRIPTION
# Description

Mettre un place un minimum d'âge pour faire une demande mini-stage.

# Remarque

Cette PR inclut aussi:
- modification des seeds d'agence (pour pouvoir créer une demande mini-stage depuis l'interface web) 
- modification des tests du schema de convention pour rendre explicites pourquoi les conventions invalides le sont