### PR TITLE
Ajout route de suppression d'un webhook

### DIFF
--- a/back/src/adapters/primary/authMiddleware.ts
+++ b/back/src/adapters/primary/authMiddleware.ts
@@ -316,7 +316,7 @@ export const makeConsumerMiddleware = (
         incTotalCountForRequest({
           authorisationStatus: "consumerNotFound",
         });
-        return responseErrorForV2(res, "consumer not found");
+        return responseErrorForV2(res, "consumer not found", 401);
       }
 
       if (new Date(apiConsumer.expirationDate) < timeGateway.now()) {
@@ -324,7 +324,7 @@ export const makeConsumerMiddleware = (
           authorisationStatus: "expiredToken",
           consumerName: apiConsumer.consumer,
         });
-        return responseErrorForV2(res, "expired token");
+        return responseErrorForV2(res, "expired token", 401);
       }
 
       // only if the OAuth is known, and the id authorized, and not expired we add apiConsumer payload to the request:

--- a/back/src/adapters/primary/config/createUseCases.ts
+++ b/back/src/adapters/primary/config/createUseCases.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../domain/auth/jwt";
 import { SaveApiConsumer } from "../../../domain/auth/useCases/SaveApiConsumer";
 import { BroadcastToPartnersOnConventionUpdates } from "../../../domain/broadcast/useCases/BroadcastToPartnersOnConventionUpdates";
+import { DeleteSubscription } from "../../../domain/broadcast/useCases/DeleteSubscription";
 import { ListActiveSubscriptions } from "../../../domain/broadcast/useCases/ListActiveSubscriptions";
 import { SubscribeToWebhook } from "../../../domain/broadcast/useCases/SubscribeToWebhook";
 import { AddConvention } from "../../../domain/convention/useCases/AddConvention";
@@ -498,6 +499,7 @@ export const createUseCases = (
         uuidGenerator,
         gateways.timeGateway,
       ),
+      deleteSubscription: new DeleteSubscription(uowPerformer),
       shareConventionByEmail: new ShareConventionLinkByEmail(
         uowPerformer,
         saveNotificationAndRelatedEvent,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createApiKeyAuthRouter.v2.ts
@@ -193,5 +193,16 @@ export const createApiKeyAuthRouterV2 = (deps: AppDependencies) => {
       }),
   );
 
+  webhooksV2Router.unsubscribeToWebhook(
+    deps.apiConsumerMiddleware,
+    (req, res) =>
+      sendHttpResponseForApiV2(req, res.status(204), async () => {
+        await deps.useCases.deleteSubscription.execute(
+          req.params.subscriptionId,
+          req.apiConsumer,
+        );
+      }),
+  );
+
   return v2ExpressRouter;
 };

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV2.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV2.ts
@@ -462,7 +462,6 @@ export const createOpenApiSpecV2 = (envType: string) =>
           },
         },
       },
-      // unsubscribeToWebhook: {} as any,
       subscribeToWebhook: {
         summary: "Souscription à un webhook",
         description:
@@ -501,6 +500,30 @@ export const createOpenApiSpecV2 = (envType: string) =>
             "401": { description: "Lorsque vous n'êtes pas authentifié" },
             "403": {
               description: "Lorsque vous n'avez pas suffisamment de droits",
+            },
+          },
+        },
+      },
+      unsubscribeToWebhook: {
+        summary: "Suppression d'une souscription de webhook",
+        description:
+          "Cette route permet de supprimer une souscription à un webhook.",
+        extraDocs: {
+          urlParams: {
+            subscriptionId: {
+              description: "Identifiant du webhook",
+            },
+          },
+          responses: {
+            "204": {
+              description: "Suppression du webhook réussie",
+            },
+            "401": { description: "Lorsque vous n'êtes pas authentifié" },
+            "403": {
+              description: "Lorsque vous n'avez pas suffisamment de droits",
+            },
+            "404": {
+              description: "La souscription demandée n'est pas trouvée",
             },
           },
         },

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   createWebhookSubscriptionSchema,
+  emptyObjectSchema,
   expressEmptyResponseBody,
   httpErrorSchema,
   searchResultSchema,
@@ -115,15 +116,15 @@ export const publicApiV2WebhooksRoutes = defineRoutes({
       403: httpErrorSchema,
     },
   }),
-  // unsubscribeToWebhook: defineRoute({
-  //   method: "delete",
-  //   url: "/v2/webhooks/:subscriptionId",
-  //   ...withAuthorizationHeaders,
-  //   responses: {
-  //     204: z.void(),
-  //     400: httpErrorSchema,
-  //     401: httpErrorSchema,
-  //     403: httpErrorSchema,
-  //   },
-  // }),
+  unsubscribeToWebhook: defineRoute({
+    method: "delete",
+    url: "/v2/webhooks/:subscriptionId",
+    ...withAuthorizationHeaders,
+    responses: {
+      204: emptyObjectSchema,
+      401: httpErrorSchema,
+      403: httpErrorSchema,
+      404: httpErrorSchema,
+    },
+  }),
 });

