### PR TITLE
fix: bloquer la création de convention mini-stage se déroulant un dimanche

### DIFF
--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -486,5 +486,8 @@ export const calculateScheduleTotalDurationInDays = (
 
 export const isSundayInSchedule = (complexSchedule: DailyScheduleDto[]) => {
   const sunday = 0;
-  return complexSchedule.some((week) => getDay(parseISO(week.date)) === sunday);
+  return complexSchedule.some(
+    (week) =>
+      getDay(parseISO(week.date)) === sunday && week.timePeriods.length > 0,
+  );
 };


### PR DESCRIPTION
## Description

Un mini-stage ne peut pas se dérouler un dimanche.  
Or, pour savoir si le dimanche est inclus, il faut aussi vérifier si des heures y sont précisés (et non pas se baser uniquement sur le jour).