### PR TITLE
improve performance on outbox using index on occured_at

### DIFF
--- a/back/src/adapters/secondary/pg/migrations/1698922693705_add-index-on-outbox-created-at.ts
+++ b/back/src/adapters/secondary/pg/migrations/1698922693705_add-index-on-outbox-created-at.ts
@@ -1,0 +1,9 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex("outbox", ["occurred_at"]);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("outbox", ["occurred_at"]);
+}


### PR DESCRIPTION
Amélioration de query sur l'outbox qui utilise un filtre ou un tri sur `occured_at`.

La query suivante passe de + de 20 secondes à 250ms :
```sql
SELECT *
FROM "outbox"
ORDER BY "occurred_at" DESC
LIMIT 50
```