### PR TITLE
Bottleneck sur l'api V2

### DIFF
--- a/back/src/_testBuilders/buildTestApp.ts
+++ b/back/src/_testBuilders/buildTestApp.ts
@@ -97,6 +97,7 @@ export const buildTestApp = async (
     EMAIL_VALIDATION_GATEWAY: "IN_MEMORY",
     SHORT_LINK_ID_GENERATOR_GATEWAY: "DETERMINIST",
     INBOUND_EMAIL_ALLOWED_IPS: "::ffff:127.0.0.1",
+    MAX_API_CONSUMER_CALLS_PER_SECOND: "2",
     ...appConfigOverrides?.configParams,
   }).build();
 

--- a/back/src/adapters/primary/config/appConfig.ts
+++ b/back/src/adapters/primary/config/appConfig.ts
@@ -274,6 +274,10 @@ export class AppConfig {
     });
   }
 
+  public get maxApiConsumerCallsPerSecond() {
+    return parseInteger(this.env.MAX_API_CONSUMER_CALLS_PER_SECOND, 5);
+  }
+
   public get maxConventionsToSyncWithPe() {
     return parseInt(
       this.#throwIfNotDefinedOrDefault("MAX_CONVENTIONS_TO_SYNC_WITH_PE", "50"),

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV2.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV2.ts
@@ -153,6 +153,10 @@ const error404Example = {
   status: 404,
   message: "No establishment found with siret 12345678912345",
 };
+const error429Example = {
+  status: 429,
+  message: "Too many requests, please try again later.",
+};
 
 const conventionExample: ConventionReadDto = {
   ...new ConventionDtoBuilder().build(),
@@ -265,6 +269,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
                 "Accès non autorisé (veuillez vérifier que vous avez les droits)",
               example: error403Example,
             },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
+            },
           },
         },
       },
@@ -312,6 +321,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
             "404": {
               description: "Résultat non trouvé",
               example: error404Example,
+            },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
             },
           },
         },
@@ -377,6 +391,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
               description: "Établissement/Contact non trouvé",
               example: error404Example,
             },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
+            },
           },
         },
       },
@@ -407,6 +426,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
               description: "Convention non trouvé",
               example: error404Example,
             },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
+            },
           },
         },
       },
@@ -433,6 +457,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
                 "Accès non autorisé (veuillez vérifier que vous avez les droits)",
               example: error403Example,
             },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
+            },
           },
         },
       },
@@ -458,6 +487,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
               description:
                 "Accès non autorisé (veuillez vérifier que vous avez les droits)",
               example: error403Example,
+            },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
             },
           },
         },
@@ -501,6 +535,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
             "403": {
               description: "Lorsque vous n'avez pas suffisamment de droits",
             },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
+            },
           },
         },
       },
