### PR TITLE
afficher un message d'erreur lorsque le type de prescripteur dans le formulaire est "pole-emploi"

### DIFF
--- a/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
+++ b/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
@@ -9,6 +9,7 @@ import {
   CreateAgencyDto,
   emailSchema,
 } from "shared";
+import { LinkHome } from "react-design-system";
 import {
   agencyKindToLabel,
   AllowedAgencyKindToAdd,
@@ -26,6 +27,7 @@ import {
   useFormContents,
 } from "src/app/hooks/formContents.hooks";
 import { useFeatureFlags } from "src/app/hooks/useFeatureFlags";
+import { routes } from "src/app/routes/routes";
 
 type AgencyFormCommonFieldsProps = {
   addressInitialValue?: AddressDto;
@@ -70,6 +72,15 @@ export const AgencyFormCommonFields = ({
   const { getFormFields } = useFormContents(formAgencyFieldsLabels);
   const fieldsContent = getFormFields();
   const getFieldError = makeFieldError(formState);
+  const agencyErrorMessage = (
+    <span>
+      Attention, toutes les agences Pôle emploi ont déjà été ajoutées par notre
+      équipe sur Immersion.{" "}
+      <LinkHome {...routes.agencyDashboard().link}>
+        Accéder à votre espace prescripteur.
+      </LinkHome>
+    </span>
+  );
 
   return (
     <>
@@ -84,6 +95,10 @@ export const AgencyFormCommonFields = ({
           ...fieldsContent.kind,
           ...register("kind"),
         }}
+        state={watch("kind") === "pole-emploi" ? "error" : "default"}
+        stateRelatedMessage={
+          watch("kind") === "pole-emploi" ? agencyErrorMessage : undefined
+        }
       />
 
       <Input

--- a/front/src/app/components/forms/agency/agencyKindToLabel.ts
+++ b/front/src/app/components/forms/agency/agencyKindToLabel.ts
@@ -4,7 +4,7 @@ export type AllowedAgencyKindToAdd = Exclude<AgencyKind, "immersion-facile">;
 
 export const agencyKindToLabel: Record<AllowedAgencyKindToAdd, string> = {
   "mission-locale": "Mission Locale",
-  "pole-emploi": "Pole Emploi",
+  "pole-emploi": "Pôle Emploi",
   "cap-emploi": "Cap Emploi",
   "conseil-departemental": "Conseil Départemental",
   "prepa-apprentissage": "Prépa Apprentissage",


### PR DESCRIPTION
## Description

Les agences Pôle emploi sont déjà référencées, elles n'ont pas besoin de le faire à nouveau.

## Solution

Afficher un message sur le formulaire d'ajout de prescripteur lorsque le type est "pole-emploi".  
Il s'agit d'un message indicatif et non bloquant pour la soumission du formulaire.