### PR TITLE
Fix review app

### DIFF
--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -59,6 +59,12 @@ jobs:
             echo "Review app for PR_ID ${{ inputs.pull_request_id }} does not exist. Creating now."
             scalingo --app if-dev-front integration-link-manual-review-app ${{ inputs.pull_request_id }}
           fi
+      - name: Deactivate back review app autodeploy
+        run: |
+          scalingo --app if-dev-back-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
+      - name: Deactivate front review app autodeploy
+        run: |
+          scalingo --app if-dev-front-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
       - name: Remove sslmode from $SCALINGO_POSTGRESQL_URL
         run: |
           current_db_url=$(scalingo --app if-dev-back-pr${{ inputs.pull_request_id }} env | grep 'SCALINGO_POSTGRESQL_URL=' | cut -d '=' -f2-)


### PR DESCRIPTION
## 📔  Description

- désactiver le déploiement automatique de la review-app par Scalingo
Nous déployons déjà depuis le Scalingo CLI via github actions. Ce déploiement finit en succès. Or avec le déploiement automatique de Scalingo d'activé, un deuxième déploiement est déclenché, ce déploiement échoue car il utilise npm et non pnpm. Pour éviter d'avoir un deuxième déploiement - qui échoue en plus, des jobs de désactivation de déploiements automatiques ont été ajoutés dans notre processus.

- nous avions une limite sur le nombre limite d'applications maximum, ce qui entrainait dernièrement un échec de création de review app. Pour corriger ce problème, Scalingo a augmenté notre nombre limite max d'applications (sans impact sur la facturation)

A tester sur une autre PR:
Puisque nous désactivons les déploiements automatiques de Scalingo au profit de nos déploiement via Scalingo CLI, un job Github de déploiement est marqué comme "fail" (marqué avec la croix rouge).
Est-ce que désactiver le lien Github depuis l'app Scalingo peut permettre d'éviter cette croix rouge ?