### PR TITLE
Fix: supprimer l'usage de http-client

### DIFF
--- a/back/transpile-back-and-prepare-for-prod.js
+++ b/back/transpile-back-and-prepare-for-prod.js
@@ -43,7 +43,6 @@ const removeFromFileLinesThatInclude = (filePath, regex) => {
 };
 
 const rootPackageJson = "build/package.json";
-const httpPackageJson = "build/libs/http-client/package.json";
 const htmlPackageJson = "build/libs/html-templates/package.json";
 const sharedPackageJson = "build/shared/package.json";
 const backPackageJson = "build/back/package.json";
@@ -52,12 +51,6 @@ const backPackageJson = "build/back/package.json";
 removeFromFileLinesThatInclude(rootPackageJson, /"prepare":.*/);
 
 // change dependencies to use js instead of ts
-removeFromFileLinesThatInclude(httpPackageJson, /"types": "src\/index.ts",?/);
-replaceInFileSync(
-  httpPackageJson,
-  /"main": "src\/index.ts"/,
-  '"main": "src/index.js"'
-);
 removeFromFileLinesThatInclude(htmlPackageJson, /"types": "src\/index.ts",?/);
 replaceInFileSync(
   htmlPackageJson,


### PR DESCRIPTION
## Description

La pipeline sur `main` est cassée car on fait référence à `http-client` dans notre script `transpile-back-and-prepare-for-prod.js`.

## Solution

Supprimer les références à `http-client`.