### PR TITLE
678 gestion des conventions à saisir depuis le tableau de bord prévoir de quoi cocher les conventions quils régularisent dans leurs applicatifs

### DIFF
--- a/back/src/adapters/primary/config/createUseCases.ts
+++ b/back/src/adapters/primary/config/createUseCases.ts
@@ -39,6 +39,7 @@ import { NotifyNewApplicationNeedsReview } from "../../../domain/convention/useC
 import { NotifySignatoriesThatConventionSubmittedNeedsSignature } from "../../../domain/convention/useCases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignature";
 import { NotifySignatoriesThatConventionSubmittedNeedsSignatureAfterModification } from "../../../domain/convention/useCases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignatureAfterModification";
 import { NotifyToAgencyApplicationSubmitted } from "../../../domain/convention/useCases/notifications/NotifyToAgencyApplicationSubmitted";
+import { MarkPartnersErroredConventionAsHandled } from "../../../domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled";
 import { RenewConvention } from "../../../domain/convention/useCases/RenewConvention";
 import { RenewConventionMagicLink } from "../../../domain/convention/useCases/RenewConventionMagicLink";
 import { SendEmailWhenAgencyIsActivated } from "../../../domain/convention/useCases/SendEmailWhenAgencyIsActivated";
@@ -260,6 +261,13 @@ export const createUseCases = (
         gateways.shortLinkGenerator,
         config,
       ),
