### PR TITLE
Eviter les conventions en doublon front

### DIFF
--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -3,9 +3,11 @@ import { fromPromise } from "rxjs/internal/observable/innerFrom";
 import {
   AbsoluteUrl,
   ConventionDto,
+  ConventionId,
   ConventionMagicLinkRoutes,
   ConventionReadDto,
   ConventionSupportedJwt,
+  FindSimilarConventionsParams,
   RenewConventionParams,
   ShareLinkByEmailDto,
   UnauthenticatedConventionRoutes,
@@ -38,6 +40,17 @@ export class HttpConventionGateway implements ConventionGateway {
         })
         .then(({ body }) => body),
     );
+  }
+
+  public getSimilarConventions$(
+    findSimilarConventionsParams: FindSimilarConventionsParams,
+  ): Observable<ConventionId[]> {
+    const conventionIdsPromise = this.unauthenticatedHttpClient
+      .findSimilarConventions({
+        queryParams: findSimilarConventionsParams,
+      })
+      .then(({ body }) => body.similarConventionIds);
+    return from(conventionIdsPromise);
   }
 
   public renewConvention$(

--- a/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
@@ -7,6 +7,7 @@ import {
   ConventionId,
   ConventionReadDto,
   ConventionSupportedJwt,
+  FindSimilarConventionsParams,
   RenewConventionParams,
   ShareLinkByEmailDto,
   sleep,
@@ -39,6 +40,8 @@ export class InMemoryConventionGateway implements ConventionGateway {
 
   public conventionSignedResult$ = new Subject<void>();
 
+  public getSimilarConventionsResult$ = new Subject<ConventionId[]>();
+
   public updateConventionCallCount = 0;
 
   public updateConventionResult$ = new Subject<void>();
@@ -59,6 +62,12 @@ export class InMemoryConventionGateway implements ConventionGateway {
 
   public getConventionStatusDashboardUrl$(_jwt: string) {
     return this.conventionDashboardUrl$;
+  }
+
+  public getSimilarConventions$(
+    _findSimilarConventionsParams: FindSimilarConventionsParams,
+  ): Observable<ConventionId[]> {
+    return this.getSimilarConventionsResult$;
   }
 
   public renewConvention$(

--- a/front/src/core-logic/domain/convention/convention.epics.ts
+++ b/front/src/core-logic/domain/convention/convention.epics.ts
@@ -31,6 +31,22 @@ const saveConventionEpic: ConventionEpic = (
     ),
   );
 
+const getSimilarConventionsEpic: ConventionEpic = (
+  action$,
+  _state$,
+  { conventionGateway },
+) =>
+  action$.pipe(
+    filter(conventionSlice.actions.getSimilarConventionsRequested.match),
+    switchMap(({ payload }) =>
+      conventionGateway.getSimilarConventions$(payload),
+    ),
+    map(conventionSlice.actions.getSimilarConventionsSucceeded),
+    catchEpicError((error: Error) =>
+      conventionSlice.actions.getSimilarConventionsFailed(error.message),
+    ),
+  );
+
 const getConventionEpic: ConventionEpic = (
   action$,
   _state$,
@@ -162,4 +178,5 @@ export const conventionEpics = [
   getConventionStatusDashboardUrl,
   getPreselectAgencyId,
   renewConventionEpic,
+  getSimilarConventionsEpic,
 ];

--- a/front/src/core-logic/domain/convention/convention.selectors.ts
+++ b/front/src/core-logic/domain/convention/convention.selectors.ts
@@ -24,6 +24,11 @@ const fetchError = createSelector(
 
 const isLoading = createSelector(conventionState, ({ isLoading }) => isLoading);
 
+const similarConventionIds = createSelector(
+  conventionState,
+  ({ similarConventionIds }) => similarConventionIds,
+);
+
 const isMinor = createSelector(conventionState, ({ formUi }) => formUi.isMinor);
 
 const showSummary = createSelector(
@@ -88,6 +93,7 @@ export const conventionSelectors = {
   currentStep,
   showSummary,
   agencyDepartment,
+  similarConventionIds,
 };
 
 export const signatoryDataFromConvention = (

--- a/front/src/core-logic/domain/convention/convention.slice.ts
+++ b/front/src/core-logic/domain/convention/convention.slice.ts
@@ -6,6 +6,7 @@ import {
   ConventionJwt,
   ConventionReadDto,
   ConventionSupportedJwt,
+  FindSimilarConventionsParams,
   RenewConventionParams,
   SignatoryRole,
   UpdateConventionStatusRequestDto,
@@ -56,6 +57,7 @@ export interface ConventionState {
   fetchError: string | null;
   feedback: ConventionSubmitFeedback;
   currentSignatoryRole: SignatoryRole | null;
+  similarConventionIds: ConventionId[];
 }
 
 export const initialConventionState: ConventionState = {
@@ -75,6 +77,7 @@ export const initialConventionState: ConventionState = {
   fetchError: null,
   feedback: { kind: "idle" },
   currentSignatoryRole: null,
+  similarConventionIds: [],
 };
 
 export type FetchConventionRequestedPayload = {
@@ -269,5 +272,21 @@ export const conventionSlice = createSlice({
       state.feedback = { kind: "renewed" };
     },
     renewConventionFailed: setFeedbackAsErrored,
+
+    // Get similar conventions
+    getSimilarConventionsRequested: (
+      state,
+      _action: PayloadAction<FindSimilarConventionsParams>,
+    ) => {
+      state.isLoading = true;
+    },
+    getSimilarConventionsSucceeded: (
+      state,
+      { payload }: PayloadAction<ConventionId[]>,
+    ) => {
+      state.isLoading = false;
+      state.similarConventionIds = payload;
+    },
+    getSimilarConventionsFailed: setFeedbackAsErrored,
   },
 });

--- a/front/src/core-logic/domain/convention/convention.test.ts
+++ b/front/src/core-logic/domain/convention/convention.test.ts
@@ -94,6 +94,7 @@ describe("Convention slice", () => {
           fetchError: null,
           feedback: { kind: "idle" },
           currentSignatoryRole: null,
+          similarConventionIds: [],
         },
       }));
       const convention = new ConventionDtoBuilder().build();
@@ -132,6 +133,34 @@ describe("Convention slice", () => {
         isLoading: false,
         feedback: { kind: "errored", errorMessage },
       });
+    });
+  });
+
+  describe("Get similar conventions", () => {
+    it("get no similar convention", () => {
+      const convention = new ConventionDtoBuilder()
+        .withStatus("READY_TO_SIGN")
+        .build();
+      store.dispatch(
+        conventionSlice.actions.getSimilarConventionsRequested({
+          siret: convention.dateStart,
+          beneficiaryBirthdate: "2023-10-01",
+          dateStart: convention.dateStart,
+          beneficiaryLastName: "Test",
+          codeAppellation: "111222",
+        }),
+      );
+      expectConventionState({
+        isLoading: true,
+      });
+      dependencies.conventionGateway.getSimilarConventionsResult$.next([]);
+      expectConventionState({
+        isLoading: false,
+      });
+      expectToEqual(
+        conventionSelectors.similarConventionIds(store.getState()),
+        [],
+      );
     });
   });
 
@@ -286,6 +315,7 @@ describe("Convention slice", () => {
           fetchError: null,
           jwt: null,
           currentSignatoryRole: null,
+          similarConventionIds: [],
         },
       }));
       store.dispatch(
@@ -636,6 +666,7 @@ describe("Convention slice", () => {
           convention,
           conventionStatusDashboardUrl: null,
           currentSignatoryRole: null,
+          similarConventionIds: [],
         },
       }));
       const signatoryData = conventionSelectors.signatoryData(store.getState());
