### PR TITLE
Ajouter les header custom dans les CallbackHeaders de souscriptions à une webhook

### DIFF
--- a/shared/src/apiConsumer/ApiConsumer.ts
+++ b/shared/src/apiConsumer/ApiConsumer.ts
@@ -86,7 +86,7 @@ export const isApiConsumerAllowed = ({
 
 export type CallbackHeaders = {
   authorization: string;
-};
+} & Record<string, string>;
 
 export const eventToRightName = (
   event: SubscriptionEvent,

--- a/shared/src/apiConsumer/apiConsumer.schema.ts
+++ b/shared/src/apiConsumer/apiConsumer.schema.ts
@@ -31,7 +31,9 @@ export const createWebhookSubscriptionSchema: z.Schema<CreateWebhookSubscription
   z.object({
     subscribedEvent: z.enum(["convention.updated"]),
     callbackUrl: absoluteUrlSchema,
-    callbackHeaders: z.object({ authorization: z.string() }),
+    callbackHeaders: z
+      .object({ authorization: z.string() })
+      .and(z.record(z.string(), z.string())),
   });
 
 export const webhookSubscriptionSchema: z.Schema<WebhookSubscription> =


### PR DESCRIPTION
## Decsription

Certains consommateurs de nos webhook souhaiteraient faire passer des headers custom dans notre callback.