### PR TITLE
feat: add department shape in public_departement_region

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "node ./transpile-back-and-prepare-for-prod.js",
-    "db:migrate": "ts-node node_modules/node-pg-migrate/bin/node-pg-migrate -j ts -m src/adapters/secondary/pg/migrations",
+    "db:migrate": "ts-node --compilerOptions '{\"resolveJsonModule\": true}' node_modules/node-pg-migrate/bin/node-pg-migrate -j ts -m src/adapters/secondary/pg/migrations",
     "db:create": "pnpm db:migrate create",
     "db:down": "pnpm db:migrate down",
     "db:up": "pnpm db:migrate up",

--- a/back/src/adapters/secondary/pg/migrations/1695885238870_add-department-shape.ts
+++ b/back/src/adapters/secondary/pg/migrations/1695885238870_add-department-shape.ts
@@ -1,0 +1,24 @@
+import { MigrationBuilder } from "node-pg-migrate";
+import departments from "../staticData/departements-avec-outre-mer.json";
+const tableName = "public_department_region";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(tableName, {
+    shape: {
+      type: "geometry",
+      notNull: false,
+    },
+  });
+  for (const department of departments.features)
+    pgm.sql(
+      `
+      UPDATE ${tableName}
+      SET shape = ST_GeomFromGeoJSON('${JSON.stringify(department.geometry)}')
+      WHERE department_code = '${department.properties.code}'
+  `,
+    );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(tableName, "shape");
+}

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es6",
     "lib": ["esNext", "ES2015"],
     "module": "CommonJS",
+    "resolveJsonModule": true,
     "outDir": "build",
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## :crying_cat_face:  Problème

Actuellement lorsqu'on souhaite associer le département sur lequel porte une recherche, on utilise le champ `address` de la table `searches_mades` qui malheureusement a un format très diverse. Pour ce faire, on utilise un regexp pour extraire le nom du département mais cela est assez fragile et permet de résoudre seulement 50% des recherches

## :tada: Solution

On ajoute dans la table `public_department_region` un champ geometry (postgis) qui va contenir la forme du departement. Pour cela on s'appuie sur https://github.com/gregoiredavid/france-geojson/ qui met à disposition des cartes des régions / département / ville au format geojson.

##  :rotating_light:  Point d'attention

N'etant pas disponible sur npm, le fichier à été coller dans le dépot. Pour le charger, il a fallu aussi modifier des option du compilateur TS pour charger des fichiers json.

## :robot:  Comment tester

- faire des recherches 
- aller sur le adminier et lancer la requete sql suivante
- voir le code departement dans les résultats
```sql
SELECT appellation_code, address, department_code
FROM searches_made
LEFT JOIN public_department_region
ON ST_Intersects(
	public_department_region.shape,
	searches_made.gps::geometry
)
```

fix #686 