@@ -681,6 +712,7 @@ describe("Convention slice", () => {
           convention,
           conventionStatusDashboardUrl: null,
           currentSignatoryRole: "beneficiary",
+          similarConventionIds: [],
         },
       }));
 
@@ -848,6 +880,7 @@ describe("Convention slice", () => {
         isLoading: false,
         fetchError: null,
         currentSignatoryRole: null,
+        similarConventionIds: [],
       },
     }));
     store.dispatch(conventionSlice.actions.clearFeedbackTriggered());
@@ -873,6 +906,7 @@ describe("Convention slice", () => {
         isLoading: false,
         fetchError: null,
         currentSignatoryRole: null,
+        similarConventionIds: [],
       },
     }));
     expectConventionState({
@@ -903,6 +937,7 @@ describe("Convention slice", () => {
         isLoading: false,
         fetchError: null,
         currentSignatoryRole: null,
+        similarConventionIds: [],
       },
     }));
     expectConventionState({
@@ -937,6 +972,7 @@ describe("Convention slice", () => {
         isLoading: false,
         fetchError: null,
         currentSignatoryRole: null,
+        similarConventionIds: [],
       },
     }));
     expectConventionState({
@@ -1010,6 +1046,7 @@ describe("Convention slice", () => {
         isLoading: false,
         fetchError: null,
         currentSignatoryRole: null,
+        similarConventionIds: [],
       },
     }));
     expectConventionState({ convention });

