### PR TITLE
fix 400 when submit contact establishment again

### DIFF
--- a/front/src/app/components/search/ContactByEmail.tsx
+++ b/front/src/app/components/search/ContactByEmail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { fr } from "@codegouvfr/react-dsfr";
 import Alert from "@codegouvfr/react-dsfr/Alert";
@@ -14,6 +14,7 @@ import {
   domElementIds,
   SiretDto,
 } from "shared";
+import { usePotentialBeneficiaryValues } from "src/app/components/search/usePotentialBeneficiaryValues";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
 import { immersionSearchGateway } from "src/config/dependencies";
 import { EmailValidationInput } from "../forms/commons/EmailValidationInput";
@@ -72,13 +73,9 @@ export const ContactByEmail = ({
     handleSubmit,
     formState,
     formState: { isSubmitting },
-    getValues,
-    reset,
   } = methods;
 
-  useEffect(() => {
-    reset({ ...getValues(), appellationCode: initialValues.appellationCode });
-  }, [appellations]);
+  usePotentialBeneficiaryValues(initialValues, methods, appellations);
 
   const getFieldError = makeFieldError(formState);
 

--- a/front/src/app/components/search/ContactByPhone.tsx
+++ b/front/src/app/components/search/ContactByPhone.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
@@ -11,6 +11,7 @@ import {
   domElementIds,
   SiretDto,
 } from "shared";
+import { usePotentialBeneficiaryValues } from "src/app/components/search/usePotentialBeneficiaryValues";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
 import { immersionSearchGateway } from "src/config/dependencies";
 
@@ -51,13 +52,9 @@ export const ContactByPhone = ({
     handleSubmit,
     formState,
     formState: { isSubmitting },
-    reset,
-    getValues,
   } = methods;
 
-  useEffect(() => {
-    reset({ ...getValues(), appellationCode: initialValues.appellationCode });
-  }, [appellations]);
+  usePotentialBeneficiaryValues(initialValues, methods, appellations);
 
   const getFieldError = makeFieldError(formState);
 

--- a/front/src/app/components/search/ContactInPerson.tsx
+++ b/front/src/app/components/search/ContactInPerson.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
@@ -11,6 +11,7 @@ import {
   domElementIds,
   SiretDto,
 } from "shared";
+import { usePotentialBeneficiaryValues } from "src/app/components/search/usePotentialBeneficiaryValues";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
 import { immersionSearchGateway } from "src/config/dependencies";
 
@@ -50,13 +51,9 @@ export const ContactInPerson = ({
     handleSubmit,
     formState,
     formState: { isSubmitting },
-    reset,
-    getValues,
   } = methods;
 
-  useEffect(() => {
-    reset({ ...getValues(), appellationCode: initialValues.appellationCode });
-  }, [appellations]);
+  usePotentialBeneficiaryValues(initialValues, methods, appellations);
 
   const getFieldError = makeFieldError(formState);
 

--- a/front/src/app/components/search/usePotentialBeneficiaryValues.ts
+++ b/front/src/app/components/search/usePotentialBeneficiaryValues.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { UseFormReturn } from "react-hook-form";
+import { AppellationDto, ContactEstablishmentRequestDto } from "shared";
+
+export const usePotentialBeneficiaryValues = <
+  T extends ContactEstablishmentRequestDto,
+>(
+  initialValues: T,
+  methods: UseFormReturn<T>,
+  appellations: AppellationDto[],
+) => {
+  useEffect(() => {
+    const values = methods.getValues();
+    const resetValues = {
+      ...initialValues,
+      potentialBeneficiaryEmail: values.potentialBeneficiaryEmail,
+      potentialBeneficiaryFirstName: values.potentialBeneficiaryFirstName,
+      potentialBeneficiaryLastName: values.potentialBeneficiaryLastName,
+      ...(values.contactMode === "EMAIL" && {
+        message: values.message,
+        immersionObjective: values.immersionObjective,
+        potentialBeneficiaryPhone: values.potentialBeneficiaryPhone,
+        potentialBeneficiaryResumeLink: values.potentialBeneficiaryResumeLink,
+      }),
+    };
+
+    methods.reset(resetValues);
+  }, [appellations]);
+};


### PR DESCRIPTION
# Description

Bug constaté sur une page de recherche d'entreprise:
1. On fait une première demande de contact d'entreprise
2. La requête API se passe bien: on reçoit une 200
3. Sur une autre entreprise on fait aussi une demande de contact
4. Erreur API: on reçoit une 409

# Problème

Lors du deuxième appel API, le `siret` envoyé est resté celui de la première entreprise.