### PR TITLE
fix pipeline: utiliser une variable dans un fichier ts plutôt qu'importer un json

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "node ./transpile-back-and-prepare-for-prod.js",
-    "db:migrate": "ts-node --compilerOptions '{\"resolveJsonModule\": true}' node_modules/node-pg-migrate/bin/node-pg-migrate -j ts -m src/adapters/secondary/pg/migrations",
+    "db:migrate": "ts-node node_modules/node-pg-migrate/bin/node-pg-migrate -j ts -m src/adapters/secondary/pg/migrations",
     "db:create": "pnpm db:migrate create",
     "db:down": "pnpm db:migrate down",
     "db:up": "pnpm db:migrate up",

--- a/back/src/adapters/secondary/pg/migrations/1695885238870_add-department-shape.ts
+++ b/back/src/adapters/secondary/pg/migrations/1695885238870_add-department-shape.ts
@@ -1,5 +1,6 @@
 import { MigrationBuilder } from "node-pg-migrate";
-import departments from "../staticData/departements-avec-outre-mer.json";
+import { departments } from "../staticData/departements-avec-outre-mer";
+
 const tableName = "public_department_region";
 
 export async function up(pgm: MigrationBuilder): Promise<void> {

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es6",
     "lib": ["esNext", "ES2015"],
     "module": "CommonJS",
-    "resolveJsonModule": true,
     "outDir": "build",
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Description

Nous rencontrons des problèmes sur [la pipeline](https://github.com/gip-inclusion/immersion-facile/actions/runs/6348539741): le paramètre `compilerOptions` n'est pas compris.

Ce paramètre est utilisé pour importer un fichier `json` depuis notre efichier de migration typescript.