### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Rapport d'anomalie
+about: Modèle de rapport d'anomalie
+title: Un titre court svp
+labels: bug
+---
+
+### :bug: Le problème
+
+<!-- Une description claire et concise du problème observé -->
+
+### :footprints: Étapes pour reproduire
+
+<!-- Étapes pour reproduire le comportement:
+1. Aller sur '...'
+2. Cliquer sur '...'
+3. Scroller sur '...'
+4. Il y a l'erreur '...'
+-->
+
+### :dart: Comportement attendu
+
+<!-- Une description claire de ce qui devrait se passer normalement -->
+
+### Screenshots
+
+<!-- Si possible, un petit screenshot du problème -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Fonctionnalité
+about: Un nouveau use case ou fonctionnalité.
+title: "Un titre court svp"
+---
+
+### :thinking: Contexte et problématique
+
+<!-- Décrire la problématique observée, le contexte et en quoi une solution serait utile. -->
+
+### :tada: Proposition de solution
+
+<!-- Quelle est la solution envisagée pour répondre à cette problématique -->
+
+### :camera: Maquettes
+
+<!-- Si possible, un lien vers les maquettes -->


### PR DESCRIPTION
## Description

Suggestion de templates pour les issues.  
Il s'agit ici des templates d'issues proposés par défaut par Github.

## Remarque

Template en français ou en anglais ?