### PR TITLE
Fix voir la convention

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionManageActions.tsx
+++ b/front/src/app/components/admin/conventions/ConventionManageActions.tsx
@@ -222,6 +222,7 @@ export const ConventionManageActions = ({
                 routes
                   .conventionDocument({
                     jwt,
+                    conventionId: convention.id,
                   })
                   .push()
               }

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Route } from "type-route";
 import {
+  BackOfficeJwt,
   ConventionJwt,
   ConventionJwtPayload,
   decodeMagicLinkJwtWithoutSignatureCheck,
@@ -47,12 +48,13 @@ type ConventionDocumentPageProps = {
 export const ConventionDocumentPage = ({
   route,
 }: ConventionDocumentPageProps) => {
-  const jwt: ConventionJwt = route.params.jwt;
+  const jwt: ConventionJwt | BackOfficeJwt = route.params.jwt;
   const { applicationId, role } =
     decodeMagicLinkJwtWithoutSignatureCheck<ConventionJwtPayload>(jwt);
+  const conventionId = applicationId ?? route.params.conventionId;
   const { convention, fetchConventionError, isLoading } = useConvention({
     jwt,
-    conventionId: applicationId,
+    conventionId,
   });
   const agencyInfo = useAppSelector(agencyInfoSelectors.details);
   const agencyFeedback = useAppSelector(agencyInfoSelectors.feedback);

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -3,9 +3,9 @@ import { useDispatch } from "react-redux";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Route } from "type-route";
 import {
-  BackOfficeJwt,
-  ConventionJwt,
+  ConventionId,
   ConventionJwtPayload,
+  ConventionSupportedJwt,
   decodeMagicLinkJwtWithoutSignatureCheck,
   isConventionRenewed,
   isStringDate,
@@ -48,13 +48,14 @@ type ConventionDocumentPageProps = {
 export const ConventionDocumentPage = ({
   route,
 }: ConventionDocumentPageProps) => {
-  const jwt: ConventionJwt | BackOfficeJwt = route.params.jwt;
-  const { applicationId, role } =
-    decodeMagicLinkJwtWithoutSignatureCheck<ConventionJwtPayload>(jwt);
-  const conventionId = applicationId ?? route.params.conventionId;
+  const jwt: ConventionSupportedJwt = route.params.jwt;
+  const routeConventionId: ConventionId | undefined = route.params.conventionId;
+  const { applicationId, role } = routeConventionId
+    ? { applicationId: routeConventionId, role: "backOffice" }
+    : decodeMagicLinkJwtWithoutSignatureCheck<ConventionJwtPayload>(jwt);
   const { convention, fetchConventionError, isLoading } = useConvention({
     jwt,
-    conventionId,
+    conventionId: applicationId,
   });
   const agencyInfo = useAppSelector(agencyInfoSelectors.details);
   const agencyFeedback = useAppSelector(agencyInfoSelectors.feedback);

--- a/front/src/app/routes/routes.ts
+++ b/front/src/app/routes/routes.ts
@@ -37,7 +37,7 @@ export const { RouteProvider, useRoute, routes } = createRouter({
     () => `/${frontRoutes.conventionImmersionRoute}-agence-immersion-facilitee`,
   ),
   conventionDocument: defineRoute(
-    { jwt: param.query.string },
+    { jwt: param.query.string, conventionId: param.query.optional.string },
     () => `/${frontRoutes.conventionDocument}`,
   ),
   conventionImmersion: defineRoute(


### PR DESCRIPTION
## Problème

Dans le backoffice, lorsque l'on clique sur "voir la convention" depuis une page de convention, on a une erreur: la convention  ne s'affiche pas sur la page `/convention-immersion`.

## Investigation

1. L'appel à l'api pour récupérer la convention est `/api/auth/demandes-immersion/undefined`. L'id de la convention est manquante
2. En remontant la trace jusque `ConventionDocumentPage.tsx`, on récupère `applicationId` à partir du jwt. Or avec le jwt de backoffice, `applicationId` est undefined.

## Solution

Lorsque l'accès à la page `/convention-immersion` se fait depuis le backoffice, alors on communique aussi l'id de la convention en param de la route