### PR TITLE
Afficher l'id de la convention 

### DIFF
--- a/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
+++ b/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
@@ -33,12 +33,12 @@ type ValidationSteps = "oneStep" | "twoSteps";
 
 const numberOfStepsOptions: { label: string; value: ValidationSteps }[] = [
   {
-    label: "1: La Convention est examinée et validée par la même personne",
+    label: "1: La convention est examinée et validée par la même personne",
     value: "oneStep",
   },
   {
     label:
-      "2: La Convention est examinée par une personne puis validée par quelqu’un d’autre",
+      "2: La convention est examinée par une personne puis validée par quelqu’un d’autre",
     value: "twoSteps",
   },
 ];

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -113,6 +113,8 @@ export const ConventionDocumentPage = ({
             <ConventionRenewedInformations renewed={convention.renewed} />
           )}
 
+          <p>Identifiant de la convention: {convention.id}</p>
+
           <h2 className={fr.cx("fr-h4")}>
             Cette convention est établie entre :
           </h2>


### PR DESCRIPTION
## Description

Des conseillers nous parlent de leur document de convention.
Mais ces documents ne contiennent pas d'id de convention. Donc il est difficile de chercher la convention concernée.

## Solution

Ajout l'id de la convention pour faciliter la communication.