### PR TITLE
Uniformiser les formats d'erreurs renvoyé depuis nos routes api V2

### DIFF
--- a/back/src/adapters/primary/authMiddleware.ts
+++ b/back/src/adapters/primary/authMiddleware.ts
@@ -283,7 +283,7 @@ export const verifyJwtConfig = <K extends JwtKind>(config: AppConfig) => {
 };
 
 const responseErrorForV2 = (res: Response, message: string, status = 403) =>
-  res.status(status).json({ message: `forbidden: ${message}`, status });
+  res.status(status).json({ message, status });
 
 export const makeApiKeyAuthMiddlewareV2 = (
   getApiConsumerById: GetApiConsumerById,

--- a/back/src/adapters/primary/config/createAppDependencies.ts
+++ b/back/src/adapters/primary/config/createAppDependencies.ts
@@ -13,6 +13,7 @@ import { makeAdminAuthMiddleware } from "../adminAuthMiddleware";
 import {
   createApiKeyAuthMiddlewareV0,
   makeApiKeyAuthMiddlewareV1,
+  makeApiKeyAuthMiddlewareV2,
   makeMagicLinkAuthMiddleware,
 } from "../authMiddleware";
 import {
@@ -110,7 +111,12 @@ export const createAppDependencies = async (config: AppConfig) => {
       gateways.timeGateway,
       config,
     ),
-    apiKeyAuthMiddleware: makeApiKeyAuthMiddlewareV1(
+    apiKeyAuthMiddlewareV1: makeApiKeyAuthMiddlewareV1(
+      useCases.getApiConsumerById.execute,
+      gateways.timeGateway,
+      config,
+    ),
+    apiKeyAuthMiddlewareV2: makeApiKeyAuthMiddlewareV2(
       useCases.getApiConsumerById.execute,
       gateways.timeGateway,
       config,

--- a/back/src/adapters/primary/helpers/handleHttpJsonResponseError.ts
+++ b/back/src/adapters/primary/helpers/handleHttpJsonResponseError.ts
@@ -2,6 +2,11 @@ import { Request, Response } from "express";
 import { HttpError } from "./httpErrors";
 import { unhandledError } from "./unhandledError";
 
+type ErrorObject = {
+  errorMessage: string;
+  status: number;
+  issues?: string[];
+};
 export const handleHttpJsonResponseError = (
   req: Request,
   res: Response,
@@ -12,6 +17,24 @@ export const handleHttpJsonResponseError = (
   if (error instanceof HttpError) {
     res.status(error.httpCode);
     return res.json({ errors: toValidJSONObjectOrString(error) });
+  }
+
+  throw Error("Should never reach there");
+};
+
+export const handleHttpJsonResponseErrorForApiV2 = (
+  req: Request,
+  res: Response,
+  error: any,
+): Response<any, Record<string, ErrorObject>> => {
+  if (!isManagedError(error)) return unhandledError(error, req, res);
+
+  if (error instanceof HttpError) {
+    res.status(error.httpCode);
+    return res.json({
+      message: toValidJSONObjectOrString(error),
+      status: error.httpCode,
+    });
   }
 
   throw Error("Should never reach there");

--- a/back/src/adapters/primary/helpers/httpErrors.schema.ts
+++ b/back/src/adapters/primary/helpers/httpErrors.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const errorSchema = z.object({
+  status: z.number(),
+  message: z.string(),
+  issues: z.array(z.string()).optional(),
+});

--- a/back/src/adapters/primary/helpers/sendHttpResponse.ts
+++ b/back/src/adapters/primary/helpers/sendHttpResponse.ts
@@ -1,5 +1,8 @@
 import { Request, Response } from "express";
-import { handleHttpJsonResponseError } from "./handleHttpJsonResponseError";
+import {
+  handleHttpJsonResponseError,
+  handleHttpJsonResponseErrorForApiV2,
+} from "./handleHttpJsonResponseError";
 
 export const sendHttpResponse = async (
   request: Request<any, any, any, any, any>,
@@ -11,5 +14,18 @@ export const sendHttpResponse = async (
     return response.json(useCaseResult);
   } catch (error: any) {
     handleHttpJsonResponseError(request, response, error);
+  }
+};
+
+export const sendHttpResponseForApiV2 = async (
+  request: Request<any, any, any, any, any>,
+  response: Response,
+  callback: () => Promise<unknown>,
+) => {
+  try {
+    const useCaseResult = await callback();
+    return response.json(useCaseResult);
+  } catch (error: any) {
+    handleHttpJsonResponseErrorForApiV2(request, response, error);
   }
 };

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
@@ -71,7 +71,7 @@ describe("POST contact-establishment public V2 route", () => {
     });
     expectToEqual(response, {
       status: 401,
-      body: { error: "forbidden: unauthenticated" },
+      body: { status: 401, message: "forbidden: unauthenticated" },
     });
   });
 
@@ -86,7 +86,8 @@ describe("POST contact-establishment public V2 route", () => {
     expectToEqual(response, {
       status: 404,
       body: {
-        errors: `No establishment found with siret: ${contactEstablishment.siret}`,
+        status: 404,
+        message: `No establishment found with siret: ${contactEstablishment.siret}`,
       },
     });
   });
@@ -106,7 +107,8 @@ describe("POST contact-establishment public V2 route", () => {
     expectToEqual(response, {
       status: 403,
       body: {
-        error: "forbidden: unauthorised consumer Id",
+        status: 403,
+        message: "forbidden: unauthorised consumer Id",
       },
     });
   });
@@ -165,7 +167,8 @@ describe("POST contact-establishment public V2 route", () => {
     expectToEqual(response, {
       status: 400,
       body: {
-        errors: `Contact mode mismatch: ${contactEstablishment.contactMode} in params. In contact (fetched with siret) : ${testEstablishmentContactMethod}`,
+        status: 400,
+        message: `Contact mode mismatch: ${contactEstablishment.contactMode} in params. In contact (fetched with siret) : ${testEstablishmentContactMethod}`,
       },
     });
   });
@@ -203,7 +206,8 @@ describe("POST contact-establishment public V2 route", () => {
     expectToEqual(response, {
       status: 400,
       body: {
-        errors: `Establishment with siret '${contactEstablishment.siret}' doesn't have an immersion offer with appellation code '${contactEstablishment.appellationCode}'.`,
+        status: 400,
+        message: `Establishment with siret '${contactEstablishment.siret}' doesn't have an immersion offer with appellation code '${contactEstablishment.appellationCode}'.`,
       },
     });
   });
@@ -235,7 +239,7 @@ describe("POST contact-establishment public V2 route", () => {
       .set("Authorization", generateApiJwt(validApiConsumerJwtPayload))
       .send(contactEstablishment);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     expect(response.body).toBe("");
   });
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
@@ -71,7 +71,7 @@ describe("POST contact-establishment public V2 route", () => {
     });
     expectToEqual(response, {
       status: 401,
-      body: { status: 401, message: "forbidden: unauthenticated" },
+      body: { status: 401, message: "unauthenticated" },
     });
   });
 
@@ -108,7 +108,7 @@ describe("POST contact-establishment public V2 route", () => {
       status: 403,
       body: {
         status: 403,
-        message: "forbidden: unauthorised consumer Id",
+        message: "unauthorised consumer Id",
       },
     });
   });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v1.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v1.ts
