### PR TITLE
lookupStreetAddressSpecialCharsRegex now catches pattern '{d}\s,' in schema and provide validation error

### DIFF
--- a/back/src/adapters/secondary/addressGateway/HttpAddressGateway.manual.test.ts
+++ b/back/src/adapters/secondary/addressGateway/HttpAddressGateway.manual.test.ts
@@ -277,6 +277,12 @@ describe("HttpOpenCageDataAddressGateway", () => {
         new Error(errorMessage.minimumCharErrorMessage(2)),
       );
     });
+    it("Should not support lookup address with 3 chars matching the pattern '{digit} ,'", async () => {
+      await expectPromiseToFailWithError(
+        httpAddressGateway.lookupStreetAddress("4 ,"),
+        new Error(errorMessage.minimumCharErrorMessage(2)),
+      );
+    });
     it("Should support lookup address with two char.", async () => {
       const resultPreviousNotFoundWithAddresseAPI =
         await httpAddressGateway.lookupStreetAddress("Ro");

--- a/shared/src/address/address.schema.ts
+++ b/shared/src/address/address.schema.ts
@@ -39,7 +39,7 @@ export const lookupStreetAddressQueryMinLength = 2;
 export const lookupStreetAddressQueryMaxWordLength = 18;
 
 export const lookupStreetAddressSpecialCharsRegex =
-  /[&/\\#,+()&$~%€.":`*?<>{}]/g;
+  /[&/\\#,+()&$~%€.":`*?<>{}]|[{d}\s,]/g;
 export const withLookupStreetAddressQueryParamsSchema: z.Schema<WithLookupAddressQueryParams> =
   z.object({
     lookup: z


### PR DESCRIPTION
Bête et méchant mais ça fait le boulot.