--- a/back/src/domain/broadcast/useCases/DeleteSubscription.ts
+++ b/back/src/domain/broadcast/useCases/DeleteSubscription.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import {
+  ApiConsumer,
+  eventToRightName,
+  findSubscribedEventFromId,
+  isApiConsumerAllowed,
+  SubscriptionEvent,
+} from "shared";
+import {
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from "../../../adapters/primary/helpers/httpErrors";
+import { UnitOfWork, UnitOfWorkPerformer } from "../../core/ports/UnitOfWork";
+import { TransactionalUseCase } from "../../core/UseCase";
+
+export class DeleteSubscription extends TransactionalUseCase<
+  string,
+  void,
+  ApiConsumer
+> {
+  protected inputSchema = z.string();
+
+  constructor(uowPerformer: UnitOfWorkPerformer) {
+    super(uowPerformer);
+  }
+
+  protected async _execute(
+    subscriptionId: SubscriptionEvent,
+    uow: UnitOfWork,
+    apiConsumer?: ApiConsumer,
+  ): Promise<void> {
+    if (!apiConsumer) throw new UnauthorizedError();
+
+    const eventToDelete = findSubscribedEventFromId(
+      apiConsumer,
+      subscriptionId,
+    );
+
+    if (!eventToDelete)
+      throw new NotFoundError(`subscription ${subscriptionId} not found`);
+    const rightName = eventToRightName(eventToDelete);
+    if (
+      !isApiConsumerAllowed({
+        apiConsumer,
+        rightName,
+        consumerKind: "SUBSCRIPTION",
+      })
+    ) {
+      throw new ForbiddenError(
+        `You do not have the "SUBSCRIPTION" kind associated to the "${rightName}" right`,
+      );
+    }
+
+    const updatedSubscriptions = apiConsumer.rights[
+      rightName
+    ].subscriptions.filter(
+      (subscription) => subscription.subscribedEvent !== eventToDelete,
+    );
+
+    await uow.apiConsumerRepository.save({
+      ...apiConsumer,
+      rights: {
+        ...apiConsumer.rights,
+        [rightName]: {
+          ...apiConsumer.rights[rightName],
+          subscriptions: updatedSubscriptions,
+        },
+      },
+    });
+  }
+}

--- a/back/src/domain/broadcast/useCases/DeleteSubscription.unit.test.ts
+++ b/back/src/domain/broadcast/useCases/DeleteSubscription.unit.test.ts
@@ -1,0 +1,108 @@
+import { expectPromiseToFailWithError, expectToEqual } from "shared";
+import { ApiConsumerBuilder } from "../../../_testBuilders/ApiConsumerBuilder";
+import {
+  createInMemoryUow,
+  InMemoryUnitOfWork,
+} from "../../../adapters/primary/config/uowConfig";
+import {
+  ForbiddenError,
+  NotFoundError,
+} from "../../../adapters/primary/helpers/httpErrors";
+import { TestUuidGenerator } from "../../../adapters/secondary/core/UuidGeneratorImplementations";
+import { InMemoryUowPerformer } from "../../../adapters/secondary/InMemoryUowPerformer";
+import { DeleteSubscription } from "./DeleteSubscription";
+
+describe("DeleteSubscription", () => {
+  const uuidGenerator = new TestUuidGenerator();
+  let uow: InMemoryUnitOfWork;
+  let deleteSubscription: DeleteSubscription;
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    const uowPerformer = new InMemoryUowPerformer(uow);
+
+    deleteSubscription = new DeleteSubscription(uowPerformer);
+  });
+
+  it("throws error when apiConsumer does not have the rights", async () => {
+    const now = new Date("2023-09-22");
+    const subscriptionId = uuidGenerator.new();
+    const apiConsumer = new ApiConsumerBuilder()
+      .withConventionRight({
+        kinds: ["WRITE"],
+        scope: { agencyIds: [] },
+        subscriptions: [
+          {
+            id: subscriptionId,
+            createdAt: now.toISOString(),
+            callbackHeaders: { authorization: "lol" },
+            callbackUrl: "https://www.lol.com",
+            subscribedEvent: "convention.updated",
+          },
+        ],
+      })
+      .build();
+    uow.apiConsumerRepository.consumers = [apiConsumer];
+
+    await expectPromiseToFailWithError(
+      deleteSubscription.execute(subscriptionId, apiConsumer),
+      new ForbiddenError(
+        `You do not have the "SUBSCRIPTION" kind associated to the "convention" right`,
+      ),
+    );
+  });
+
+  it("delete a webhook subscription", async () => {
+    const now = new Date("2023-09-22");
+    const subscriptionId = uuidGenerator.new();
+    const apiConsumer = new ApiConsumerBuilder()
+      .withConventionRight({
+        kinds: ["SUBSCRIPTION"],
+        scope: { agencyIds: ["yolo"] },
+        subscriptions: [
+          {
+            id: subscriptionId,
+            createdAt: now.toISOString(),
+            callbackHeaders: { authorization: "lol" },
+            callbackUrl: "https://www.lol.com",
+            subscribedEvent: "convention.updated",
+          },
+        ],
+      })
+      .build();
+    uow.apiConsumerRepository.consumers = [apiConsumer];
+
+    await deleteSubscription.execute(subscriptionId, apiConsumer);
+
+    const expectedConsumer = await uow.apiConsumerRepository.getById(
+      apiConsumer.id,
+    );
+    expectToEqual(expectedConsumer?.rights.convention.subscriptions, []);
+  });
+
+  it("throws 404 when subscription not found", async () => {
+    const now = new Date("2023-09-22");
+    const subscriptionId = "unexisting-id";
+    const apiConsumer = new ApiConsumerBuilder()
+      .withConventionRight({
+        kinds: ["SUBSCRIPTION"],
+        scope: { agencyIds: ["yolo"] },
+        subscriptions: [
+          {
+            id: uuidGenerator.new(),
+            createdAt: now.toISOString(),
+            callbackHeaders: { authorization: "lol" },
+            callbackUrl: "https://www.lol.com",
+            subscribedEvent: "convention.updated",
+          },
+        ],
+      })
+      .build();
+    uow.apiConsumerRepository.consumers = [apiConsumer];
+
+    await expectPromiseToFailWithError(
+      deleteSubscription.execute(subscriptionId, apiConsumer),
+      new NotFoundError(`subscription ${subscriptionId} not found`),
+    );
+  });
+});

