### PR TITLE
ajout fichier de migration pour mettre à jour la colonne rights de api_consumers

### DIFF
--- a/back/src/adapters/secondary/pg/migrations/1694089930949_update-api-consumers-rights.ts
+++ b/back/src/adapters/secondary/pg/migrations/1694089930949_update-api-consumers-rights.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+const apiConsumersTable = "api_consumers";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  const rights = {
+    searchEstablishment: {
+      kinds: ["READ"],
+      scope: "no-scope",
+    },
+    convention: {
+      kinds: [],
+      scope: {
+        agencyKinds: [],
+      },
+    },
+  };
+
+  pgm.sql(`
+    UPDATE ${apiConsumersTable}
+    SET rights = '${JSON.stringify(rights)}'`);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  const rights = {
+    searchEstablishment: {
+      kinds: ["READ"],
+      scope: "no-scope",
+    },
+    convention: {
+      kinds: [],
+      scope: {
+        agencyKinds: [],
+        agencyIds: [],
+      },
+    },
+  };
+
+  pgm.sql(`
+    UPDATE ${apiConsumersTable}
+    SET rights = '${JSON.stringify(rights)}'`);
+}


### PR DESCRIPTION
## Description

La colonne rights de la table api_consumers ne peut désormais contenir qu'un seul propriété: soit `searchEstablishment` soit `convention` mais pas les deux en même temps (cf le type ApiConsumer).

Cette PR met à jour les informations déjà existantes en DB.

## Remarque

On met à jour toutes les lignes en DB: elle n'ont actuellement que les droits `READ` en `searchEstablishment`, d'où le fait que notre requête d'update ne contient pas de clause `where`.