@@ -24,7 +24,7 @@ const logger = createLogger(__filename);
 export const createApiKeyAuthRouterV1 = (deps: AppDependencies) => {
   const publicV1Router = Router({ mergeParams: true });
 
-  publicV1Router.use(deps.apiKeyAuthMiddleware);
+  publicV1Router.use(deps.apiKeyAuthMiddlewareV1);
 
   // Form establishments routes
   publicV1Router

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { pipeWithValue, SiretAndAppellationDto } from "shared";
+import { pipeWithValue } from "shared";
 import { createExpressSharedRouter } from "shared-routes/express";
 import { createLogger } from "../../../../utils/logger";
 import type { AppDependencies } from "../../config/createAppDependencies";
@@ -7,7 +7,7 @@ import {
   ForbiddenError,
   validateAndParseZodSchema,
 } from "../../helpers/httpErrors";
-import { sendHttpResponse } from "../../helpers/sendHttpResponse";
+import { sendHttpResponseForApiV2 } from "../../helpers/sendHttpResponse";
 import { contactEstablishmentPublicV2ToDomain } from "../DtoAndSchemas/v2/input/ContactEstablishmentPublicV2.dto";
 import { contactEstablishmentPublicV2Schema } from "../DtoAndSchemas/v2/input/ContactEstablishmentPublicV2.schema";
 import { searchImmersionRequestPublicV2ToDomain } from "../DtoAndSchemas/v2/input/SearchImmersionRequestPublicV2.dto";
@@ -27,9 +27,9 @@ export const createApiKeyAuthRouterV2 = (deps: AppDependencies) => {
   );
 
   publicV2SharedRouter.searchImmersion(async (req, res) =>
-    sendHttpResponse(req, res, async () => {
+    sendHttpResponseForApiV2(req, res, async () => {
       const searchImmersionRequest = searchImmersionRequestPublicV2ToDomain(
-        req.query as any,
+        req.query,
       );
       const searchImmersionResultDtos =
         await deps.useCases.searchImmersion.execute(
@@ -43,14 +43,14 @@ export const createApiKeyAuthRouterV2 = (deps: AppDependencies) => {
   );
 
   publicV2SharedRouter.getOfferBySiretAndAppellationCode(async (req, res) =>
-    sendHttpResponse(req, res, async () => {
+    sendHttpResponseForApiV2(req, res, async () => {
       if (!req.apiConsumer?.isAuthorized) throw new ForbiddenError();
       return domainToSearchImmersionResultPublicV2(
         await deps.useCases.getSearchImmersionResultBySiretAndAppellationCode.execute(
           {
             siret: req.params.siret,
             appellationCode: req.params.appellationCode,
-          } as SiretAndAppellationDto,
+          },
           req.apiConsumer,
         ),
       );
@@ -58,7 +58,7 @@ export const createApiKeyAuthRouterV2 = (deps: AppDependencies) => {
   );
 
   publicV2SharedRouter.contactEstablishment(async (req, res) =>
-    sendHttpResponse(req, res, () => {
+    sendHttpResponseForApiV2(req, res.status(201), () => {
       if (!req.apiConsumer?.isAuthorized) throw new ForbiddenError();
       return pipeWithValue(
         validateAndParseZodSchema(

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
@@ -19,7 +19,7 @@ const logger = createLogger(__filename);
 export const createApiKeyAuthRouterV2 = (deps: AppDependencies) => {
   const publicV2Router = Router({ mergeParams: true });
 
-  publicV2Router.use("/v2", deps.apiKeyAuthMiddleware);
+  publicV2Router.use("/v2", deps.apiKeyAuthMiddlewareV2);
 
   const publicV2SharedRouter = createExpressSharedRouter(
     publicApiV2Routes,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/getImmersionOfferBySiretAndAppellationCode.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/getImmersionOfferBySiretAndAppellationCode.e2e.test.ts
@@ -94,7 +94,7 @@ describe(`Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
 
     expectToEqual(response, {
       status: 401,
-      body: { error: "forbidden: unauthenticated" },
+      body: { status: 401, message: "forbidden: unauthenticated" },
     });
   });
 
@@ -143,7 +143,8 @@ describe(`Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
     expectToEqual(response, {
       status: 404,
       body: {
-        errors: `No offer found for siret ${siretNotInDB} and appellation code ${styliste.appellationCode}`,
+        message: `No offer found for siret ${siretNotInDB} and appellation code ${styliste.appellationCode}`,
+        status: 404,
       },
     });
   });
@@ -165,7 +166,7 @@ describe(`Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
 
     expectToEqual(response, {
       status: 403,
-      body: { error: "forbidden: unauthorised consumer Id" },
+      body: { message: "forbidden: unauthorised consumer Id", status: 403 },
     });
   });
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/getImmersionOfferBySiretAndAppellationCode.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/getImmersionOfferBySiretAndAppellationCode.e2e.test.ts
@@ -94,7 +94,7 @@ describe(`Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
 
     expectToEqual(response, {
       status: 401,
-      body: { status: 401, message: "forbidden: unauthenticated" },
+      body: { status: 401, message: "unauthenticated" },
     });
   });
 
@@ -166,7 +166,7 @@ describe(`Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
 
     expectToEqual(response, {
       status: 403,
-      body: { message: "forbidden: unauthorised consumer Id", status: 403 },
+      body: { message: "unauthorised consumer Id", status: 403 },
     });
   });
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
@@ -16,9 +16,21 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: searchImmersionResultSchema,
-      401: z.object({ error: z.string() }),
-      403: z.object({ error: z.string() }),
-      404: z.object({ errors: z.string() }),
+      401: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      403: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      404: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
     },
   }),
   searchImmersion: defineRoute({
@@ -31,10 +43,18 @@ export const publicApiV2Routes = defineRoutes({
       400: z.object({
         status: z.number(),
         message: z.string(),
-        issues: z.array(z.string()),
+        issues: z.array(z.string()).optional(),
       }),
-      401: z.object({ error: z.string() }),
-      403: z.object({ error: z.string() }),
+      401: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      403: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
     },
   }),
   contactEstablishment: defineRoute({
@@ -44,16 +64,26 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       201: z.void(),
-      400: z
-        .object({
-          status: z.number(),
-          message: z.string(),
-          issues: z.array(z.string()).optional(),
-        })
-        .or(z.object({ errors: z.string() })),
-      401: z.object({ error: z.string() }),
-      403: z.object({ error: z.string() }),
-      404: z.object({ errors: z.string() }),
+      400: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      401: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      403: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
+      404: z.object({
+        status: z.number(),
+        message: z.string(),
+        issues: z.array(z.string()).optional(),
+      }),
     },
   }),
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
@@ -5,6 +5,7 @@ import {
   withAuthorizationHeaders,
 } from "shared";
 import { defineRoute, defineRoutes } from "shared-routes";
+import { errorSchema } from "../../helpers/httpErrors.schema";
 import { contactEstablishmentPublicV2Schema } from "../DtoAndSchemas/v2/input/ContactEstablishmentPublicV2.schema";
 import { searchImmersionRequestPublicV2Schema } from "../DtoAndSchemas/v2/input/SearchImmersionRequestPublicV2.schema";
 
@@ -16,21 +17,9 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: searchImmersionResultSchema,
-      401: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      403: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      404: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
+      401: errorSchema,
+      403: errorSchema,
+      404: errorSchema,
     },
   }),
   searchImmersion: defineRoute({
@@ -40,21 +29,9 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: searchImmersionsSchema,
-      400: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      401: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      403: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
+      400: errorSchema,
+      401: errorSchema,
+      403: errorSchema,
     },
   }),
   contactEstablishment: defineRoute({
@@ -64,26 +41,10 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       201: z.void(),
-      400: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      401: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      403: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
-      404: z.object({
-        status: z.number(),
-        message: z.string(),
-        issues: z.array(z.string()).optional(),
-      }),
+      400: errorSchema,
+      401: errorSchema,
+      403: errorSchema,
+      404: errorSchema,
     },
   }),
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 import {
+  httpErrorSchema,
   searchImmersionResultSchema,
   searchImmersionsSchema,
   withAuthorizationHeaders,
 } from "shared";
 import { defineRoute, defineRoutes } from "shared-routes";
-import { errorSchema } from "../../helpers/httpErrors.schema";
 import { contactEstablishmentPublicV2Schema } from "../DtoAndSchemas/v2/input/ContactEstablishmentPublicV2.schema";
 import { searchImmersionRequestPublicV2Schema } from "../DtoAndSchemas/v2/input/SearchImmersionRequestPublicV2.schema";
 
@@ -17,9 +17,9 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: searchImmersionResultSchema,
-      401: errorSchema,
-      403: errorSchema,
-      404: errorSchema,
+      401: httpErrorSchema,
+      403: httpErrorSchema,
+      404: httpErrorSchema,
     },
   }),
   searchImmersion: defineRoute({
@@ -29,9 +29,9 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: searchImmersionsSchema,
-      400: errorSchema,
-      401: errorSchema,
-      403: errorSchema,
+      400: httpErrorSchema,
+      401: httpErrorSchema,
+      403: httpErrorSchema,
     },
   }),
   contactEstablishment: defineRoute({
@@ -41,10 +41,10 @@ export const publicApiV2Routes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       201: z.void(),
-      400: errorSchema,
-      401: errorSchema,
-      403: errorSchema,
-      404: errorSchema,
+      400: httpErrorSchema,
+      401: httpErrorSchema,
+      403: httpErrorSchema,
+      404: httpErrorSchema,
     },
   }),
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
@@ -43,7 +43,7 @@ describe("search-immersion route", () => {
         });
         expectToEqual(response, {
           status: 401,
-          body: { message: "forbidden: unauthenticated", status: 401 },
+          body: { message: "unauthenticated", status: 401 },
         });
       });
 
@@ -61,12 +61,12 @@ describe("search-immersion route", () => {
           status: 403,
           body: {
             status: 403,
-            message: "forbidden: unauthorised consumer Id",
+            message: "unauthorised consumer Id",
           },
         });
       });
     });
-    describe("authenficated consumer", () => {
+    describe("authenticated consumer", () => {
       it("with given rome, appellation code and position", async () => {
         const immersionOffer = new ImmersionOfferEntityV2Builder()
           .withRomeCode("M1808")

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
@@ -43,7 +43,7 @@ describe("search-immersion route", () => {
         });
         expectToEqual(response, {
           status: 401,
-          body: { error: "forbidden: unauthenticated" },
+          body: { message: "forbidden: unauthenticated", status: 401 },
         });
       });
 
@@ -60,7 +60,8 @@ describe("search-immersion route", () => {
         expectToEqual(response, {
           status: 403,
           body: {
-            error: "forbidden: unauthorised consumer Id",
+            status: 403,
+            message: "forbidden: unauthorised consumer Id",
           },
         });
       });

--- a/back/src/domain/core/UseCase.ts
+++ b/back/src/domain/core/UseCase.ts
@@ -67,6 +67,7 @@ export abstract class TransactionalUseCase<
   JWTPayload = ConventionMagicLinkPayload,
 > {
   protected abstract inputSchema: z.ZodSchema<Input>;
+
   protected constructor(private uowPerformer: UnitOfWorkPerformer) {}
 
   // this methode should not be overwritten, implement _execute instead

--- a/shared/src/httpClient/errors/httpErrors.schema.ts
+++ b/shared/src/httpClient/errors/httpErrors.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const errorSchema = z.object({
+export const httpErrorSchema = z.object({
   status: z.number(),
   message: z.string(),
   issues: z.array(z.string()).optional(),

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -43,6 +43,7 @@ export * from "./geoPosition/geoPosition.schema";
 export * from "./headers";
 export * from "./http/httpStatus";
 export { HttpClientError as LegacyHttpClientError } from "./httpClient/errors/4xxClientError.error";
+export { httpErrorSchema } from "./httpClient/errors/httpErrors.schema";
 export * from "./httpClient/ports/axios.port";
 export * from "./immersionAssessment/ImmersionAssessmentDto";
 export * from "./immersionAssessment/immersionAssessmentSchema";

--- a/shared/src/searchImmersion/searchImmersion.routes.ts
+++ b/shared/src/searchImmersion/searchImmersion.routes.ts
@@ -1,18 +1,13 @@
 import { z } from "zod";
 import { defineRoute, defineRoutes } from "shared-routes";
 import { contactEstablishmentRequestSchema } from "../contactEstablishmentRequest/contactEstablishmentRequest.schema";
+import { httpErrorSchema } from "../httpClient/errors/httpErrors.schema";
 import {
   contactEstablishmentRoute,
   immersionOffersRoute,
 } from "../routes/routes";
 import { searchImmersionQueryParamsSchema } from "./SearchImmersionQueryParams.schema";
 import { searchImmersionsSchema } from "./SearchImmersionResult.schema";
-
-const errorSchema = z.object({
-  status: z.number(),
-  message: z.string(),
-  issues: z.array(z.string()).optional(),
-});
 
 export type SearchImmersionRoutes = typeof searchImmersionRoutes;
 export const searchImmersionRoutes = defineRoutes({
@@ -27,13 +22,17 @@ export const searchImmersionRoutes = defineRoutes({
     queryParamsSchema: searchImmersionQueryParamsSchema,
     responses: {
       200: searchImmersionsSchema,
-      400: errorSchema,
+      400: httpErrorSchema,
     },
   }),
   contactEstablishment: defineRoute({
     method: "post",
     url: `/${contactEstablishmentRoute}`,
     requestBodySchema: contactEstablishmentRequestSchema,
-    responses: { 201: z.string().max(0), 400: errorSchema, 404: errorSchema },
+    responses: {
+      201: z.string().max(0),
+      400: httpErrorSchema,
+      404: httpErrorSchema,
+    },
   }),
 });


### PR DESCRIPTION
## Description

Les erreurs renvoyées par notre api V2 ont des formats différents: parfois avec une propriété `errors`, parfois avec `error`, parfois contenant une tableau `issues`, etc.

Cette PR permet de mettre en place un format fixe.