+
+      markPartnersErroredConventionAsHandled:
+        new MarkPartnersErroredConventionAsHandled(
+          uowPerformer,
+          createNewEvent,
+          gateways.timeGateway,
+        ),
 
       // immersionOffer
       searchImmersion: new SearchImmersion(

--- a/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
+++ b/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
@@ -40,7 +40,7 @@ export const createInclusionConnectedAllowedRouter = (
   );
 
   inclusionConnectedSharedRoutes.markPartnersErroredConventionAsHandled(
-    deps.applicationMagicLinkAuthMiddleware,
+    createInclusionConnectedMiddleware(deps.config.jwtPublicKey),
     async (req, res) =>
       sendHttpResponse(req, res, () =>
         match(req.payloads)

--- a/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
+++ b/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { match, P } from "ts-pattern";
 import { inclusionConnectedAllowedRoutes } from "shared";
 import { createExpressSharedRouter } from "shared-routes/express";
 import { AppDependencies } from "../../config/createAppDependencies";
@@ -45,19 +44,15 @@ export const createInclusionConnectedAllowedRouter = (
 
   inclusionConnectedSharedRoutes.markPartnersErroredConventionAsHandled(
     inclusionConnectedMiddleware,
-    async (req, res) =>
-      sendHttpResponse(req, res, () =>
-        match(req.payloads)
-          .with({ inclusion: P.not(P.nullish) }, ({ inclusion }) =>
-            deps.useCases.markPartnersErroredConventionAsHandled.execute(
-              req.body,
-              inclusion,
-            ),
-          )
-          .otherwise(() => {
-            throw new UnauthorizedError();
-          }),
-      ),
+    (req, res) =>
+      sendHttpResponse(req, res, async () => {
+        const inclusion = req.payloads?.inclusion;
+        if (!inclusion) throw new UnauthorizedError();
+        await deps.useCases.markPartnersErroredConventionAsHandled.execute(
+          req.body,
+          inclusion,
+        );
+      }),
   );
 
   return inclusionConnectedRouter;

--- a/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
+++ b/back/src/adapters/primary/routers/inclusionConnect/createInclusionConnectedAllowedRouter.ts
@@ -17,8 +17,12 @@ export const createInclusionConnectedAllowedRouter = (
     inclusionConnectedRouter,
   );
 
+  const inclusionConnectedMiddleware = createInclusionConnectedMiddleware(
+    deps.config.jwtPublicKey,
+  );
+
   inclusionConnectedSharedRoutes.getInclusionConnectedUser(
-    createInclusionConnectedMiddleware(deps.config.jwtPublicKey),
+    inclusionConnectedMiddleware,
     (req, res) =>
       sendHttpResponse(req, res, async () =>
         deps.useCases.getUserAgencyDashboardUrl.execute(
@@ -29,7 +33,7 @@ export const createInclusionConnectedAllowedRouter = (
   );
 
   inclusionConnectedSharedRoutes.registerAgenciesToUser(
-    createInclusionConnectedMiddleware(deps.config.jwtPublicKey),
+    inclusionConnectedMiddleware,
     (req, res) =>
       sendHttpResponse(req, res, () =>
         deps.useCases.registerAgencyToInclusionConnectUser.execute(
@@ -40,7 +44,7 @@ export const createInclusionConnectedAllowedRouter = (
   );
 
   inclusionConnectedSharedRoutes.markPartnersErroredConventionAsHandled(
-    createInclusionConnectedMiddleware(deps.config.jwtPublicKey),
+    inclusionConnectedMiddleware,
     async (req, res) =>
       sendHttpResponse(req, res, () =>
         match(req.payloads)

--- a/back/src/adapters/primary/subscribeToEvents.ts
+++ b/back/src/adapters/primary/subscribeToEvents.ts
@@ -125,6 +125,8 @@ const getUseCasesByTopics = (
 
   //Api Consumer related:
   ApiConsumerSaved: [],
+  //partnersErroredConvention related
+  PartnerErroredConventionMarkAsHandled: [],
 });
 
 export const subscribeToEvents = (deps: AppDependencies) => {

--- a/back/src/adapters/primary/subscribeToEvents.ts
+++ b/back/src/adapters/primary/subscribeToEvents.ts
@@ -126,7 +126,7 @@ const getUseCasesByTopics = (
   //Api Consumer related:
   ApiConsumerSaved: [],
   //partnersErroredConvention related
-  PartnerErroredConventionMarkAsHandled: [],
+  PartnerErroredConventionMarkedAsHandled: [],
 });
 
 export const subscribeToEvents = (deps: AppDependencies) => {

--- a/back/src/adapters/secondary/core/InMemoryErrorRepository.ts
+++ b/back/src/adapters/secondary/core/InMemoryErrorRepository.ts
@@ -14,16 +14,17 @@ export class InMemoryErrorRepository implements ErrorRepository {
     conventionId: ConventionId,
   ): Promise<void> {
     const hasConventionErrorToMarkAsHandled = this.#savedErrors.some(
-      (savedError) => isSavedErrorForConvention(savedError, conventionId),
+      (savedError) =>
+        isUnhandledSavedErrorForConvention(savedError, conventionId),
     );
 
     if (!hasConventionErrorToMarkAsHandled)
       throw new NotFoundError(
-        `There's no ${broadcastToPeServiceName} errors for convention id '${conventionId}'.`,
+        `There's no ${broadcastToPeServiceName} unhandled errors for convention id '${conventionId}'.`,
       );
 
     this.#savedErrors = this.#savedErrors.map((savedError) => {
-      if (isSavedErrorForConvention(savedError, conventionId)) {
+      if (isUnhandledSavedErrorForConvention(savedError, conventionId)) {
         return { ...savedError, handledByAgency: true };
       }
       return savedError;
@@ -39,10 +40,11 @@ export class InMemoryErrorRepository implements ErrorRepository {
   }
 }
 
-const isSavedErrorForConvention = (
+const isUnhandledSavedErrorForConvention = (
   savedError: SavedError,
   conventionId: ConventionId,
 ) =>
   "conventionId" in savedError.params &&
   savedError.params.conventionId === conventionId &&
-  savedError.serviceName === broadcastToPeServiceName;
+  savedError.serviceName === broadcastToPeServiceName &&
+  savedError.handledByAgency === false;

--- a/back/src/adapters/secondary/core/InMemoryErrorRepository.ts
+++ b/back/src/adapters/secondary/core/InMemoryErrorRepository.ts
@@ -1,11 +1,36 @@
+import { ConventionId } from "shared";
 import {
+  broadcastToPeServiceName,
   ErrorRepository,
   SavedError,
 } from "../../../domain/core/ports/ErrorRepository";
+import { NotFoundError } from "../../primary/helpers/httpErrors";
 
 export class InMemoryErrorRepository implements ErrorRepository {
   // for testing purposes
   #savedErrors: SavedError[] = [];
+
+  public async markPartnersErroredConventionAsHandled(
+    id: ConventionId,
+  ): Promise<void> {
+    let erroredConventionMarked = false;
+    this.#savedErrors = this.#savedErrors.map((savedError) => {
+      if (
+        "conventionId" in savedError.params &&
+        savedError.params.conventionId === id &&
+        savedError.serviceName === broadcastToPeServiceName
+      ) {
+        erroredConventionMarked = true;
+        return { ...savedError, handledByAgency: true };
+      }
+
+      return savedError;
+    });
+    if (!erroredConventionMarked)
+      throw new NotFoundError(
+        `There's no ${broadcastToPeServiceName} errors for convention id '${id}'.`,
+      );
+  }
 
   public async save(savedError: SavedError): Promise<void> {
     this.#savedErrors.push(savedError);

--- a/back/src/adapters/secondary/pg/kysely/model/database.ts
+++ b/back/src/adapters/secondary/pg/kysely/model/database.ts
@@ -7,6 +7,7 @@ export interface Database {
   groups: Groups;
   groups__sirets: GroupsSirets;
   agencies: Agencies;
+  saved_errors: SavedErrors;
 }
 
 export type JsonArray = JsonValue[];
@@ -100,4 +101,13 @@ export interface Agencies {
   city: string;
   department_code: string;
   refers_to_agency_id: string | null;
+}
+
+export interface SavedErrors {
+  id: Generated<number>;
+  service_name: string;
+  message: string;
+  params: Json | null;
+  occurred_at: Timestamp;
+  handled_by_agency: Generated<boolean>;
 }

--- a/back/src/adapters/secondary/pg/repositories/PgErrorRepository.integration.test.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgErrorRepository.integration.test.ts
@@ -109,7 +109,7 @@ describe("PgErrorRepository", () => {
       await expectPromiseToFailWithError(
         pgErrorRepository.markPartnersErroredConventionAsHandled(conventionId1),
         new NotFoundError(
-          `There's no ${broadcastToPeServiceName} errors for convention id '${conventionId1}'.`,
+          `There's no ${broadcastToPeServiceName} unhandled errors for convention id '${conventionId1}'.`,
         ),
       );
     });

--- a/back/src/adapters/secondary/pg/repositories/PgErrorRepository.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgErrorRepository.ts
@@ -1,11 +1,32 @@
+import { ConventionId } from "shared";
 import {
+  broadcastToPeServiceName,
   ErrorRepository,
   SavedError,
 } from "../../../../domain/core/ports/ErrorRepository";
+import { NotFoundError } from "../../../primary/helpers/httpErrors";
 import { executeKyselyRawSqlQuery, KyselyDb } from "../kysely/kyselyUtils";
 
 export class PgErrorRepository implements ErrorRepository {
   constructor(private transaction: KyselyDb) {}
+
+  public async markPartnersErroredConventionAsHandled(
+    conventionId: ConventionId,
+  ): Promise<void> {
+    const query = `UPDATE saved_errors SET
+    handled_by_agency = true
+    WHERE(params ->> 'conventionId') = $1
+    AND service_name = $2`;
+    const result = await executeKyselyRawSqlQuery(this.transaction, query, [
+      conventionId,
+      broadcastToPeServiceName,
+    ]);
+
+    if (Number(result.numAffectedRows) === 0)
+      throw new NotFoundError(
+        `There's no ${broadcastToPeServiceName} errors for convention id '${conventionId}'.`,
+      );
+  }
 
   public async save(savedError: SavedError): Promise<void> {
     // prettier-ignore

--- a/back/src/adapters/secondary/pg/repositories/PgErrorRepository.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgErrorRepository.ts
@@ -19,11 +19,12 @@ export class PgErrorRepository implements ErrorRepository {
       .set({ handled_by_agency: true })
       .where(sql`(params ->> 'conventionId')`, "=", conventionId)
       .where("service_name", "=", broadcastToPeServiceName)
+      .where("handled_by_agency", "=", false)
       .executeTakeFirst();
 
     if (Number(result.numUpdatedRows) === 0)
       throw new NotFoundError(
-        `There's no ${broadcastToPeServiceName} errors for convention id '${conventionId}'.`,
+        `There's no ${broadcastToPeServiceName} unhandled errors for convention id '${conventionId}'.`,
       );
   }
 

--- a/back/src/domain/convention/useCases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.ts
+++ b/back/src/domain/convention/useCases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.ts
@@ -1,5 +1,6 @@
 import { ConventionDto, conventionSchema, ImmersionObjective } from "shared";
 import { NotFoundError } from "../../../../adapters/primary/helpers/httpErrors";
+import { broadcastToPeServiceName } from "../../../core/ports/ErrorRepository";
 import { TimeGateway } from "../../../core/ports/TimeGateway";
 import {
   UnitOfWork,
@@ -125,10 +126,11 @@ export class BroadcastToPoleEmploiOnConventionUpdates extends TransactionalUseCa
 
     if (!isBroadcastResponseOk(response)) {
       await uow.errorRepository.save({
-        serviceName: "PoleEmploiGateway.notifyOnConventionUpdated",
+        serviceName: broadcastToPeServiceName,
         message: response.message,
         params: { conventionId: convention.id, httpStatus: response.status },
         occurredAt: this.timeGateway.now(),
+        handledByAgency: false,
       });
     }
   }

--- a/back/src/domain/convention/useCases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.unit.test.ts
+++ b/back/src/domain/convention/useCases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.unit.test.ts
@@ -12,6 +12,7 @@ import { CustomTimeGateway } from "../../../../adapters/secondary/core/TimeGatew
 import { InMemoryFeatureFlagRepository } from "../../../../adapters/secondary/InMemoryFeatureFlagRepository";
 import { InMemoryUowPerformer } from "../../../../adapters/secondary/InMemoryUowPerformer";
 import { InMemoryPoleEmploiGateway } from "../../../../adapters/secondary/poleEmploi/InMemoryPoleEmploiGateway";
+import { broadcastToPeServiceName } from "../../../core/ports/ErrorRepository";
 import { BroadcastToPoleEmploiOnConventionUpdates } from "./BroadcastToPoleEmploiOnConventionUpdates";
 
 const prepareUseCase = async ({
@@ -130,13 +131,14 @@ describe("Broadcasts events to pole-emploi", () => {
     expect(poleEmploiGateWay.notifications).toHaveLength(1);
     expectToEqual(uow.errorRepository.savedErrors, [
       {
-        serviceName: "PoleEmploiGateway.notifyOnConventionUpdated",
+        serviceName: broadcastToPeServiceName,
         params: {
           conventionId: convention.id,
           httpStatus: 404,
         },
         message: "Ops, something is bad",
         occurredAt: now,
+        handledByAgency: false,
       },
     ]);
   });

--- a/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.ts
+++ b/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.ts
@@ -1,6 +1,4 @@
 import {
-  AuthenticatedUserId,
-  ConventionId,
   InclusionConnectDomainJwtPayload,
   MarkPartnersErroredConventionAsHandledRequest,
   markPartnersErroredConventionAsHandledRequestSchema,
@@ -11,7 +9,6 @@ import {
   UnauthorizedError,
 } from "../../../../adapters/primary/helpers/httpErrors";
 import { CreateNewEvent } from "../../../core/eventBus/EventBus";
-import { DomainTopic } from "../../../core/eventBus/events";
 import { TimeGateway } from "../../../core/ports/TimeGateway";
 import {
   UnitOfWork,
@@ -70,27 +67,15 @@ export class MarkPartnersErroredConventionAsHandled extends TransactionalUseCase
       params.conventionId,
     );
 
-    await uow.outboxRepository.save({
-      ...this.#createEvent(
-        params.conventionId,
-        userId,
-        "PartnerErroredConventionMarkAsHandled",
-      ),
-      occurredAt: conventionMarkAsHandledAt,
-    });
-  }
-
-  #createEvent(
-    conventionId: ConventionId,
-    userId: AuthenticatedUserId,
-    domainTopic: DomainTopic,
-  ) {
-    return this.createNewEvent({
-      topic: domainTopic,
-      payload: {
-        conventionId,
-        userId,
-      },
-    });
+    await uow.outboxRepository.save(
+      this.createNewEvent({
+        topic: "PartnerErroredConventionMarkedAsHandled",
+        payload: {
+          conventionId: params.conventionId,
+          userId,
+        },
+        occurredAt: conventionMarkAsHandledAt,
+      }),
+    );
   }
 }

--- a/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.unit.test.ts
+++ b/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.unit.test.ts
@@ -1,0 +1,278 @@
+import {
+  AgencyDtoBuilder,
+  ConventionDtoBuilder,
+  expectPromiseToFailWith,
+  expectToEqual,
+  InclusionConnectDomainJwtPayload,
+  InclusionConnectedUser,
+} from "shared";
+import {
+  createInMemoryUow,
+  InMemoryUnitOfWork,
+} from "../../../../adapters/primary/config/uowConfig";
+import { InMemoryOutboxRepository } from "../../../../adapters/secondary/core/InMemoryOutboxRepository";
+import { CustomTimeGateway } from "../../../../adapters/secondary/core/TimeGateway/CustomTimeGateway";
+import { TestUuidGenerator } from "../../../../adapters/secondary/core/UuidGeneratorImplementations";
+import { InMemoryUowPerformer } from "../../../../adapters/secondary/InMemoryUowPerformer";
+import {
+  CreateNewEvent,
+  makeCreateNewEvent,
+} from "../../../core/eventBus/EventBus";
+import { broadcastToPeServiceName } from "../../../core/ports/ErrorRepository";
+import { MarkPartnersErroredConventionAsHandled } from "./MarkPartnersErroredConventionAsHandled";
+
+describe("mark partners errored convention as handled", () => {
+  let uow: InMemoryUnitOfWork;
+  let outboxRepo: InMemoryOutboxRepository;
+  let timeGateway: CustomTimeGateway;
+  let markPartnersErroredConventionAsHandled: MarkPartnersErroredConventionAsHandled;
+  let createNewEvent: CreateNewEvent;
+
+  const conventionId = "add5c20e-6dd2-45af-affe-927358004444";
+  const userId = "decd5596-bf79-45ae-8e77-6913f1069835";
+
+  const icJwtDomainPayload: InclusionConnectDomainJwtPayload = { userId };
+
+  const agency = new AgencyDtoBuilder().build();
+
+  const icUserWithoutRight: InclusionConnectedUser = {
+    id: userId,
+    email: "my-user@email.com",
+    firstName: "John",
+    lastName: "Doe",
+    agencyRights: [],
+  };
+
+  const icUserWithAgencyRights: InclusionConnectedUser = {
+    id: userId,
+    email: "my-user@email.com",
+    firstName: "John",
+    lastName: "Doe",
+    agencyRights: [{ role: "validator", agency }],
+  };
+
+  const convention = new ConventionDtoBuilder()
+    .withId(conventionId)
+    .withAgencyId(agency.id)
+    .build();
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    outboxRepo = uow.outboxRepository;
+    timeGateway = new CustomTimeGateway();
+
+    createNewEvent = makeCreateNewEvent({
+      timeGateway,
+      uuidGenerator: new TestUuidGenerator(),
+    });
+
+    markPartnersErroredConventionAsHandled =
+      new MarkPartnersErroredConventionAsHandled(
+        new InMemoryUowPerformer(uow),
+        createNewEvent,
+        timeGateway,
+      );
+  });
+
+  it("Mark partner errored convention as handled", async () => {
+    const conventionRepository = uow.conventionRepository;
+    const inclusionConnectRepository = uow.inclusionConnectedUserRepository;
+    const savedErrorsRepository = uow.errorRepository;
+
+    const savedErrorConvention = {
+      serviceName: broadcastToPeServiceName,
+      params: {
+        conventionId,
+        httpStatus: 404,
+      },
+      message: "Ops, something is bad",
+      occurredAt: timeGateway.now(),
+      handledByAgency: false,
+    };
+
+    await conventionRepository.save(convention);
+    await savedErrorsRepository.save(savedErrorConvention);
+
+    await inclusionConnectRepository.setInclusionConnectedUsers([
+      icUserWithAgencyRights,
+    ]);
+
+    await markPartnersErroredConventionAsHandled.execute(
+      {
+        conventionId,
+      },
+      icJwtDomainPayload,
+    );
+
+    expectToEqual(savedErrorsRepository.savedErrors, [
+      {
+        ...savedErrorConvention,
+        handledByAgency: true,
+      },
+    ]);
+
+    expectToEqual(outboxRepo.events, [
+      createNewEvent({
+        topic: "PartnerErroredConventionMarkAsHandled",
+        payload: {
+          conventionId,
+          userId,
+        },
+      }),
+    ]);
+  });
+
+  it("only mark as handled the errored conventions that have the corresponding service name", async () => {
+    const conventionRepository = uow.conventionRepository;
+    const inclusionConnectRepository = uow.inclusionConnectedUserRepository;
+    const savedErrorsRepository = uow.errorRepository;
+
+    const savedErrorConvention1 = {
+      serviceName: broadcastToPeServiceName,
+      params: {
+        conventionId,
+        httpStatus: 404,
+      },
+      message: "Ops, something is bad",
+      occurredAt: timeGateway.now(),
+      handledByAgency: false,
+    };
+
+    const savedErrorConvention2 = {
+      serviceName: broadcastToPeServiceName,
+      params: {
+        conventionId,
+        httpStatus: 404,
+      },
+      message: "Ops, something is bad AGAIN",
+      occurredAt: timeGateway.now(),
+      handledByAgency: false,
+    };
+
+    const savedErrorConvention3 = {
+      serviceName: "Yolo.serviceName",
+      params: {
+        conventionId,
+        httpStatus: 404,
+      },
+      message: "yolo",
+      occurredAt: timeGateway.now(),
+      handledByAgency: false,
+    };
+
+    await conventionRepository.save(convention);
+    await savedErrorsRepository.save(savedErrorConvention1);
+    await savedErrorsRepository.save(savedErrorConvention2);
+    await savedErrorsRepository.save(savedErrorConvention3);
+
+    await inclusionConnectRepository.setInclusionConnectedUsers([
+      icUserWithAgencyRights,
+    ]);
+
+    await markPartnersErroredConventionAsHandled.execute(
+      {
+        conventionId,
+      },
+      icJwtDomainPayload,
+    );
+
+    expectToEqual(savedErrorsRepository.savedErrors, [
+      {
+        ...savedErrorConvention1,
+        handledByAgency: true,
+      },
+      {
+        ...savedErrorConvention2,
+        handledByAgency: true,
+      },
+      { ...savedErrorConvention3 },
+    ]);
+
+    expectToEqual(outboxRepo.events, [
+      createNewEvent({
+        topic: "PartnerErroredConventionMarkAsHandled",
+        payload: {
+          conventionId,
+          userId,
+        },
+      }),
+    ]);
+  });
+
+  it("Throw when convention is not errored", async () => {
+    const conventionRepository = uow.conventionRepository;
+    const inclusionConnectRepository = uow.inclusionConnectedUserRepository;
+
+    await conventionRepository.save(convention);
+    await inclusionConnectRepository.setInclusionConnectedUsers([
+      icUserWithAgencyRights,
+    ]);
+
+    await expectPromiseToFailWith(
+      markPartnersErroredConventionAsHandled.execute(
+        {
+          conventionId,
+        },
+        icJwtDomainPayload,
+      ),
+      `There's no ${broadcastToPeServiceName} errors for convention id '${conventionId}'.`,
+    );
+  });
+
+  it("Throw when no jwt were provided", async () => {
+    await expectPromiseToFailWith(
+      markPartnersErroredConventionAsHandled.execute({
+        conventionId,
+      }),
+      `Veuillez vous authentifier`,
+    );
+  });
+
+  it("Throw when no convention was found", async () => {
+    await expectPromiseToFailWith(
+      markPartnersErroredConventionAsHandled.execute(
+        {
+          conventionId,
+        },
+        icJwtDomainPayload,
+      ),
+      `Convention with id '${conventionId}' missing.`,
+    );
+  });
+
+  it("Throw when no user was found", async () => {
+    const conventionRepository = uow.conventionRepository;
+
+    await conventionRepository.save(convention);
+
+    await expectPromiseToFailWith(
+      markPartnersErroredConventionAsHandled.execute(
+        {
+          conventionId,
+        },
+        icJwtDomainPayload,
+      ),
+      `User '${userId}' not found on inclusion connected user repository.`,
+    );
+  });
+
+  it("Throw when user doesn't have right for agency", async () => {
+    const conventionRepository = uow.conventionRepository;
+    const inclusionConnectRepository = uow.inclusionConnectedUserRepository;
+
+    await conventionRepository.save(convention);
+    await inclusionConnectRepository.setInclusionConnectedUsers([
+      icUserWithoutRight,
+    ]);
+
+    await expectPromiseToFailWith(
+      markPartnersErroredConventionAsHandled.execute(
+        {
+          conventionId,
+        },
+        icJwtDomainPayload,
+      ),
+      `User '${userId}' has no role on agency '${agency.id}'.`,
+    );
+  });
+});

--- a/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.unit.test.ts
+++ b/back/src/domain/convention/useCases/partnersErroredConvention/MarkPartnersErroredConventionAsHandled.unit.test.ts
@@ -113,7 +113,7 @@ describe("mark partners errored convention as handled", () => {
 
     expectToEqual(outboxRepo.events, [
       createNewEvent({
-        topic: "PartnerErroredConventionMarkAsHandled",
+        topic: "PartnerErroredConventionMarkedAsHandled",
         payload: {
           conventionId,
           userId,
@@ -190,7 +190,7 @@ describe("mark partners errored convention as handled", () => {
 
     expectToEqual(outboxRepo.events, [
       createNewEvent({
-        topic: "PartnerErroredConventionMarkAsHandled",
+        topic: "PartnerErroredConventionMarkedAsHandled",
         payload: {
           conventionId,
           userId,

--- a/back/src/domain/core/eventBus/events.ts
+++ b/back/src/domain/core/eventBus/events.ts
@@ -4,6 +4,7 @@ import {
   AuthenticatedUserId,
   ContactEstablishmentEventPayload,
   ConventionDto,
+  ConventionId,
   DateIsoString,
   EstablishmentJwtPayload,
   Flavor,
@@ -100,7 +101,9 @@ export type DomainEvent =
   | GenericEvent<"AgencyRegisteredToInclusionConnectedUser", { userId: AuthenticatedUserId, agencyIds: AgencyId[] }>
   | GenericEvent<"IcUserAgencyRightChanged", IcUserRoleForAgencyParams>
   // API CONSUMER related
-  | GenericEvent<"ApiConsumerSaved", { consumerId: string }>;
+  | GenericEvent<"ApiConsumerSaved", { consumerId: string }>
+  // ERRORED CONVENTION RELATED
+  | GenericEvent<"PartnerErroredConventionMarkAsHandled", { conventionId: ConventionId, userId: AuthenticatedUserId }>;
 
 export type DomainTopic = DomainEvent["topic"];
 

--- a/back/src/domain/core/eventBus/events.ts
+++ b/back/src/domain/core/eventBus/events.ts
@@ -103,7 +103,7 @@ export type DomainEvent =
   // API CONSUMER related
   | GenericEvent<"ApiConsumerSaved", { consumerId: string }>
   // ERRORED CONVENTION RELATED
-  | GenericEvent<"PartnerErroredConventionMarkAsHandled", { conventionId: ConventionId, userId: AuthenticatedUserId }>;
+  | GenericEvent<"PartnerErroredConventionMarkedAsHandled", { conventionId: ConventionId, userId: AuthenticatedUserId }>;
 
 export type DomainTopic = DomainEvent["topic"];
 

--- a/back/src/domain/core/ports/ErrorRepository.ts
+++ b/back/src/domain/core/ports/ErrorRepository.ts
@@ -1,10 +1,15 @@
+import { ConventionId } from "shared";
+
 export type SavedError = {
   serviceName: string;
   message: string;
-  params: unknown;
+  params: Record<string, unknown>;
   occurredAt: Date;
+  handledByAgency: boolean;
 };
-
+export const broadcastToPeServiceName =
+  "PoleEmploiGateway.notifyOnConventionUpdated";
 export interface ErrorRepository {
   save: (savedError: SavedError) => Promise<void>;
+  markPartnersErroredConventionAsHandled: (id: ConventionId) => Promise<void>;
 }

--- a/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
+++ b/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
@@ -60,7 +60,6 @@ export const AgencyDashboardPage = () => {
               <>
                 <Button
                   priority="secondary"
-                  className={fr.cx("fr-mb-5v")}
                   linkProps={{
                     href: "https://view.officeapps.live.com/op/embed.aspx?src=https://mediatheque.pole-emploi.fr/documents/Immersion_facilitee/GUIDE_SAISIE_DES_CONVENTIONS.pptx",
                     target: "_blank",
@@ -69,10 +68,6 @@ export const AgencyDashboardPage = () => {
                 >
                   Guide de saisie des conventions
                 </Button>
-                <MetabaseView
-                  title="Tableau de bord agence"
-                  url={conventionErrorUrl}
-                />
                 {inclusionConnectedJwt ? (
                   <>
                     <MarkPartnersErroredConventionAsHandledFormSection
@@ -96,6 +91,11 @@ export const AgencyDashboardPage = () => {
                     description="Cette page est reservée aux utilisateurs connectés avec Inclusion Connect, et dont l'agence est responsable de cette convention."
                   />
                 )}
+
+                <MetabaseView
+                  title="Tableau de bord agence"
+                  url={conventionErrorUrl}
+                />
               </>
             ),
           },

--- a/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
+++ b/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
@@ -12,8 +12,10 @@ import { MetabaseView } from "src/app/components/MetabaseView";
 import { SubmitFeedbackNotification } from "src/app/components/SubmitFeedbackNotification";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { ManageConventionFormSection } from "src/app/pages/admin/ManageConventionFormSection";
+import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { authSlice } from "src/core-logic/domain/auth/auth.slice";
 import { inclusionConnectedSelectors } from "src/core-logic/domain/inclusionConnected/inclusionConnected.selectors";
+import { partnersErroredConventionSelectors } from "src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.selector";
 import { RegisterAgenciesForm } from "../../components/forms/register-agencies/RegisterAgenciesForm";
 import { MarkPartnersErroredConventionAsHandledFormSection } from "./MarkPartnersErroredConventionAsHandledFormSection";
 
@@ -21,8 +23,13 @@ export const AgencyDashboardPage = () => {
   // the Layout (Header, Footer...) is given by InclusionConnectedPrivateRoute (higher order component)
   const currentUser = useAppSelector(inclusionConnectedSelectors.currentUser);
   const feedback = useAppSelector(inclusionConnectedSelectors.feedback);
+  const markErroredConventionAsHandledFeedback = useAppSelector(
+    partnersErroredConventionSelectors.feedback,
+  );
   const isLoading = useAppSelector(inclusionConnectedSelectors.isLoading);
-
+  const inclusionConnectedJwt = useAppSelector(
+    authSelectors.inclusionConnectToken,
+  );
   const dispatch = useDispatch();
 
   type AgencyDashboardTab = {
@@ -66,7 +73,29 @@ export const AgencyDashboardPage = () => {
                   title="Tableau de bord agence"
                   url={conventionErrorUrl}
                 />
-                <MarkPartnersErroredConventionAsHandledFormSection />
+                {inclusionConnectedJwt ? (
+                  <>
+                    <MarkPartnersErroredConventionAsHandledFormSection
+                      jwt={inclusionConnectedJwt}
+                    />
+                    <SubmitFeedbackNotification
+                      submitFeedback={markErroredConventionAsHandledFeedback}
+                      messageByKind={{
+                        markedAsHandled: {
+                          title: "Succès",
+                          message:
+                            "La convention a bien été marquée comme traité.",
+                        },
+                      }}
+                    />
+                  </>
+                ) : (
+                  <Alert
+                    severity="error"
+                    title="Non autorisé"
+                    description="Cette page est reservée aux utilisateurs connectés avec Inclusion Connect, et dont l'agence est responsable de cette convention."
+                  />
+                )}
               </>
             ),
           },

--- a/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
+++ b/front/src/app/pages/agencyDashboard/AgencyDashboardPage.tsx
@@ -14,7 +14,8 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { ManageConventionFormSection } from "src/app/pages/admin/ManageConventionFormSection";
 import { authSlice } from "src/core-logic/domain/auth/auth.slice";
 import { inclusionConnectedSelectors } from "src/core-logic/domain/inclusionConnected/inclusionConnected.selectors";
-import { RegisterAgenciesForm } from "../components/forms/register-agencies/RegisterAgenciesForm";
+import { RegisterAgenciesForm } from "../../components/forms/register-agencies/RegisterAgenciesForm";
+import { MarkPartnersErroredConventionAsHandledFormSection } from "./MarkPartnersErroredConventionAsHandledFormSection";
 
 export const AgencyDashboardPage = () => {
   // the Layout (Header, Footer...) is given by InclusionConnectedPrivateRoute (higher order component)
@@ -65,6 +66,7 @@ export const AgencyDashboardPage = () => {
                   title="Tableau de bord agence"
                   url={conventionErrorUrl}
                 />
+                <MarkPartnersErroredConventionAsHandledFormSection />
               </>
             ),
           },

--- a/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
+++ b/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  MarkPartnersErroredConventionAsHandledRequest,
+  markPartnersErroredConventionAsHandledRequestSchema,
+} from "shared";
+import { makeFieldError } from "src/app/hooks/formContents.hooks";
+
+export const MarkPartnersErroredConventionAsHandledFormSection = () => {
+  const { register, handleSubmit, formState } =
+    useForm<MarkPartnersErroredConventionAsHandledRequest>({
+      resolver: zodResolver(
+        markPartnersErroredConventionAsHandledRequestSchema,
+      ),
+      mode: "onTouched",
+    });
+
+  return (
+    <>
+      <h5 className={fr.cx("fr-h5", "fr-mb-2w")}>
+        Marquer une convention comme traité
+      </h5>
+      <div className={fr.cx("fr-card", "fr-px-4w", "fr-py-2w", "fr-mb-4w")}>
+        <form
+          onSubmit={handleSubmit(({ conventionId }) => {
+            console.log("submit!!!===>", conventionId);
+          })}
+        >
+          <div className={fr.cx("fr-grid-row")}>
+            <Input
+              label="Id de la convention *"
+              nativeInputProps={{
+                ...register("conventionId"),
+                id: "MarkPartnersErroredConvention-conventionId",
+                placeholder: "Id de la convention",
+              }}
+              className={fr.cx("fr-col-12", "fr-col-lg-6")}
+              {...makeFieldError(formState)("conventionId")}
+            />
+          </div>
+          <Button
+            title="Marquer la convention comme traité"
+            disabled={!formState.isValid}
+            className={fr.cx("fr-mt-2w")}
+          >
+            Marquer la convention comme traité
+          </Button>
+        </form>
+      </div>
+    </>
+  );
+};

--- a/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
+++ b/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 import { useForm } from "react-hook-form";
+import { useDispatch } from "react-redux";
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  InclusionConnectJwt,
   MarkPartnersErroredConventionAsHandledRequest,
   markPartnersErroredConventionAsHandledRequestSchema,
 } from "shared";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
+import { partnersErroredConventionSlice } from "src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice";
 
-export const MarkPartnersErroredConventionAsHandledFormSection = () => {
+export const MarkPartnersErroredConventionAsHandledFormSection = ({
+  jwt,
+}: {
+  jwt: InclusionConnectJwt;
+}) => {
   const { register, handleSubmit, formState } =
     useForm<MarkPartnersErroredConventionAsHandledRequest>({
       resolver: zodResolver(
@@ -18,16 +25,21 @@ export const MarkPartnersErroredConventionAsHandledFormSection = () => {
       ),
       mode: "onTouched",
     });
-
+  const dispatch = useDispatch();
   return (
-    <>
+    <section className={fr.cx("fr-mt-4w")}>
       <h5 className={fr.cx("fr-h5", "fr-mb-2w")}>
-        Marquer une convention comme traité
+        Marquer une convention comme traitée
       </h5>
       <div className={fr.cx("fr-card", "fr-px-4w", "fr-py-2w", "fr-mb-4w")}>
         <form
           onSubmit={handleSubmit(({ conventionId }) => {
-            console.log("submit!!!===>", conventionId);
+            dispatch(
+              partnersErroredConventionSlice.actions.markAsHandledRequested({
+                jwt,
+                markAsHandledParams: { conventionId },
+              }),
+            );
           })}
         >
           <div className={fr.cx("fr-grid-row")}>
@@ -43,14 +55,14 @@ export const MarkPartnersErroredConventionAsHandledFormSection = () => {
             />
           </div>
           <Button
-            title="Marquer la convention comme traité"
+            title="Marquer la convention comme traitée"
             disabled={!formState.isValid}
             className={fr.cx("fr-mt-2w")}
           >
-            Marquer la convention comme traité
+            Marquer la convention comme traitée
           </Button>
         </form>
       </div>
-    </>
+    </section>
   );
 };

--- a/front/src/app/pages/convention/ConventionManageAdminPage.tsx
+++ b/front/src/app/pages/convention/ConventionManageAdminPage.tsx
@@ -31,7 +31,7 @@ export const ConventionManageAdminPage = ({
           <Alert
             severity="error"
             title="Non autorisé"
-            description="Cette page est reservé aux administrateurs d'Immersion Facilitée."
+            description="Cette page est reservée aux administrateurs d'Immersion Facilitée."
           />
         )}
       </MainWrapper>

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Route } from "type-route";
 import { AdminPage } from "src/app/pages/admin/AdminPage";
 import { AddAgencyPage } from "src/app/pages/agency/AddAgencyPage";
-import { AgencyDashboardPage } from "src/app/pages/AgencyDashboardPage";
+import { AgencyDashboardPage } from "src/app/pages/agencyDashboard/AgencyDashboardPage";
 import { ConventionImmersionPage } from "src/app/pages/convention/ConventionImmersionPage";
 import { ConventionManageInclusionConnectedPage } from "src/app/pages/convention/ConventionManageInclusionConnectedPage";
 import { ConventionMiniStagePage } from "src/app/pages/convention/ConventionMiniStagePage";

--- a/front/src/core-logic/adapters/InclusionConnected/HttpInclusionConnectedGateway.ts
+++ b/front/src/core-logic/adapters/InclusionConnected/HttpInclusionConnectedGateway.ts
@@ -3,6 +3,7 @@ import {
   AgencyId,
   InclusionConnectedAllowedRoutes,
   InclusionConnectedUser,
+  MarkPartnersErroredConventionAsHandledRequest,
 } from "shared";
 import { HttpClient } from "shared-routes";
 import { InclusionConnectedGateway } from "src/core-logic/ports/InclusionConnectedGateway";
@@ -23,6 +24,17 @@ export class HttpInclusionConnectedGateway
     );
   }
 
+  public markPartnersErroredConventionAsHandled$(
+    params: MarkPartnersErroredConventionAsHandledRequest,
+    jwt: string,
+  ): Observable<void> {
+    return from(
+      this.#markPartnersErroredConventionAsHandled(params, jwt).then(
+        () => undefined,
+      ),
+    );
+  }
+
   public registerAgenciesToCurrentUser$(
     agencyIds: AgencyId[],
     token: string,
@@ -40,6 +52,18 @@ export class HttpInclusionConnectedGateway
     return this.httpClient.getInclusionConnectedUser({
       headers: { authorization: token },
     });
+  }
+
+  #markPartnersErroredConventionAsHandled(
+    params: MarkPartnersErroredConventionAsHandledRequest,
+    jwt: string,
+  ): Promise<void> {
+    return this.httpClient
+      .markPartnersErroredConventionAsHandled({
+        body: params,
+        headers: { authorization: jwt },
+      })
+      .then(() => undefined);
   }
 
   #registerAgenciesToCurrentUser(agencyIds: AgencyId[], token: string) {

--- a/front/src/core-logic/adapters/InclusionConnected/HttpInclusionConnectedGateway.ts
+++ b/front/src/core-logic/adapters/InclusionConnected/HttpInclusionConnectedGateway.ts
@@ -63,7 +63,14 @@ export class HttpInclusionConnectedGateway
         body: params,
         headers: { authorization: jwt },
       })
-      .then(() => undefined);
+      .then(() => undefined)
+      .catch((error) => {
+        if (error?.httpStatusCode === 404)
+          throw new Error(
+            "L'erreur sur la convention que vous cherchez à traiter n'existe pas, peut-être est-elle déjà marquée comme traitée. Rechargez la page pour mettre à jour le tableau.",
+          );
+        throw error;
+      });
   }
 
   #registerAgenciesToCurrentUser(agencyIds: AgencyId[], token: string) {

--- a/front/src/core-logic/adapters/InclusionConnected/SimulatedInclusionConnectedGateway.ts
+++ b/front/src/core-logic/adapters/InclusionConnected/SimulatedInclusionConnectedGateway.ts
@@ -1,5 +1,9 @@
-import { delay, Observable, of, throwError } from "rxjs";
-import { AgencyId, InclusionConnectedUser } from "shared";
+import { delay, Observable, of, Subject, throwError } from "rxjs";
+import {
+  AgencyId,
+  InclusionConnectedUser,
+  MarkPartnersErroredConventionAsHandledRequest,
+} from "shared";
 import { InclusionConnectedGateway } from "src/core-logic/ports/InclusionConnectedGateway";
 
 const simulatedUserConnected: InclusionConnectedUser = {
@@ -15,10 +19,19 @@ export const nonExisitingAgencyId: AgencyId = "not-found-agency-id";
 export class SimulatedInclusionConnectedGateway
   implements InclusionConnectedGateway
 {
+  public markPartnersErroredConventionAsHandledResult$ = new Subject<void>();
+
   constructor(private simulatedLatency: number = 0) {}
 
   public getCurrentUser$(_token: string): Observable<InclusionConnectedUser> {
     return of(simulatedUserConnected);
+  }
+
+  public markPartnersErroredConventionAsHandled$(
+    _params: MarkPartnersErroredConventionAsHandledRequest,
+    _jwt: string,
+  ): Observable<void> {
+    return this.markPartnersErroredConventionAsHandledResult$;
   }
 
   public registerAgenciesToCurrentUser$(

--- a/front/src/core-logic/adapters/InclusionConnected/TestInclusionConnectedGateway.ts
+++ b/front/src/core-logic/adapters/InclusionConnected/TestInclusionConnectedGateway.ts
@@ -1,5 +1,9 @@
 import { Observable, Subject } from "rxjs";
-import { AgencyId, InclusionConnectedUser } from "shared";
+import {
+  AgencyId,
+  InclusionConnectedUser,
+  MarkPartnersErroredConventionAsHandledRequest,
+} from "shared";
 import { InclusionConnectedGateway } from "src/core-logic/ports/InclusionConnectedGateway";
 
 export class TestInclusionConnectedGateway
@@ -8,10 +12,19 @@ export class TestInclusionConnectedGateway
   // for test purpose
   public currentUser$ = new Subject<InclusionConnectedUser>();
 
+  public markPartnersErroredConventionAsHandledResult$ = new Subject<void>();
+
   public registerAgenciesToCurrentUserResponse$ = new Subject<undefined>();
 
   public getCurrentUser$(_token: string): Observable<InclusionConnectedUser> {
     return this.currentUser$;
+  }
+
+  public markPartnersErroredConventionAsHandled$(
+    _params: MarkPartnersErroredConventionAsHandledRequest,
+    _jwt: string,
+  ): Observable<void> {
+    return this.markPartnersErroredConventionAsHandledResult$;
   }
 
   public registerAgenciesToCurrentUser$(

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.epics.ts
@@ -1,0 +1,42 @@
+import { filter, map, switchMap } from "rxjs";
+import { catchEpicError } from "src/core-logic/storeConfig/catchEpicError";
+import {
+  ActionOfSlice,
+  AppEpic,
+} from "src/core-logic/storeConfig/redux.helpers";
+import { partnersErroredConventionSlice } from "./partnersErroredConvention.slice";
+
+type PartnersErroredConvention = ActionOfSlice<
+  typeof partnersErroredConventionSlice
+>;
+
+type PartnersErroredConventionEpic = AppEpic<PartnersErroredConvention>;
+
+const markPartnersErroredConventionAsHandledEpic: PartnersErroredConventionEpic =
+  (action$, _, { inclusionConnectedGateway }) =>
+    action$.pipe(
+      filter(
+        partnersErroredConventionSlice.actions.markAsHandledRequested.match,
+      ),
+      switchMap(({ payload }) =>
+        inclusionConnectedGateway
+          .markPartnersErroredConventionAsHandled$(
+            payload.markAsHandledParams,
+            payload.jwt,
+          )
+          .pipe(
+            map(() =>
+              partnersErroredConventionSlice.actions.markAsHandledSucceeded(),
+            ),
+          ),
+      ),
+      catchEpicError((error: Error) =>
+        partnersErroredConventionSlice.actions.markAsHandledFailed(
+          error.message,
+        ),
+      ),
+    );
+
+export const partnersErroredConventionEpics = [
+  markPartnersErroredConventionAsHandledEpic,
+];

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.selector.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.selector.ts
@@ -1,0 +1,21 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { createRootSelector } from "src/core-logic/storeConfig/store";
+
+const partnersErroredConvention = createRootSelector(
+  (state) => state.partnersErroredConvention,
+);
+
+const feedback = createSelector(
+  partnersErroredConvention,
+  ({ feedback }) => feedback,
+);
+
+const isLoading = createSelector(
+  partnersErroredConvention,
+  ({ isLoading }) => isLoading,
+);
+
+export const partnersErroredConventionSelectors = {
+  feedback,
+  isLoading,
+};

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.slice.ts
@@ -1,0 +1,51 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+  ConventionSupportedJwt,
+  MarkPartnersErroredConventionAsHandledRequest,
+} from "shared";
+import { SubmitFeedBack } from "../SubmitFeedback";
+
+export type PartnersErroredConventionFeedbackKind = "markedAsHandled";
+
+export type PartnersErroredConventionSubmitFeedback =
+  SubmitFeedBack<PartnersErroredConventionFeedbackKind>;
+
+export interface PartnersErroredConventionState {
+  isLoading: boolean;
+  feedback: PartnersErroredConventionSubmitFeedback;
+}
+
+export const initialPartnersErroredConventionState: PartnersErroredConventionState =
+  {
+    isLoading: false,
+    feedback: { kind: "idle" },
+  };
+
+type MarkPartnersErroredConventionAsHandledRequestPayload = {
+  jwt: ConventionSupportedJwt;
+  markAsHandledParams: MarkPartnersErroredConventionAsHandledRequest;
+};
+
+export const partnersErroredConventionSlice = createSlice({
+  name: "partnersErroredConvention",
+  initialState: initialPartnersErroredConventionState,
+  reducers: {
+    markAsHandledRequested: (
+      state,
+      _action: PayloadAction<MarkPartnersErroredConventionAsHandledRequestPayload>,
+    ) => {
+      state.isLoading = true;
+    },
+    markAsHandledSucceeded: (state) => {
+      state.isLoading = false;
+      state.feedback = { kind: "markedAsHandled" };
+    },
+    markAsHandledFailed: (
+      state: PartnersErroredConventionState,
+      action: PayloadAction<string>,
+    ) => {
+      state.isLoading = false;
+      state.feedback = { kind: "errored", errorMessage: action.payload };
+    },
+  },
+});

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
@@ -1,0 +1,78 @@
+import {
+  createTestStore,
+  TestDependencies,
+} from "src/core-logic/storeConfig/createTestStore";
+import { ReduxStore } from "src/core-logic/storeConfig/store";
+import {
+  partnersErroredConventionSlice,
+  PartnersErroredConventionState,
+} from "./partnersErroredConvention.slice";
+
+describe("Agency info in store", () => {
+  let store: ReduxStore;
+  let dependencies: TestDependencies;
+  const fakeConventionId = "add5c20e-6dd2-45af-affe-927358005251";
+  beforeEach(() => {
+    ({ store, dependencies } = createTestStore());
+  });
+
+  it("should switch isLoading to true when mark as handled is requested", () => {
+    store.dispatch(
+      partnersErroredConventionSlice.actions.markAsHandledRequested({
+        jwt: "my-jwt",
+        markAsHandledParams: { conventionId: fakeConventionId },
+      }),
+    );
+    expectIsLoadingToBe(true);
+  });
+
+  it("should set feedbackKind as mark as handled when mark as handled succesfull", () => {
+    const expectedFeedback: PartnersErroredConventionState["feedback"] = {
+      kind: "markedAsHandled",
+    };
+
+    store.dispatch(
+      partnersErroredConventionSlice.actions.markAsHandledRequested({
+        jwt: "my-jwt",
+        markAsHandledParams: { conventionId: fakeConventionId },
+      }),
+    );
+    dependencies.inclusionConnectedGateway.markPartnersErroredConventionAsHandledResult$.next();
+
+    expectIsLoadingToBe(false);
+    expectFeedbackToEqual(expectedFeedback);
+  });
+
+  it("should throw an error when something goes wrong", () => {
+    const errorMessage = "Error trying to mark error convention as handled";
+    const expectedFeedback: PartnersErroredConventionState["feedback"] = {
+      kind: "errored",
+      errorMessage,
+    };
+    store.dispatch(
+      partnersErroredConventionSlice.actions.markAsHandledRequested({
+        jwt: "my-jwt",
+        markAsHandledParams: { conventionId: fakeConventionId },
+      }),
+    );
+
+    dependencies.inclusionConnectedGateway.markPartnersErroredConventionAsHandledResult$.error(
+      new Error(errorMessage),
+    );
+
+    expectIsLoadingToBe(false);
+    expectFeedbackToEqual(expectedFeedback);
+  });
+
+  const expectIsLoadingToBe = (
+    expected: PartnersErroredConventionState["isLoading"],
+  ) =>
+    expect(store.getState().partnersErroredConvention.isLoading).toBe(expected);
+
+  const expectFeedbackToEqual = (
+    expected: PartnersErroredConventionState["feedback"],
+  ) =>
+    expect(store.getState().partnersErroredConvention.feedback).toEqual(
+      expected,
+    );
+});

--- a/front/src/core-logic/ports/InclusionConnectedGateway.ts
+++ b/front/src/core-logic/ports/InclusionConnectedGateway.ts
@@ -1,10 +1,19 @@
 import { Observable } from "rxjs";
-import { AgencyId, InclusionConnectedUser } from "shared";
+import {
+  AgencyId,
+  ConventionSupportedJwt,
+  InclusionConnectedUser,
+  MarkPartnersErroredConventionAsHandledRequest,
+} from "shared";
 
 export interface InclusionConnectedGateway {
   getCurrentUser$(token: string): Observable<InclusionConnectedUser>;
   registerAgenciesToCurrentUser$(
     agencyIds: AgencyId[],
     token: string,
+  ): Observable<void>;
+  markPartnersErroredConventionAsHandled$(
+    params: MarkPartnersErroredConventionAsHandledRequest,
+    jwt: ConventionSupportedJwt,
   ): Observable<void>;
 }

--- a/front/src/core-logic/storeConfig/store.ts
+++ b/front/src/core-logic/storeConfig/store.ts
@@ -41,6 +41,8 @@ import { geosearchEpics } from "../domain/geosearch/geosearch.epics";
 import { geosearchSlice } from "../domain/geosearch/geosearch.slice";
 import { immersionAssessmentEpics } from "../domain/immersionAssessment/immersionAssessment.epics";
 import { immersionAssessmentSlice } from "../domain/immersionAssessment/immersionAssessment.slice";
+import { partnersErroredConventionEpics } from "../domain/partnersErroredConvention/partnersErroredConvention.epics";
+import { partnersErroredConventionSlice } from "../domain/partnersErroredConvention/partnersErroredConvention.slice";
 
 const allEpics: any[] = [
   ...dashboardUrlsEpics,
@@ -62,6 +64,7 @@ const allEpics: any[] = [
   ...agencyInfoEpics,
   ...icUsersAdminEpics,
   ...apiConsumerEpics,
+  ...partnersErroredConventionEpics,
 ];
 
 const rootReducer = combineReducers({
@@ -78,6 +81,7 @@ const rootReducer = combineReducers({
   [authSlice.name]: authSlice.reducer,
   [establishmentBatchSlice.name]: establishmentBatchSlice.reducer,
   [inclusionConnectedSlice.name]: inclusionConnectedSlice.reducer,
+  [partnersErroredConventionSlice.name]: partnersErroredConventionSlice.reducer,
   admin: combineReducers({
     [agencyAdminSlice.name]: agencyAdminSlice.reducer,
     [icUsersAdminSlice.name]: icUsersAdminSlice.reducer,

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -333,3 +333,7 @@ export type RenewConventionParams = Pick<
   ConventionRenewed,
   "id" | "dateStart" | "dateEnd" | "schedule" | "renewed"
 >;
+
+export type MarkPartnersErroredConventionAsHandledRequest = {
+  conventionId: ConventionId;
+};

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -59,6 +59,7 @@ import {
   InternshipKind,
   internshipKinds,
   levelsOfEducation,
+  MarkPartnersErroredConventionAsHandledRequest,
   MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT,
   RenewConventionParams,
   RenewMagicLinkRequestDto,
@@ -422,6 +423,10 @@ export const renewMagicLinkResponseSchema: z.Schema<RenewMagicLinkResponse> =
   z.object({
     message: z.literal("Le lien magique est périmé"),
     needsNewMagicLink: z.boolean(),
+  });
+export const markPartnersErroredConventionAsHandledRequestSchema: z.Schema<MarkPartnersErroredConventionAsHandledRequest> =
+  z.object({
+    conventionId: conventionIdSchema,
   });
 
 const addIssuesIfDuplicateSignatoriesEmails = (

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
@@ -35,6 +35,10 @@ export const inclusionConnectedAllowedRoutes = defineRoutes({
     method: "post",
     ...withAuthorizationHeaders,
     requestBodySchema: markPartnersErroredConventionAsHandledRequestSchema,
-    responses: { 200: expressEmptyResponseBody, 404: httpErrorSchema },
+    responses: {
+      200: expressEmptyResponseBody,
+      404: httpErrorSchema,
+      400: httpErrorSchema,
+    },
   }),
 });

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
@@ -35,6 +35,6 @@ export const inclusionConnectedAllowedRoutes = defineRoutes({
     method: "post",
     ...withAuthorizationHeaders,
     requestBodySchema: markPartnersErroredConventionAsHandledRequestSchema,
-    responses: { 200: expressEmptyResponseBody, 400: httpErrorSchema },
+    responses: { 200: expressEmptyResponseBody, 404: httpErrorSchema },
   }),
 });

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
@@ -1,5 +1,6 @@
 import { defineRoute, defineRoutes } from "shared-routes";
 import { agencyIdsSchema } from "../agency/agency.schema";
+import { markPartnersErroredConventionAsHandledRequestSchema } from "../convention/convention.schema";
 import { withAuthorizationHeaders } from "../headers";
 import { httpErrorSchema } from "../httpClient/errors/httpErrors.schema";
 import { expressEmptyResponseBody } from "../zodUtils";
@@ -27,5 +28,13 @@ export const inclusionConnectedAllowedRoutes = defineRoutes({
       200: expressEmptyResponseBody,
       400: httpErrorSchema,
     },
+  }),
+
+  markPartnersErroredConventionAsHandled: defineRoute({
+    url: "/auth/mark-errored-convention-as-handled",
+    method: "post",
+    requestBodySchema: markPartnersErroredConventionAsHandledRequestSchema,
+    ...withAuthorizationHeaders,
+    responses: { 200: expressEmptyResponseBody },
   }),
 });

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.routes.ts
@@ -31,10 +31,10 @@ export const inclusionConnectedAllowedRoutes = defineRoutes({
   }),
 
   markPartnersErroredConventionAsHandled: defineRoute({
-    url: "/auth/mark-errored-convention-as-handled",
+    url: "/inclusion-connected/mark-errored-convention-as-handled",
     method: "post",
-    requestBodySchema: markPartnersErroredConventionAsHandledRequestSchema,
     ...withAuthorizationHeaders,
-    responses: { 200: expressEmptyResponseBody },
+    requestBodySchema: markPartnersErroredConventionAsHandledRequestSchema,
+    responses: { 200: expressEmptyResponseBody, 400: httpErrorSchema },
   }),
 });


### PR DESCRIPTION
- add input in errored convention dashboard to mark a convention as handled front part
-  mark partners errored convention as handled
