### PR TITLE
Mis à jour de la page d'accessibilité

### DIFF
--- a/front/src/app/components/layout/LayoutFooter.tsx
+++ b/front/src/app/components/layout/LayoutFooter.tsx
@@ -135,7 +135,7 @@ const links: NavLink[] = [
 const bottomsLinks: NavLink[] = [
   {
     label: "Accessibilité : partiellement conforme",
-    ...routes.standard({ pagePath: "declaration-accessibilite" }).link,
+    ...routes.standard({ pagePath: "accessibilite" }).link,
     id: bottomsLinksIds.accessibility,
   },
   {

--- a/front/src/app/contents/meta/metaContents.ts
+++ b/front/src/app/contents/meta/metaContents.ts
@@ -130,8 +130,8 @@ export const standardMetaContent: Record<StandardPageSlugs, MetaContentType> = {
     title: "Politique de confidentialité",
     description: "Faciliter la réalisation des immersions professionnelles.",
   },
-  "declaration-accessibilite": {
-    title: "Déclaration d'accessibilité",
+  accessibilite: {
+    title: "Accessibilité",
     description: "Faciliter la réalisation des immersions professionnelles.",
   },
   "plan-du-site": {

--- a/front/src/app/contents/standard/accessibilite.ts
+++ b/front/src/app/contents/standard/accessibilite.ts
@@ -1,10 +1,14 @@
 import { immersionFacileContactEmail } from "shared";
 
 export default {
-  title: "Déclaration d'accessibilité",
+  title: "Accessibilité",
   content: `
 
-  GIP Plateforme de l'Inclusion s’engage à rendre ses sites internet, intranet, extranet et ses progiciels accessibles (et ses applications mobiles et mobilier urbain numérique) conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
+  <strong>Déclaration d’accessibilité</strong>
+
+  Le GIP Plateforme de l’inclusion s’engage à rendre ses sites internet et applications accessibles conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
+
+  Son schéma pluriannuel décrit les points importants sur lesquels le GIP de la plateforme de l’inclusion s’appuiera pour améliorer l’accessibilité numérique de l’ensemble de ses sites internet et applications. Ce schéma s’accompagne du plans d’action annuels (<a target="_blank" href="https://inclusion.beta.gouv.fr/documents/86/GIP_plateforme_de_linclusion_-_Plan_annuel_daccessibilite_2023.pdf">2023</a>) qui détaillent les opérations programmées et mises en œuvre pour l'année courante, ainsi que l’état de suivis de ces actions, détaillé dans le <a target="_blank" href="https://inclusion.beta.gouv.fr/documents/87/GIP_plateforme_de_linclusion_-_Schema_pluriannuel_daccessibilite_2023-2026.pdf">schéma pluriannuel d’accessibilité 2023-2026</a>.
   
   Cette déclaration d’accessibilité s’applique à https://immersion-facile.beta.gouv.fr.
 

--- a/front/src/app/contents/standard/siteMap.ts
+++ b/front/src/app/contents/standard/siteMap.ts
@@ -46,9 +46,9 @@ const siteMapLinks: RegisteredLinkProps[] = [
     ...routes.addAgency().link,
   },
   {
-    title: "Déclaration d'accessibilité",
+    title: "Accessibilité",
     id: siteMapIds.accessibility,
-    ...routes.standard({ pagePath: "declaration-accessibilite" }).link,
+    ...routes.standard({ pagePath: "accessibilite" }).link,
   },
   {
     title: "Mentions légales",

--- a/front/src/app/contents/standard/textSetup.ts
+++ b/front/src/app/contents/standard/textSetup.ts
@@ -1,7 +1,7 @@
 import { StandardPageSlugs } from "src/app/routes/routeParams/standardPage";
+import accessibilityContent from "./accessibilite";
 import budgetContent from "./budget";
 import cguContent from "./cgu";
-import accessibilityContent from "./declaration-accessibilite";
 import legalsContent from "./mentions-legales";
 import obligationsContent from "./obligations-des-parties";
 import policiesContent from "./politique-de-confidentialite";
@@ -16,7 +16,7 @@ const mappedContents: Record<StandardPageSlugs, StandardPageContent> = {
   cgu: cguContent,
   "mentions-legales": legalsContent,
   "politique-de-confidentialite": policiesContent,
-  "declaration-accessibilite": accessibilityContent,
+  accessibilite: accessibilityContent,
   "plan-du-site": siteMapContent,
   "obligations-des-parties": obligationsContent,
   budget: budgetContent,

--- a/front/src/app/routes/routeParams/standardPage.ts
+++ b/front/src/app/routes/routeParams/standardPage.ts
@@ -6,7 +6,7 @@ export const standardPageSlugs = [
   "mentions-legales",
   "cgu",
   "politique-de-confidentialite",
-  "declaration-accessibilite",
+  "accessibilite",
   "plan-du-site",
   "obligations-des-parties",
   "budget",


### PR DESCRIPTION
## Description

Sur la page d'accessibilité, il nous manque des infos sur le schéma annuel et pluriannuel de la Plateforme de l'inclusion.

Le début de la page modifiée donne:
<img width="869" alt="Screenshot 2023-11-28 at 11 17 34" src="https://github.com/gip-inclusion/immersion-facile/assets/11294487/6b166a43-99bf-425d-add0-5fbf9e6fa301">

