### PR TITLE
Afficher le schedule du pdf de convention sous forme de liste

### DIFF
--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -51,7 +51,7 @@ type ConventionDocumentPageProps = {
 
 type FormattedScheduleByWeek = {
   formattedHours: string;
-  formattedDaySchedules: string[];
+  formattedDaySchedules: string;
 }[];
 
 const formatSchedule = (convention: ConventionReadDto) => {
@@ -65,22 +65,27 @@ const formatSchedule = (convention: ConventionReadDto) => {
       if (line.includes("Heures de travail hebdomadaires : ")) {
         scheduleByWeek.push({
           formattedHours: line,
-          formattedDaySchedules: [],
+          formattedDaySchedules: "",
         });
       } else {
         const lastWeek = scheduleByWeek[scheduleByWeek.length - 1];
-        lastWeek.formattedDaySchedules.push(line);
+        lastWeek.formattedDaySchedules =
+          lastWeek.formattedDaySchedules.length > 0
+            ? `${lastWeek.formattedDaySchedules}, ${line}`
+            : line;
       }
     });
 
-  return scheduleByWeek.map((schedule) => (
-    <ul key={schedule.formattedHours}>
-      {schedule.formattedHours}
-      {schedule.formattedDaySchedules.map((day) => (
-        <li key={day}>{day}</li>
+  return (
+    <ul>
+      {scheduleByWeek.map((schedule) => (
+        <li key={schedule.formattedHours}>
+          <div>{schedule.formattedHours}</div>
+          <div>{schedule.formattedDaySchedules}</div>
+        </li>
       ))}
     </ul>
-  ));
+  );
 };
 
 export const ConventionDocumentPage = ({


### PR DESCRIPTION
## Description

Le schedule actuel n'est pas simple à lire, on a actuellement:

<img width="999" alt="Screenshot 2023-10-05 at 15 02 37" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/6761d4a0-9128-4b53-9bad-5bb6e0ff68c6">

## Solution

Formatter le texte pour insérer une liste par semaine.

Avec cette PR, on afficherait :

<img width="994" alt="Screenshot 2023-10-05 at 14 49 34" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/aed94856-b1d6-407a-a2fb-5e1b2287266e">