--- a/front/src/core-logic/ports/ConventionGateway.ts
+++ b/front/src/core-logic/ports/ConventionGateway.ts
@@ -2,8 +2,10 @@ import { Observable } from "rxjs";
 import {
   AbsoluteUrl,
   ConventionDto,
+  ConventionId,
   ConventionReadDto,
   ConventionSupportedJwt,
+  FindSimilarConventionsParams,
   RenewConventionParams,
   ShareLinkByEmailDto,
   UpdateConventionStatusRequestDto,
@@ -17,6 +19,9 @@ export interface ConventionGateway {
   getConventionStatusDashboardUrl$(jwt: string): Observable<AbsoluteUrl>;
 
   createConvention$(conventionDto: ConventionDto): Observable<void>;
+  getSimilarConventions$(
+    findSimilarConventionsParams: FindSimilarConventionsParams,
+  ): Observable<ConventionId[]>;
   updateConvention$(
     conventionDto: ConventionDto,
     jwt: string,

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -13,10 +13,7 @@ import {
   appellationDtoSchema,
 } from "../romeAndAppellationDtos/romeAndAppellation.schema";
 import { DailyScheduleDto } from "../schedule/Schedule.dto";
-import {
-  dateIsoStringSchema,
-  scheduleSchema,
-} from "../schedule/Schedule.schema";
+import { scheduleSchema } from "../schedule/Schedule.schema";
 import {
   calculateWeeklyHoursFromSchedule,
   isSundayInSchedule,
@@ -527,8 +524,14 @@ export const findSimilarConventionsParamsSchema: z.Schema<FindSimilarConventions
   z.object({
     siret: siretSchema,
     codeAppellation: appellationCodeSchema,
-    dateStart: dateIsoStringSchema,
-    beneficiaryBirthdate: dateIsoStringSchema,
+    dateStart: zStringMinLength1.regex(
+      dateRegExp,
+      localization.invalidDateStart,
+    ),
+    beneficiaryBirthdate: zStringMinLength1.regex(
+      dateRegExp,
+      localization.invalidDate,
+    ),
     beneficiaryLastName: zStringMinLength1,
   });
 


### PR DESCRIPTION
## Description

On souhaite éviter la création de convention en doublon.  
Pour cela:
1. on affiche un message sur la page de récapitulatif de convention à créer
<img width="908" alt="Screenshot 2023-11-10 at 11 08 18" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/f68a3406-89f1-41e2-9705-f692cc5fb24c">

2. lorsque l'on clique sur "Envoyer la convention", une modale demande la confirmation de création de ce possible doublon
<img width="911" alt="Screenshot 2023-11-10 at 11 08 27" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/faf8f2b5-e2dd-44c6-bc8c-48e49c857e8b">
