### PR TITLE
fix pipeline: supprimer le --compilerOptions du package.json

### DIFF
--- a/back/transpile-back-and-prepare-for-prod.js
+++ b/back/transpile-back-and-prepare-for-prod.js
@@ -81,6 +81,11 @@ replaceInFileSync(
 // change ts-node scripts to node scripts
 replaceInFileSync(backPackageJson, /"ts-node /g, '"node ');
 replaceInFileSync(backPackageJson, /"node (.*)(\.ts)/g, '"node $1.js');
+replaceInFileSync(
+  backPackageJson,
+  /--compilerOptions '{\\"resolveJsonModule\\": true}'/g,
+  "",
+);
 
 // change migration script from ts source files to js
 replaceInFileSync(


### PR DESCRIPTION
## Description

Nous rencontrons des problèmes sur [la pipeline](https://github.com/gip-inclusion/immersion-facile/actions/runs/6348539741): le paramètre `compilerOptions` n'est pas compris.

Ce paramètre est utilisé pour importer un fichier `json` depuis notre fichier de migration typescript.

## Solution

Le paramètre `compilerOptions` n'est plus nécessaire une fois le back buildé.
Cette PR propose de le supprimer depuis le `transpile-back-and-prepare-for-prod.js`.