### PR TITLE
ne pas autoriser le dimanche pour les mini stage

### DIFF
--- a/front/src/app/components/forms/commons/SchedulePicker/RegularSchedulePicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/RegularSchedulePicker.tsx
@@ -30,6 +30,11 @@ export const RegularSchedulePicker = (props: RegularSchedulePickerProps) => {
   const name: keyof ConventionDto = "schedule";
   const { setValue, getValues } = useFormContext<ConventionReadDto>();
   const values = getValues();
+  const dayPeriods = dayPeriodsFromComplexSchedule(
+    values.schedule.complexSchedule,
+    props.interval.start,
+  );
+
   return (
     <>
       <div
@@ -47,10 +52,7 @@ export const RegularSchedulePicker = (props: RegularSchedulePickerProps) => {
         >
           <WeekdayPicker
             name={name}
-            dayPeriods={dayPeriodsFromComplexSchedule(
-              values.schedule.complexSchedule,
-              props.interval.start,
-            )}
+            dayPeriods={dayPeriods}
             onValueChange={(dayPeriods: DayPeriodsDto) => {
               values.schedule = new ScheduleDtoBuilder(values.schedule)
                 .withDateInterval(props.interval)
@@ -61,6 +63,7 @@ export const RegularSchedulePicker = (props: RegularSchedulePickerProps) => {
                 .build();
               setValue(name, values.schedule);
             }}
+            maxDay={values.internshipKind === "mini-stage-cci" ? 5 : 6}
             interval={props.interval}
             disabled={props.disabled}
           />

--- a/front/src/app/components/forms/commons/SchedulePicker/SchedulePicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/SchedulePicker.tsx
@@ -31,7 +31,7 @@ export const SchedulePicker = ({
   const values = getValues();
   const onBoolRadioPickerChange = (isSimple: boolean): void => {
     const newScheduleValue = isSimple
-      ? reasonableSchedule(interval, [])
+      ? reasonableSchedule(interval, [], [])
       : scheduleWithFirstDayActivity(interval);
     setValue(name, newScheduleValue);
   };

--- a/front/src/app/components/forms/commons/SchedulePicker/SchedulePicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/SchedulePicker.tsx
@@ -8,6 +8,7 @@ import {
   DateIntervalDto,
   reasonableSchedule,
   scheduleWithFirstDayActivity,
+  Weekday,
 } from "shared";
 import { ComplexSchedulePicker } from "./ComplexSchedulePicker";
 import { RegularSchedulePicker } from "./RegularSchedulePicker";
@@ -16,11 +17,13 @@ import "./SchedulePicker.css";
 type SchedulePickerProps = {
   disabled?: boolean;
   interval: DateIntervalDto;
+  excludedDays: Weekday[];
 };
 
 export const SchedulePicker = ({
   interval,
   disabled,
+  excludedDays,
 }: SchedulePickerProps): JSX.Element => {
   const name: keyof ConventionDto = "schedule";
   const {
@@ -31,8 +34,8 @@ export const SchedulePicker = ({
   const values = getValues();
   const onBoolRadioPickerChange = (isSimple: boolean): void => {
     const newScheduleValue = isSimple
-      ? reasonableSchedule(interval, [], [])
-      : scheduleWithFirstDayActivity(interval);
+      ? reasonableSchedule(interval, excludedDays, [])
+      : scheduleWithFirstDayActivity(interval, excludedDays);
     setValue(name, newScheduleValue);
   };
   const error = errors[name];

--- a/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
@@ -32,12 +32,13 @@ export const WeekdayPicker = ({
     if (dayPeriods.length === 0) return false;
     const lastPeriod = dayPeriods[dayPeriods.length - 1];
     const lastPeriodEnd = lastPeriod[1];
-    return lastPeriodEnd < 5 ? lastPeriod : false;
+    const lastPeriodStart = maxDay - 1;
+    return lastPeriodEnd < lastPeriodStart ? lastPeriod : false;
   };
 
   const add = () => {
     let start = 0;
-    let end = 5;
+    let end = maxDay - 1;
     // Autofill next period as one day after the current period,
     // with duration of 1 day.
     const last = canAddNewPeriod();

--- a/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
@@ -16,6 +16,7 @@ type WeekdayPickerProps = {
   onValueChange: (dayPeriods: DayPeriodsDto) => void;
   disabled?: boolean;
   interval: DateIntervalDto;
+  maxDay: WeekdayNumber;
 };
 
 export const WeekdayPicker = ({
@@ -24,6 +25,7 @@ export const WeekdayPicker = ({
   onValueChange,
   disabled,
   interval,
+  maxDay,
 }: WeekdayPickerProps) => {
   const { cx } = useStyles();
   const canAddNewPeriod = (): WeekDayRangeSchemaDTO | false => {
@@ -95,7 +97,7 @@ export const WeekdayPicker = ({
                     name="du"
                     id={`weekday-dropdown-end-day-${index}`}
                     minDay={dayRange[0]}
-                    maxDay={6}
+                    maxDay={maxDay}
                     selected={dayRange[1]}
                     onValueChange={(x) => onEndChange(x as WeekdayNumber)}
                     disabled={disabled}

--- a/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
+++ b/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
@@ -38,11 +38,11 @@ export const ImmersionHourLocationSection = () => {
   const [dateMax, setDateMax] = useState(
     addMonths(defaultDateMax, 1).toISOString(),
   );
+  const excludedDays =
+    values.internshipKind === "mini-stage-cci"
+      ? (["dimanche"] as Weekday[])
+      : [];
   const resetSchedule = (interval: DateIntervalDto) => {
-    const excludedDays =
-      values.internshipKind === "mini-stage-cci"
-        ? (["dimanche"] as Weekday[])
-        : [];
     setValue(
       "schedule",
       values.schedule.isSimple
@@ -145,6 +145,7 @@ export const ImmersionHourLocationSection = () => {
           start: new Date(values.dateStart),
           end: new Date(values.dateEnd),
         }}
+        excludedDays={excludedDays}
       />
       <AddressAutocomplete
         {...formContents["immersionAddress"]}

--- a/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
+++ b/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
@@ -12,6 +12,7 @@ import {
   reasonableSchedule,
   scheduleWithFirstDayActivity,
   toDateString,
+  Weekday,
 } from "shared";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import {
@@ -38,11 +39,15 @@ export const ImmersionHourLocationSection = () => {
     addMonths(defaultDateMax, 1).toISOString(),
   );
   const resetSchedule = (interval: DateIntervalDto) => {
+    const excludedDays =
+      values.internshipKind === "mini-stage-cci"
+        ? (["dimanche"] as Weekday[])
+        : [];
     setValue(
       "schedule",
       values.schedule.isSimple
-        ? reasonableSchedule(interval, [], [])
-        : scheduleWithFirstDayActivity(interval),
+        ? reasonableSchedule(interval, excludedDays, [])
+        : scheduleWithFirstDayActivity(interval, excludedDays),
     );
   };
   const getFieldError = makeFieldError(formState);

--- a/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
+++ b/front/src/app/components/forms/convention/sections/hour-location/ImmersionHourLocationSection.tsx
@@ -41,7 +41,7 @@ export const ImmersionHourLocationSection = () => {
     setValue(
       "schedule",
       values.schedule.isSimple
-        ? reasonableSchedule(interval, [])
+        ? reasonableSchedule(interval, [], [])
         : scheduleWithFirstDayActivity(interval),
     );
   };

--- a/front/src/app/routes/routeParams/convention.ts
+++ b/front/src/app/routes/routeParams/convention.ts
@@ -400,6 +400,7 @@ const scheduleFromParams = (
           end: new Date(dateEnd),
         },
         [],
+        [],
       ),
   };
 };

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -366,6 +366,7 @@ describe("conventionDtoSchema", () => {
             .withDateEnd(
               addDays(new Date(DATE_START), maxCalendarDays + 1).toISOString(),
             )
+            .withSchedule(reasonableSchedule, ["dimanche"])
             .build();
 
           expectConventionInvalidWithIssueMessages(
@@ -394,6 +395,7 @@ describe("conventionDtoSchema", () => {
             .withInternshipKind(internshipKind)
             .withDateStart(dateStart)
             .withDateEnd(dateEnd)
+            .withSchedule(reasonableSchedule, ["dimanche"])
             .build();
 
           expectConventionDtoToBeValid(convention);
@@ -402,8 +404,8 @@ describe("conventionDtoSchema", () => {
     });
     describe("CCI specific, minor under 16yo", () => {
       it("max week hours depends on beneficiary age", () => {
-        const dateStart = DATE_START;
-        const dateEnd = addDays(new Date(DATE_START), 4).toISOString();
+        const dateStart = new Date("2021-01-04").toISOString();
+        const dateEnd = addDays(new Date(DATE_START), 3).toISOString();
         const convention = new ConventionDtoBuilder()
           .withInternshipKind("mini-stage-cci")
           .withDateStart(dateStart)
@@ -592,7 +594,7 @@ describe("conventionDtoSchema", () => {
         .withInternshipKind("mini-stage-cci")
         .withDateStart(immersionStartDate.toISOString())
         .withDateEnd(new Date("2022-01-02").toISOString())
-        .withSchedule(reasonableSchedule)
+        .withSchedule(reasonableSchedule, ["dimanche"])
         .withBeneficiary(beneficiary)
         .build();
 

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -601,6 +601,26 @@ describe("conventionDtoSchema", () => {
       ]);
     });
   });
+
+  describe("when sunday is in schedule", () => {
+    const conventionBuilder = new ConventionDtoBuilder()
+      .withDateStart(new Date("2023-07-20").toISOString())
+      .withDateEnd(new Date("2023-07-25").toISOString());
+
+    it("rejects when internship kind is mini-stage-cci", () => {
+      expectConventionInvalidWithIssueMessages(
+        conventionSchema,
+        conventionBuilder.withInternshipKind("mini-stage-cci").build(),
+        ["Le mini-stage ne peut pas se dérouler un dimanche"],
+      );
+    });
+
+    it("accepts valid convention when kind is immersion", () => {
+      expectConventionDtoToBeValid(
+        conventionBuilder.withInternshipKind("immersion").build(),
+      );
+    });
+  });
 });
 
 const expectConventionDtoToBeValid = (validConvention: ConventionDto): void => {

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -2,7 +2,11 @@ import { AgencyId } from "../agency/agency.dto";
 import { Builder } from "../Builder";
 import { PeConnectIdentity } from "../federatedIdentities/federatedIdentity.dto";
 import { AppellationAndRomeDto } from "../romeAndAppellationDtos/romeAndAppellation.dto";
-import { DateIntervalDto, ScheduleDto } from "../schedule/Schedule.dto";
+import {
+  DateIntervalDto,
+  ScheduleDto,
+  Weekday,
+} from "../schedule/Schedule.dto";
 import { reasonableSchedule } from "../schedule/ScheduleUtils";
 import {
   Beneficiary,
@@ -106,6 +110,30 @@ const validConvention: ConventionDto = {
 
 export class ConventionDtoBuilder implements Builder<ConventionDto> {
   constructor(private dto: ConventionDto = validConvention) {}
+
+  private get establishmentTutor(): EstablishmentTutor {
+    return this.dto.establishmentTutor;
+  }
+
+  private get establishmentRepresentative(): EstablishmentRepresentative {
+    return this.dto.signatories.establishmentRepresentative;
+  }
+
+  private get beneficiary(): Beneficiary<InternshipKind> {
+    return this.dto.signatories.beneficiary;
+  }
+
+  private get beneficiaryRepresentative():
+    | BeneficiaryRepresentative
+    | undefined {
+    return this.dto.signatories.beneficiaryRepresentative;
+  }
+
+  private get beneficiaryCurrentEmployer():
+    | BeneficiaryCurrentEmployer
+    | undefined {
+    return this.dto.signatories.beneficiaryCurrentEmployer;
+  }
 
   public withBusinessName(businessName: string): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, businessName });
@@ -288,6 +316,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
       firstName,
     });
   }
+
   public withEstablishmentRepresentativeLastName(lastName: string) {
     return this.withEstablishmentRepresentative({
       ...this.dto.signatories.establishmentRepresentative,
@@ -389,6 +418,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   ): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, dateValidation });
   }
+
   public withoutDateValidation(): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, dateValidation: undefined });
   }
@@ -396,11 +426,13 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   public withId(id: ConventionId): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, id });
   }
+
   public withExternalId(
     externalId: ConventionExternalId,
   ): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, externalId });
   }
+
   public withAgencyId(agencyId: AgencyId): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, agencyId });
   }
@@ -408,6 +440,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   public withStatus(status: ConventionStatus): ConventionDtoBuilder {
     return new ConventionDtoBuilder({ ...this.dto, status });
   }
+
   public validated(): ConventionDtoBuilder {
     return new ConventionDtoBuilder({
       ...this.dto,
@@ -450,14 +483,21 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   }
 
   public withSchedule(
-    scheduleMaker: (interval: DateIntervalDto) => ScheduleDto,
+    scheduleMaker: (
+      interval: DateIntervalDto,
+      excludedDays: Weekday[],
+    ) => ScheduleDto,
+    excludedDays: Weekday[] = [],
   ) {
     return new ConventionDtoBuilder({
       ...this.dto,
-      schedule: scheduleMaker({
-        start: new Date(this.dto.dateStart),
-        end: new Date(this.dto.dateEnd),
-      }),
+      schedule: scheduleMaker(
+        {
+          start: new Date(this.dto.dateStart),
+          end: new Date(this.dto.dateEnd),
+        },
+        excludedDays,
+      ),
     });
   }
 
@@ -499,6 +539,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
       federatedIdentity: undefined,
     });
   }
+
   public notSigned(): ConventionDtoBuilder {
     if (
       this.dto.internshipKind === "immersion" &&
@@ -593,30 +634,6 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
       ...this.dto,
       immersionObjective,
     });
-  }
-
-  private get establishmentTutor(): EstablishmentTutor {
-    return this.dto.establishmentTutor;
-  }
-
-  private get establishmentRepresentative(): EstablishmentRepresentative {
-    return this.dto.signatories.establishmentRepresentative;
-  }
-
-  private get beneficiary(): Beneficiary<InternshipKind> {
-    return this.dto.signatories.beneficiary;
-  }
-
-  private get beneficiaryRepresentative():
-    | BeneficiaryRepresentative
-    | undefined {
-    return this.dto.signatories.beneficiaryRepresentative;
-  }
-
-  private get beneficiaryCurrentEmployer():
-    | BeneficiaryCurrentEmployer
-    | undefined {
-    return this.dto.signatories.beneficiaryCurrentEmployer;
   }
 
   public build() {

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -4,8 +4,12 @@ import { agencyIdSchema } from "../agency/agency.schema";
 import { emailPossiblyEmptySchema, emailSchema } from "../email/email.schema";
 import { peConnectIdentitySchema } from "../federatedIdentities/federatedIdentity.schema";
 import { appellationDtoSchema } from "../romeAndAppellationDtos/romeAndAppellation.schema";
+import { DailyScheduleDto } from "../schedule/Schedule.dto";
 import { scheduleSchema } from "../schedule/Schedule.schema";
-import { calculateWeeklyHoursFromSchedule } from "../schedule/ScheduleUtils";
+import {
+  calculateWeeklyHoursFromSchedule,
+  isSundayInSchedule,
+} from "../schedule/ScheduleUtils";
 import { siretSchema } from "../siret/siret.schema";
 import { allRoles } from "../tokens/token.dto";
 import { phoneRegExp } from "../utils";
@@ -238,6 +242,10 @@ export const conventionWithoutExternalIdSchema: z.Schema<ConventionDtoWithoutExt
           addIssue,
           beneficiaryAgeAtConventionStart,
         );
+        addIssueIfSundayIsInSchedule(
+          addIssue,
+          convention.schedule.complexSchedule,
+        );
         addIssueIfAgeLessThanMinimumAge(
           addIssue,
           beneficiaryAgeAtConventionStart,
@@ -379,4 +387,16 @@ const addIssueIfAgeLessThanMinimumAge = (
       `L'âge du bénéficiaire doit être au minimum de ${miniumAgeRequirement}ans`,
       getConventionFieldName("signatories.beneficiary.birthdate"),
     );
+};
+
+const addIssueIfSundayIsInSchedule = (
+  addIssue: (message: string, path: string) => void,
+  complexSchedule: DailyScheduleDto[],
+) => {
+  if (isSundayInSchedule(complexSchedule)) {
+    addIssue(
+      "Le mini-stage ne peut pas se dérouler un dimanche",
+      getConventionFieldName("schedule.workedDays"),
+    );
+  }
 };

--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -427,16 +427,19 @@ export const emptySchedule = (
 
 export const scheduleWithFirstDayActivity = (
   interval: DateIntervalDto,
+  excludedDays: Weekday[] = [],
 ): Readonly<ScheduleDto> => {
-  const complexSchedule = makeComplexSchedule(interval, []).map((schedule) => {
-    if (schedule.date === interval.start.toISOString()) {
-      schedule.timePeriods = [
-        { start: "09:00", end: "12:00" },
-        { start: "13:00", end: "17:00" },
-      ];
-    }
-    return schedule;
-  });
+  const complexSchedule = makeComplexSchedule(interval, [], excludedDays).map(
+    (schedule) => {
+      if (schedule.date === interval.start.toISOString()) {
+        schedule.timePeriods = [
+          { start: "09:00", end: "12:00" },
+          { start: "13:00", end: "17:00" },
+        ];
+      }
+      return schedule;
+    },
+  );
   return {
     totalHours:
       calculateTotalImmersionHoursFromComplexSchedule(complexSchedule),

--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -87,9 +87,14 @@ const reasonableTimePeriods: TimePeriodsDto = [
 ];
 export const reasonableSchedule = (
   interval: DateIntervalDto,
+  excludedDays: Weekday[] = [],
   timePeriods: TimePeriodsDto = reasonableTimePeriods,
 ): ScheduleDto => {
-  const complexSchedule = makeComplexSchedule(interval, timePeriods);
+  const complexSchedule = makeComplexSchedule(
+    interval,
+    timePeriods,
+    excludedDays,
+  );
   return {
     totalHours:
       calculateTotalImmersionHoursFromComplexSchedule(complexSchedule),
@@ -456,14 +461,24 @@ export const makeDailySchedule = (
 export const makeComplexSchedule = (
   { start, end }: DateIntervalDto,
   timePeriods: TimePeriodsDto,
+  excludedDays?: Weekday[],
 ): DailyScheduleDto[] => {
   const complexSchedules: DailyScheduleDto[] = [];
+  const excludedDayNumbers =
+    excludedDays?.map(
+      (weekday) =>
+        dayOfWeekMapping.find((value) => value.frenchDayName === weekday)
+          ?.universalDay,
+    ) || [];
+
   for (
     let currentDate = start;
     currentDate <= end;
     currentDate = addHours(currentDate, 24)
-  )
-    complexSchedules.push(makeDailySchedule(currentDate, timePeriods));
+  ) {
+    if (!excludedDayNumbers.includes(getDay(currentDate)))
+      complexSchedules.push(makeDailySchedule(currentDate, timePeriods));
+  }
   return complexSchedules;
 };
 

--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -51,26 +51,10 @@ export const calculateWeeklyHoursFromSchedule = (schedule: ScheduleDto) =>
     calculateWeeklyHours(week),
   );
 
-export const isArrayOfWeekdays = (value: any): boolean =>
-  Array.isArray(value) && value.every((el) => weekdays.includes(el));
-
 type DatesOfImmersion = {
   dateStart: string;
   dateEnd: string;
 };
-
-type CalculateTotalHoursProps = DatesOfImmersion & {
-  schedule: ScheduleDto;
-};
-
-export const calculateTotalImmersionHoursBetweenDate = ({
-  schedule,
-  ...dates
-}: CalculateTotalHoursProps): number =>
-  calculateTotalImmersionHoursBetweenDateComplex({
-    complexSchedule: schedule.complexSchedule,
-    ...dates,
-  });
 
 export const calculateTotalImmersionHoursFromComplexSchedule = (
   complexSchedule: DailyScheduleDto[],
@@ -90,14 +74,6 @@ export const prettyPrintSchedule = (
   displayFreeDays = true,
 ): string =>
   prettyPrintComplexSchedule(schedule.complexSchedule, displayFreeDays);
-
-// Extract all weekday names for which there is at least one
-export const convertToFrenchNamedDays = (schedule: ScheduleDto): Weekday[] => {
-  const complexSchedule = schedule.complexSchedule;
-  return complexSchedule
-    .filter((daily) => daily.timePeriods.length > 0)
-    .map((daily) => weekdays[frenchDayMapping(daily.date).frenchDay]);
-};
 
 const reasonableTimePeriods: TimePeriodsDto = [
   {
@@ -295,7 +271,9 @@ const calculateTotalImmersionHoursBetweenDateComplex = ({
   dateStart,
   dateEnd,
   complexSchedule,
-}: DatesOfImmersion & { complexSchedule: DailyScheduleDto[] }): number => {
+}: DatesOfImmersion & {
+  complexSchedule: DailyScheduleDto[];
+}): number => {
   const start = parseISO(dateStart);
   const end = parseISO(dateEnd);
   let totalOfMinutes = 0;

--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -475,3 +475,8 @@ export const calculateScheduleTotalDurationInDays = (
   const dateEnd = dates.reverse()[0];
   return differenceInDays(new Date(dateEnd), new Date(dateStart));
 };
+
+export const isSundayInSchedule = (complexSchedule: DailyScheduleDto[]) => {
+  const sunday = 0;
+  return complexSchedule.some((week) => getDay(parseISO(week.date)) === sunday);
+};

--- a/shared/src/schedule/ScheduleUtils.unit.test.ts
+++ b/shared/src/schedule/ScheduleUtils.unit.test.ts
@@ -8,6 +8,7 @@ import {
   calculateTotalImmersionHoursFromComplexSchedule,
   calculateWeeklyHoursFromSchedule,
   dayPeriodsFromComplexSchedule,
+  isSundayInSchedule,
   makeDailySchedule,
   prettyPrintSchedule,
 } from "./ScheduleUtils";
@@ -509,6 +510,23 @@ describe("ScheduleUtils", () => {
         4,
       );
       expectToEqual(calculateNumberOfWorkedDays(schedule.complexSchedule), 1);
+    });
+  });
+  describe("isSundayInSchedule", () => {
+    it("return false if schedule does not contain sunday", () => {
+      const complexSchedule = makeDailySchedule(new Date("2023-07-18"), [
+        { start: "01:00", end: "02:00" },
+      ]);
+
+      expect(isSundayInSchedule([complexSchedule])).toBe(false);
+    });
+
+    it("return true if schedule contains sunday", () => {
+      const complexSchedule = makeDailySchedule(new Date("2023-07-23"), [
+        { start: "01:00", end: "02:00" },
+      ]);
+
+      expect(isSundayInSchedule([complexSchedule])).toBe(true);
     });
   });
 });

--- a/shared/src/schedule/ScheduleUtils.unit.test.ts
+++ b/shared/src/schedule/ScheduleUtils.unit.test.ts
@@ -6,6 +6,7 @@ import {
   calculateNumberOfWorkedDays,
   calculateScheduleTotalDurationInDays,
   calculateTotalImmersionHoursFromComplexSchedule,
+  calculateWeeklyHoursFromSchedule,
   dayPeriodsFromComplexSchedule,
   makeDailySchedule,
   prettyPrintSchedule,
@@ -243,6 +244,29 @@ describe("ScheduleUtils", () => {
           exampleLongRegularSchedule.complexSchedule,
         ),
       ).toEqual(expectedForLongSchedule);
+    });
+  });
+  describe("calculateWeeklyHoursFromSchedule", () => {
+    it("calculates correctly the total number of hours from a complex schedule", () => {
+      const schedule = new ScheduleDtoBuilder()
+        .withDateInterval({
+          start: new Date("2022-06-06"),
+          end: new Date("2022-06-10"),
+        })
+        .withRegularSchedule({
+          dayPeriods: [
+            [0, 0],
+            [2, 3],
+          ],
+          timePeriods: [
+            { start: "09:00", end: "12:30" },
+            { start: "14:00", end: "18:00" },
+          ],
+        })
+        .build();
+
+      const weeklyHours = calculateWeeklyHoursFromSchedule(schedule);
+      expectToEqual(weeklyHours, [22.5]);
     });
   });
   describe("CalculateTotalImmersionHoursFromComplexSchedule", () => {


### PR DESCRIPTION
## Description

Pour les mini-stage, il ne doit pas être possible de travailler le dimanche.

## Solution

- modification des schemas
- bloquer la sélection du dimanche dans le formulaire de création de convention mini-stage

## Remarque

Il n'est pas possible de désactiver une date en particulier sur le datepicker natif html.  
Par contre, si un dimanche est sélectionné en date de début/fin, les dropdowns de sélection de jour de semaine indiquent bien que le dimanche n'est pas inclus (voir screenshot ci-dessous, où 29 juillet est un samedi et 30 juillet est un dimanche).

![Screenshot 2023-07-24 at 17 05 53](https://github.com/gip-inclusion/immersion-facile/assets/11294487/e2becf3c-fdcc-405c-9cdf-8dbd26a75a41)

