### PR TITLE
Envoyer le lien de bilan de l'agence, si présent, dans les mails

### DIFF
--- a/back/src/_testBuilders/emailAssertions.ts
+++ b/back/src/_testBuilders/emailAssertions.ts
@@ -101,6 +101,7 @@ export const expectEmailFinalValidationConfirmationMatchingConvention = (
       validatorName: convention.validators?.agencyValidator
         ? concatValidatorNames(convention.validators?.agencyValidator)
         : "",
+      agencyAssessmentDocumentLink: agency.questionnaireUrl,
     },
   });
 

--- a/back/src/domain/convention/useCases/notifications/NotifyAllActorsOfFinalConventionValidation.ts
+++ b/back/src/domain/convention/useCases/notifications/NotifyAllActorsOfFinalConventionValidation.ts
@@ -9,6 +9,7 @@ import {
   displayEmergencyContactInfos,
   Email,
   frontRoutes,
+  isUrlValid,
   Role,
   TemplatedEmail,
 } from "shared";
@@ -169,6 +170,9 @@ export class NotifyAllActorsOfFinalConventionValidation extends TransactionalUse
           beneficiary,
         }),
         agencyLogoUrl: agency.logoUrl,
+        agencyAssessmentDocumentLink: isUrlValid(agency.questionnaireUrl)
+          ? agency.questionnaireUrl
+          : undefined,
         magicLink: await makeShortMagicLink(frontRoutes.conventionDocument),
         validatorName: convention.validators?.agencyValidator
           ? concatValidatorNames(convention.validators?.agencyValidator)

--- a/back/src/domain/offer/useCases/SendEmailsWithAssessmentCreationLink.ts
+++ b/back/src/domain/offer/useCases/SendEmailsWithAssessmentCreationLink.ts
@@ -5,6 +5,7 @@ import {
   ConventionId,
   frontRoutes,
   immersionFacileNoReplyEmailSender,
+  isUrlValid,
 } from "shared";
 import { GenerateConventionMagicLinkUrl } from "../../../adapters/primary/config/magicLinkUrl";
 import { createLogger } from "../../../utils/logger";
