### PR TITLE
Increase nginx buffer size

### DIFF
--- a/front/scalingo/nginx.conf.erb
+++ b/front/scalingo/nginx.conf.erb
@@ -15,4 +15,6 @@ location /api {
   rewrite /api/(.*) /$1 break;
   real_ip_header X-Forwarded-For;
   proxy_pass https://<%= ENV['APP'].gsub("front", "back") %>.<%= ENV['REGION_NAME'] %>.scalingo.io;
+  proxy_buffer_size 16k;
+  proxy_busy_buffers_size 16k;
 }


### PR DESCRIPTION
When redirecting short link, location header is too long