### PR TITLE
Ajout d'un composant simple-section dans notre DS

### DIFF
--- a/libs/react-design-system/src/immersionFacile/components/index.ts
+++ b/libs/react-design-system/src/immersionFacile/components/index.ts
@@ -27,6 +27,7 @@ export * from "./section-convention-next-steps";
 export * from "./section-faq";
 export * from "./section-stats";
 export * from "./section-text-embed";
+export * from "./simple-section";
 export * from "./skip-links";
 export * from "./submit-confirmation-section";
 export * from "./tooltip";

--- a/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.scss
+++ b/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.scss
@@ -1,0 +1,22 @@
+@import "../../../config/responsive";
+
+.im-simple-section {
+  display: flex;
+}
+
+.im-simple-section__content {
+  width: 70%;
+}
+
+.im-simple-section__illustration {
+  display: none;
+  width: 30%;
+  @include for-screen-min($bp-md) {
+    display: flex;
+    img {
+      max-width: 100%;
+      height: auto;
+      margin: auto;
+    }
+  }
+}

--- a/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.stories.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.stories.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { ArgTypes, Meta, StoryObj } from "@storybook/react";
+import { SimpleSection, SimpleSectionProps } from "./SimpleSection";
+
+const Component = SimpleSection;
+type Story = StoryObj<typeof Component>;
+const argTypes: Partial<ArgTypes<SimpleSectionProps>> | undefined = {};
+
+const componentDescription = `
+\`\`\`tsx  
+import { SimpleSection } from "react-design-system";
+\`\`\`
+`;
+
+export default {
+  title: "SimpleSection",
+  component: Component,
+  argTypes,
+  parameters: {
+    docs: {
+      description: {
+        component: componentDescription,
+      },
+    },
+  },
+} as Meta<typeof Component>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <>
+        <h1>
+          Quelqu'un a partagé une demande de convention d'immersion avec vous
+        </h1>
+        <p>
+          Une entreprise ou un candidat a rempli ses informations dans le
+          formulaire de demande de convention. Vous n'avez plus qu'à remplir vos
+          informations et à valider le formulaire en quelques clics.
+        </p>
+      </>
+    ),
+    illustrationUrl: "assets/images/logo-if.svg",
+    button: {
+      label: "Continuer",
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onClick: () => {},
+    },
+    link: {
+      href: "#",
+      label:
+        "Ou continuer avec mes identifiants Pôle emploi (candidats inscrits à Pôle emploi)",
+    },
+  },
+};

--- a/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/simple-section/SimpleSection.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import "./SimpleSection.scss";
+
+export type SimpleSectionProps = {
+  button: {
+    label: string;
+    onClick: () => void;
+  };
+  illustrationUrl: string;
+  link: {
+    href: string;
+    label: string;
+  };
+  children: React.ReactNode;
+};
+
+export const SimpleSection = (props: SimpleSectionProps) => (
+  <section className={"im-simple-section"}>
+    <div className={"im-simple-section__content"}>
+      {props.children}
+      <Button onClick={props.button.onClick}>{props.button.label}</Button>
+      <div className={fr.cx("fr-mt-2w")}>
+        <a href={props.link.href} className={fr.cx("fr-link")}>
+          {props.link.label}
+        </a>
+      </div>
+    </div>
+    <div className={"im-simple-section__illustration"}>
+      <img src={props.illustrationUrl} alt="" />
+    </div>
+  </section>
+);

--- a/libs/react-design-system/src/immersionFacile/components/simple-section/index.ts
+++ b/libs/react-design-system/src/immersionFacile/components/simple-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./SimpleSection";


### PR DESCRIPTION
## Description

Nous souhaitons créer un nouveau type de section qui ressemblerait à:

![Screenshot 2023-11-02 at 17 44 13](https://github.com/gip-inclusion/immersion-facile/assets/11294487/f52514d1-1704-4729-a801-ab5e7caa1c0c)

Pour permettre de rendre ce format réutilisable, je propose d'inclure ce template dans notre design-system: textes, image, boutons et liens sont ainsi customisables. Voici le rendu depuis la story:

![Screenshot 2023-11-02 at 17 31 23](https://github.com/gip-inclusion/immersion-facile/assets/11294487/66024ec9-5236-4d58-8bb4-cd9c93a615d6)

## Remarques

Je n'ai pas réussi à ajouter les flèches dans les boutons/liens. J'ai bien testé avec la classe `fr-link--icon-right` mais ça n'a pas fonctionné, si quelqu'un a une piste... sinon je verrai avec @enguerranws à son retour.