@@ -524,6 +563,11 @@ export const createOpenApiSpecV2 = (envType: string) =>
             },
             "404": {
               description: "La souscription demandée n'est pas trouvée",
+            },
+            "429": {
+              description:
+                "Trop d'appels en cours. Veuillez réessayer dans quelques instants",
+              example: error429Example,
             },
           },
         },

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2.routes.ts
@@ -27,6 +27,7 @@ export const publicApiV2SearchEstablishmentRoutes = defineRoutes({
       401: httpErrorSchema,
       403: httpErrorSchema,
       404: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
   searchImmersion: defineRoute({
@@ -39,6 +40,7 @@ export const publicApiV2SearchEstablishmentRoutes = defineRoutes({
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
   contactEstablishment: defineRoute({
@@ -52,6 +54,7 @@ export const publicApiV2SearchEstablishmentRoutes = defineRoutes({
       401: httpErrorSchema,
       403: httpErrorSchema,
       404: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
 });
@@ -68,6 +71,7 @@ export const publicApiV2ConventionRoutes = defineRoutes({
       401: httpErrorSchema,
       403: httpErrorSchema,
       404: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
   getConventions: defineRoute({
@@ -80,6 +84,7 @@ export const publicApiV2ConventionRoutes = defineRoutes({
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
 });
@@ -96,6 +101,7 @@ export const publicApiV2WebhooksRoutes = defineRoutes({
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
   listActiveSubscriptions: defineRoute({
@@ -114,6 +120,7 @@ export const publicApiV2WebhooksRoutes = defineRoutes({
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
   unsubscribeToWebhook: defineRoute({
@@ -125,6 +132,7 @@ export const publicApiV2WebhooksRoutes = defineRoutes({
       401: httpErrorSchema,
       403: httpErrorSchema,
       404: httpErrorSchema,
+      429: httpErrorSchema,
     },
   }),
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2Bottleneck.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2Bottleneck.e2e.test.ts
@@ -1,0 +1,123 @@
+import { SuperTest, Test } from "supertest";
+import {
+  AgencyDtoBuilder,
+  ConventionDtoBuilder,
+  ConventionId,
+  expectArraysToEqual,
+  expectHttpResponseToEqual,
+} from "shared";
+import { HttpClient } from "shared-routes";
+import { createSupertestSharedClient } from "shared-routes/supertest";
+import { ApiConsumerBuilder } from "../../../../_testBuilders/ApiConsumerBuilder";
+import { buildTestApp } from "../../../../_testBuilders/buildTestApp";
+import { GenerateApiConsumerJwt } from "../../../../domain/auth/jwt";
+import { InMemoryUnitOfWork } from "../../config/uowConfig";
+import {
+  PublicApiV2ConventionRoutes,
+  publicApiV2ConventionRoutes,
+} from "./publicApiV2.routes";
+
+const createApiCall = (
+  sharedRequest: HttpClient<PublicApiV2ConventionRoutes>,
+  authorization: string,
+  conventionId: ConventionId,
+) =>
+  sharedRequest.getConventionById({
+    headers: {
+      authorization,
+    },
+    urlParams: { conventionId },
+  });
+
+const agency = new AgencyDtoBuilder().build();
+
+const convention = new ConventionDtoBuilder().withAgencyId(agency.id).build();
+
+const consumer1 = new ApiConsumerBuilder()
+  .withId("id-consumer-1")
+  .withConventionRight({
+    kinds: ["READ"],
+    scope: {
+      agencyIds: [agency.id],
+    },
+    subscriptions: [],
+  })
+  .build();
+
+const consumer2 = new ApiConsumerBuilder()
+  .withId("id-consumer-2")
+  .withConventionRight({
+    kinds: ["READ"],
+    scope: {
+      agencyIds: [agency.id],
+    },
+    subscriptions: [],
+  })
+  .build();
+
+describe("bottleneck", () => {
+  let request: SuperTest<Test>;
+  let generateApiConsumerJwt: GenerateApiConsumerJwt;
+  let sharedRequest: HttpClient<PublicApiV2ConventionRoutes>;
+  let authorizationToken1: string;
+  let authorizationToken2: string;
+  let inMemoryUow: InMemoryUnitOfWork;
+
+  beforeEach(async () => {
+    ({ request, generateApiConsumerJwt, inMemoryUow } = await buildTestApp());
+    inMemoryUow.apiConsumerRepository.consumers = [consumer1, consumer2];
+    authorizationToken1 = generateApiConsumerJwt({
+      id: consumer1.id,
+    });
+    authorizationToken2 = generateApiConsumerJwt({
+      id: consumer2.id,
+    });
+    sharedRequest = createSupertestSharedClient(
+      publicApiV2ConventionRoutes,
+      request,
+    );
+  });
+
+  it("fails when too many request for a same bottleneck group", async () => {
+    inMemoryUow.agencyRepository.setAgencies([agency]);
+    inMemoryUow.conventionRepository.setConventions({
+      [convention.id]: convention,
+    });
+
+    const response = await Promise.all([
+      createApiCall(sharedRequest, authorizationToken1, convention.id),
+      createApiCall(sharedRequest, authorizationToken1, convention.id),
+      createApiCall(sharedRequest, authorizationToken1, convention.id),
+    ]);
+
+    expectArraysToEqual(
+      response.map((res) => res.status),
+      [200, 200, 429],
+    );
+    expectHttpResponseToEqual(response[2], {
+      status: 429,
+      body: {
+        message: "Too many requests, please try again later.",
+        status: 429,
+      },
+    });
+  });
+
+  it("success when two different bottleneck groups", async () => {
+    inMemoryUow.agencyRepository.setAgencies([agency]);
+    inMemoryUow.conventionRepository.setConventions({
+      [convention.id]: convention,
+    });
+
+    const response = await Promise.all([
+      createApiCall(sharedRequest, authorizationToken1, convention.id),
+      createApiCall(sharedRequest, authorizationToken1, convention.id),
+      createApiCall(sharedRequest, authorizationToken2, convention.id),
+    ]);
+
+    expectArraysToEqual(
+      response.map((res) => res.status),
+      [200, 200, 200],
+    );
+  });
+});


### PR DESCRIPTION
## Description

Pour éviter que nos consommateurs surcharge nos serveurs avec leurs appels à nos api publiques, nous souhaitons mettre en place une limite.

## Solution

Nous utilisons la librairie Bottleneck pour mettre en place ce mécanisme.
Le nom maximal d'appels api concurrents pour un même consommateur est défini par la variable d'environnement `MAX_API_CONSUMER_CALLS_PER_SECOND`. Au-delà, l'appel api est rejeté en HTTP 429.