@@ -101,6 +102,9 @@ export class SendEmailsWithAssessmentCreationLink extends TransactionalUseCase<
       params: {
         agencyLogoUrl: agency.logoUrl,
         agencyValidatorEmail: agency.validatorEmails[0],
+        agencyAssessmentDocumentLink: isUrlValid(agency.questionnaireUrl)
+          ? agency.questionnaireUrl
+          : undefined,
         beneficiaryFirstName: convention.signatories.beneficiary.firstName,
         beneficiaryLastName: convention.signatories.beneficiary.lastName,
         conventionId: convention.id,

--- a/back/src/domain/offer/useCases/SendEmailsWithAssessmentCreationLink.unit.test.ts
+++ b/back/src/domain/offer/useCases/SendEmailsWithAssessmentCreationLink.unit.test.ts
@@ -76,6 +76,7 @@ describe("SendEmailWithImmersionAssessmentCreationLink", () => {
         ],
         sender: immersionFacileNoReplyEmailSender,
         params: {
+          agencyAssessmentDocumentLink: undefined,
           agencyLogoUrl: expectedAgency.logoUrl,
           agencyValidatorEmail: expectedAgency.validatorEmails[0],
           beneficiaryFirstName:

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -291,6 +291,7 @@ export const defaultEmailValueByEmailKind: {
     warning: "WARNING",
   },
   VALIDATED_CONVENTION_FINAL_CONFIRMATION: {
+    agencyAssessmentDocumentLink: "AGENCY_ASSESSMENT_DOCUMENT_LINK",
     agencyLogoUrl: defaultEmailPreviewUrl,
     beneficiaryBirthdate: "BENEFICIARY_BIRTHDATE",
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -484,6 +484,7 @@ export const defaultEmailValueByEmailKind: {
     businessAddress: "BUSINESS_ADDRESS",
   },
   CREATE_IMMERSION_ASSESSMENT: {
+    agencyAssessmentDocumentLink: "AGENCY_ASSESSMENT_DOCUMENT_LINK",
     agencyLogoUrl: defaultEmailPreviewUrl,
     agencyValidatorEmail: "VALIDATOR_EMAIL",
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",

--- a/shared/src/agency/AgencyDtoBuilder.ts
+++ b/shared/src/agency/AgencyDtoBuilder.ts
@@ -21,7 +21,7 @@ const emptyAgency: AgencyDto = {
   counsellorEmails: [],
   validatorEmails: [defaultValidatorEmail],
   adminEmails: [],
-  questionnaireUrl: "empty-questionnaire-url",
+  questionnaireUrl: "https://empty-questionnaire-url",
   signature: "empty-signature",
   address: emptyAddress,
   position: {

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -302,6 +302,7 @@ export type EmailParamsByEmailType = {
     businessAddress: string;
   };
   VALIDATED_CONVENTION_FINAL_CONFIRMATION: {
+    agencyAssessmentDocumentLink: string | undefined;
     agencyLogoUrl: AbsoluteUrl | undefined;
     beneficiaryBirthdate: string;
     beneficiaryFirstName: string;

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -99,6 +99,7 @@ export type EmailParamsByEmailType = {
     requesterName: string;
   };
   CREATE_IMMERSION_ASSESSMENT: {
+    agencyAssessmentDocumentLink: string | undefined;
     agencyLogoUrl: AbsoluteUrl | undefined;
     agencyValidatorEmail: string;
     beneficiaryFirstName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -380,6 +380,7 @@ export const emailTemplatesByName =
         internshipKind,
         magicLink,
         validatorName,
+        agencyAssessmentDocumentLink,
       }) => ({
         subject:
           internshipKind === "immersion"
@@ -411,11 +412,13 @@ export const emailTemplatesByName =
           },
           {
             label: "Télécharger la fiche bilan",
-            url: `${
-              internshipKind === "immersion"
-                ? "https://immersion.cellar-c2.services.clever-cloud.com/bilan-immersion-professionnelle-inscriptible.pdf"
-                : "https://immersion.cellar-c2.services.clever-cloud.com/CCI_MiniStage_Bilan.pdf"
-            }`,
+            url:
+              agencyAssessmentDocumentLink ||
+              `${
+                internshipKind === "immersion"
+                  ? "https://immersion.cellar-c2.services.clever-cloud.com/bilan-immersion-professionnelle-inscriptible.pdf"
+                  : "https://immersion.cellar-c2.services.clever-cloud.com/CCI_MiniStage_Bilan.pdf"
+              }`,
           },
         ],
         highlight: {

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1197,6 +1197,7 @@ export const emailTemplatesByName =
         establishmentTutorName,
         immersionAssessmentCreationLink,
         internshipKind,
+        agencyAssessmentDocumentLink,
       }) => ({
         subject:
           internshipKind === "immersion"
@@ -1229,11 +1230,13 @@ export const emailTemplatesByName =
           },
           {
             label: "Télécharger la fiche bilan",
-            url: `${
-              internshipKind === "immersion"
-                ? "https://immersion.cellar-c2.services.clever-cloud.com/PMSMP_Bilan.pdf"
-                : "https://immersion.cellar-c2.services.clever-cloud.com/CCI_MiniStage_Bilan.pdf"
-            }`,
+            url:
+              agencyAssessmentDocumentLink ||
+              `${
+                internshipKind === "immersion"
+                  ? "https://immersion.cellar-c2.services.clever-cloud.com/PMSMP_Bilan.pdf"
+                  : "https://immersion.cellar-c2.services.clever-cloud.com/CCI_MiniStage_Bilan.pdf"
+              }`,
           },
         ],
         highlight: {

--- a/shared/src/utils.ts
+++ b/shared/src/utils.ts
@@ -165,3 +165,13 @@ type Primitive = string | boolean | number | undefined | null;
 
 export const arrayFromNumber = (n: number): number[] =>
   n > 0 ? Array.from(Array(n).keys()) : [];
+
+export const isUrlValid = (url: string | undefined) => {
+  if (!url) return false;
+  try {
+    const validUrl = new URL(url);
+    return validUrl.protocol === "http:" || validUrl.protocol === "https:";
+  } catch (_error) {
+    return false;
+  }
+};


### PR DESCRIPTION
## Problème

Dans les mails de validation et de création de bilan, le lien du bilan est toujours celui par défaut.  
Celui renseigné par le prescripteur n'est pas communiqué dans les mails.