--- a/shared/src/apiConsumer/ApiConsumer.ts
+++ b/shared/src/apiConsumer/ApiConsumer.ts
@@ -150,3 +150,16 @@ export const createApiConsumerParamsFromApiConsumer = (
   contact: apiConsumer.contact,
   description: apiConsumer.description,
 });
+
+export const findSubscribedEventFromId = (
+  apiConsumer: ApiConsumer,
+  subscriptionId: ApiConsumerSubscriptionId,
+): SubscriptionEvent | undefined => {
+  for (const rightName of apiConsumerRightNames) {
+    const subscription = apiConsumer.rights[rightName].subscriptions.find(
+      (subscription) => subscription.id === subscriptionId,
+    );
+    if (subscription) return subscription.subscribedEvent;
+  }
+  return;
+};

--- a/shared/src/apiConsumer/ApiConsumer.ts
+++ b/shared/src/apiConsumer/ApiConsumer.ts
@@ -1,3 +1,4 @@
+import { keys } from "ramda";
 import { AbsoluteUrl } from "../AbsoluteUrl";
 import type { AgencyId, AgencyKind } from "../agency/agency.dto";
 import type { Email } from "../email/email.dto";
@@ -151,15 +152,12 @@ export const createApiConsumerParamsFromApiConsumer = (
   description: apiConsumer.description,
 });
 
-export const findSubscribedEventFromId = (
+export const findRightNameFromSubscriptionId = (
   apiConsumer: ApiConsumer,
   subscriptionId: ApiConsumerSubscriptionId,
-): SubscriptionEvent | undefined => {
-  for (const rightName of apiConsumerRightNames) {
-    const subscription = apiConsumer.rights[rightName].subscriptions.find(
-      (subscription) => subscription.id === subscriptionId,
-    );
-    if (subscription) return subscription.subscribedEvent;
-  }
-  return;
-};
+): ApiConsumerRightName | undefined =>
+  keys(apiConsumer.rights).find((rightName) =>
+    apiConsumer.rights[rightName].subscriptions.find(
+      (sub) => sub.id === subscriptionId,
+    ),
+  );


### PR DESCRIPTION
## 📔  Description

On pouvait créer et lister les souscriptions webhooks d'un apiConsumer.  
Cette PR permet d'en supprimer une.

<img width="1204" alt="Screenshot 2023-11-14 at 17 50 30" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/cb3b8af2-68d3-451e-8002-7b1e7c16381e">

## 🔍 Pour tester

```bash
curl --request DELETE 'http://localhost:3000/api/v2/webhooks/1be3d916-7030-4bc3-8755-8a6cf5b78bbc' --header 'authorization:  {your token}'
```

