### PR TITLE
Préciser à quelle adresse mail envoyer le bilan dans le mail de "Convention finale validée"

### DIFF
--- a/back/src/_testBuilders/emailAssertions.ts
+++ b/back/src/_testBuilders/emailAssertions.ts
@@ -102,6 +102,7 @@ export const expectEmailFinalValidationConfirmationMatchingConvention = (
         ? concatValidatorNames(convention.validators?.agencyValidator)
         : "",
       agencyAssessmentDocumentLink: agency.questionnaireUrl,
+      agencyValidatorEmail: agency.validatorEmails[0],
     },
   });
 

--- a/back/src/domain/convention/useCases/notifications/NotifyAllActorsOfFinalConventionValidation.ts
+++ b/back/src/domain/convention/useCases/notifications/NotifyAllActorsOfFinalConventionValidation.ts
@@ -173,6 +173,7 @@ export class NotifyAllActorsOfFinalConventionValidation extends TransactionalUse
         agencyAssessmentDocumentLink: isUrlValid(agency.questionnaireUrl)
           ? agency.questionnaireUrl
           : undefined,
+        agencyValidatorEmail: agency.validatorEmails[0],
         magicLink: await makeShortMagicLink(frontRoutes.conventionDocument),
         validatorName: convention.validators?.agencyValidator
           ? concatValidatorNames(convention.validators?.agencyValidator)

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -293,6 +293,7 @@ export const defaultEmailValueByEmailKind: {
   VALIDATED_CONVENTION_FINAL_CONFIRMATION: {
     agencyAssessmentDocumentLink: "AGENCY_ASSESSMENT_DOCUMENT_LINK",
     agencyLogoUrl: defaultEmailPreviewUrl,
+    agencyValidatorEmail: "AGENCY_VALIDATOR_EMAIL",
     beneficiaryBirthdate: "BENEFICIARY_BIRTHDATE",
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",
     beneficiaryLastName: "BENEFICIARY_LAST_NAME",

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -306,6 +306,7 @@ export type EmailParamsByEmailType = {
   VALIDATED_CONVENTION_FINAL_CONFIRMATION: {
     agencyAssessmentDocumentLink: string | undefined;
     agencyLogoUrl: AbsoluteUrl | undefined;
+    agencyValidatorEmail: string;
     beneficiaryBirthdate: string;
     beneficiaryFirstName: string;
     beneficiaryLastName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -381,6 +381,7 @@ export const emailTemplatesByName =
         magicLink,
         validatorName,
         agencyAssessmentDocumentLink,
+        agencyValidatorEmail,
       }) => ({
         subject:
           internshipKind === "immersion"
@@ -425,9 +426,9 @@ export const emailTemplatesByName =
           kind: "info",
           content: `${
             internshipKind === "immersion"
-              ? "À la fin de l'immersion, nous vous remercions de compléter la fiche bilan de l'immersion, et de l'envoyer au conseiller qui a signé la convention (Pôle Emploi, Mission Locale…). Cette évaluation doit être complétée par le tuteur, si possible en présence du bénéficiaire de l'immersion."
-              : "À la fin du mini stage, nous vous remercions de compléter la fiche bilan du mini stage, et de l'envoyer au conseiller de la Chambre de Commerce et d'Instrustrie - CCI qui a signé la convention. Cette évaluation doit être complétée par le tuteur, si possible en présence du bénéficiaire du mini stage."
-          }`,
+              ? "À la fin de l'immersion, nous vous remercions de compléter la fiche bilan de l'immersion, et de l'envoyer au conseiller qui a signé la convention (Pôle Emploi, Mission Locale…). Cette évaluation doit être complétée par le tuteur, si possible en présence du bénéficiaire de l'immersion,"
+              : "À la fin du mini stage, nous vous remercions de compléter la fiche bilan du mini stage, et de l'envoyer au conseiller de la Chambre de Commerce et d'Instrustrie - CCI qui a signé la convention. Cette évaluation doit être complétée par le tuteur, si possible en présence du bénéficiaire du mini stage, "
+          } puis envoyée à <a href= "mailto:${agencyValidatorEmail}" target="_blank">${agencyValidatorEmail}</a>.`,
         },
         subContent: `
       ${defaultSignature(internshipKind)}


### PR DESCRIPTION
## 📔  Description

Certains stagiaires renvoient le bilan à l'équipe IF.  
Pour éviter cela, nous souhaitons préciser dans le mail de "Convention finale validée" d'envoyer le bilan au valideur de la convention.

## 🦄  Remarque

Dans le mail de "Lien de creation du bilan", il est déjà précisé d'envoyer le bilan au valideur de la convention avec son adresse mail.