### PR TITLE
Empêcher la création/mise à jour de doublon d'agences

### DIFF
--- a/back/src/adapters/primary/routers/agencies/agencies.e2e.test.ts
+++ b/back/src/adapters/primary/routers/agencies/agencies.e2e.test.ts
@@ -271,7 +271,7 @@ describe(`Agency routes`, () => {
 
       it("Updates the agency and returns code 200", async () => {
         // Prepare
-        await inMemoryUow.agencyRepository.insert(agency4NeedsReview);
+        await inMemoryUow.agencyRepository.setAgencies([agency4NeedsReview]);
 
         const updatedAgency = new AgencyDtoBuilder()
           .withId(agency4NeedsReview.id)

--- a/back/src/adapters/secondary/InMemoryAgencyRepository.ts
+++ b/back/src/adapters/secondary/InMemoryAgencyRepository.ts
@@ -1,7 +1,9 @@
 import { values } from "ramda";
 import {
+  AddressDto,
   AgencyDto,
   AgencyId,
+  AgencyKind,
   AgencyKindFilter,
   AgencyOption,
   AgencyPositionFilter,
@@ -173,6 +175,26 @@ export class InMemoryAgencyRepository implements AgencyRepository {
   // test purpose only
   public get agencies(): AgencyDto[] {
     return values(this.#agencies).filter(isTruthy);
+  }
+
+  public async alreadyHasActiveAgencyWithSameAddressAndKind({
+    address,
+    kind,
+    idToIgnore,
+  }: {
+    address: AddressDto;
+    kind: AgencyKind;
+    idToIgnore: AgencyId;
+  }): Promise<boolean> {
+    return this.agencies.some(
+      (agency) =>
+        agency.kind === kind &&
+        agency.address.streetNumberAndAddress ===
+          address.streetNumberAndAddress &&
+        agency.address.city === address.city &&
+        (agency.status === "active" || agency.status === "from-api-PE") &&
+        agency.id !== idToIgnore,
+    );
   }
 
   public async getAgencies({

--- a/back/src/adapters/secondary/pg/repositories/PgConventionQueries.integration.test.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgConventionQueries.integration.test.ts
@@ -259,7 +259,7 @@ describe("Pg implementation of ConventionQueries", () => {
           agencyId: conventionIdB,
           agencyName: "agency B",
           agencyDepartment: "76",
-          agencyKind: "autre",
+          agencyKind: "cci",
           agencySiret: "11112222000088",
         }),
       ]);

--- a/back/src/adapters/secondary/pg/repositories/PgInclusionConnectedUserRepository.integration.test.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgInclusionConnectedUserRepository.integration.test.ts
@@ -36,6 +36,7 @@ const agency1 = new AgencyDtoBuilder()
 const agency2 = new AgencyDtoBuilder()
   .withId("22222222-2222-4bbb-2222-222222222222")
   .withName("Agence 2")
+  .withKind("cci")
   .build();
 
 describe("PgInclusionConnectedUserRepository", () => {

--- a/back/src/domain/convention/entities/Agency.ts
+++ b/back/src/domain/convention/entities/Agency.ts
@@ -1,0 +1,23 @@
+import { AgencyDto } from "shared";
+import { ConflictError } from "../../../adapters/primary/helpers/httpErrors";
+import { UnitOfWork } from "../../core/ports/UnitOfWork";
+
+export const throwConflictErrorOnSimilarAgencyFound = async ({
+  uow,
+  agency,
+}: {
+  uow: UnitOfWork;
+  agency: AgencyDto;
+}) => {
+  const hasSimilarAgency =
+    await uow.agencyRepository.alreadyHasActiveAgencyWithSameAddressAndKind({
+      address: agency.address,
+      kind: agency.kind,
+      idToIgnore: agency.id,
+    });
+
+  if (hasSimilarAgency)
+    throw new ConflictError(
+      "An other agency exists with the same address and kind",
+    );
+};

--- a/back/src/domain/convention/ports/AgencyRepository.ts
+++ b/back/src/domain/convention/ports/AgencyRepository.ts
@@ -1,23 +1,32 @@
 import {
+  AddressDto,
   AgencyDto,
   AgencyId,
+  AgencyKind,
   GetAgenciesFilter,
   PartialAgencyDto,
 } from "shared";
 
 export interface AgencyRepository {
-  getBySafir(safirCode: string): Promise<AgencyDto | undefined>;
   insert: (agency: AgencyDto) => Promise<AgencyId | undefined>;
   update: (partialAgency: PartialAgencyDto) => Promise<void>;
   getByIds: (ids: AgencyId[]) => Promise<AgencyDto[]>;
-  getById: (ids: AgencyId) => Promise<AgencyDto | undefined>;
-  getAgenciesRelatedToAgency(id: AgencyId): Promise<AgencyDto[]>;
+  getById: (id: AgencyId) => Promise<AgencyDto | undefined>;
   getImmersionFacileAgencyId: () => Promise<AgencyId | undefined>;
   getAgencies: (props: {
     filters?: GetAgenciesFilter;
     limit?: number;
   }) => Promise<AgencyDto[]>;
   getAgencyWhereEmailMatches: (email: string) => Promise<AgencyDto | undefined>;
+
+  getBySafir(safirCode: string): Promise<AgencyDto | undefined>;
+
+  getAgenciesRelatedToAgency(id: AgencyId): Promise<AgencyDto[]>;
+  alreadyHasActiveAgencyWithSameAddressAndKind(params: {
+    address: AddressDto;
+    kind: AgencyKind;
+    idToIgnore: AgencyId;
+  }): Promise<boolean>;
 }
 
 export const someAgenciesMissingMessage = (agencyIds: AgencyId[]) =>

--- a/back/src/domain/convention/ports/AgencyRepository.ts
+++ b/back/src/domain/convention/ports/AgencyRepository.ts
@@ -8,25 +8,23 @@ import {
 } from "shared";
 
 export interface AgencyRepository {
-  insert: (agency: AgencyDto) => Promise<AgencyId | undefined>;
-  update: (partialAgency: PartialAgencyDto) => Promise<void>;
-  getByIds: (ids: AgencyId[]) => Promise<AgencyDto[]>;
-  getById: (id: AgencyId) => Promise<AgencyDto | undefined>;
-  getImmersionFacileAgencyId: () => Promise<AgencyId | undefined>;
-  getAgencies: (props: {
-    filters?: GetAgenciesFilter;
-    limit?: number;
-  }) => Promise<AgencyDto[]>;
-  getAgencyWhereEmailMatches: (email: string) => Promise<AgencyDto | undefined>;
-
-  getBySafir(safirCode: string): Promise<AgencyDto | undefined>;
-
-  getAgenciesRelatedToAgency(id: AgencyId): Promise<AgencyDto[]>;
   alreadyHasActiveAgencyWithSameAddressAndKind(params: {
     address: AddressDto;
     kind: AgencyKind;
     idToIgnore: AgencyId;
   }): Promise<boolean>;
+  getAgencies(props: {
+    filters?: GetAgenciesFilter;
+    limit?: number;
+  }): Promise<AgencyDto[]>;
+  getAgenciesRelatedToAgency(id: AgencyId): Promise<AgencyDto[]>;
+  getAgencyWhereEmailMatches(email: string): Promise<AgencyDto | undefined>;
+  getById(id: AgencyId): Promise<AgencyDto | undefined>;
+  getByIds(ids: AgencyId[]): Promise<AgencyDto[]>;
+  getBySafir(safirCode: string): Promise<AgencyDto | undefined>;
+  getImmersionFacileAgencyId(): Promise<AgencyId | undefined>;
+  insert(agency: AgencyDto): Promise<AgencyId | undefined>;
+  update(partialAgency: PartialAgencyDto): Promise<void>;
 }
 
 export const someAgenciesMissingMessage = (agencyIds: AgencyId[]) =>

--- a/back/src/domain/convention/useCases/agencies/AddAgency.ts
+++ b/back/src/domain/convention/useCases/agencies/AddAgency.ts
@@ -12,6 +12,7 @@ import {
   UnitOfWorkPerformer,
 } from "../../../core/ports/UnitOfWork";
 import { TransactionalUseCase } from "../../../core/UseCase";
+import { throwConflictErrorOnSimilarAgencyFound } from "../../entities/Agency";
 import { referedAgencyMissingMessage } from "../../ports/AgencyRepository";
 
 export class AddAgency extends TransactionalUseCase<CreateAgencyDto, void> {
@@ -43,6 +44,8 @@ export class AddAgency extends TransactionalUseCase<CreateAgencyDto, void> {
       status: "needsReview",
       questionnaireUrl: params.questionnaireUrl || "",
     };
+
+    await throwConflictErrorOnSimilarAgencyFound({ uow, agency });
 
     await Promise.all([
       uow.agencyRepository.insert(agency),

--- a/back/src/domain/convention/useCases/agencies/UpdateAgency.ts
+++ b/back/src/domain/convention/useCases/agencies/UpdateAgency.ts
@@ -6,6 +6,7 @@ import {
   UnitOfWorkPerformer,
 } from "../../../core/ports/UnitOfWork";
 import { TransactionalUseCase } from "../../../core/UseCase";
+import { throwConflictErrorOnSimilarAgencyFound } from "../../entities/Agency";
 
 export class UpdateAgency extends TransactionalUseCase<AgencyDto> {
   protected inputSchema = agencySchema;
@@ -21,6 +22,8 @@ export class UpdateAgency extends TransactionalUseCase<AgencyDto> {
   }
 
   public async _execute(agency: AgencyDto, uow: UnitOfWork): Promise<void> {
+    await throwConflictErrorOnSimilarAgencyFound({ uow, agency });
+
     await uow.agencyRepository.update(agency).catch((error) => {
       if (error.message === `Agency ${agency.id} does not exist`) {
         throw new NotFoundError(`No agency found with id : ${agency.id}`);

--- a/back/src/domain/convention/useCases/agencies/UpdateAgencyStatus.ts
+++ b/back/src/domain/convention/useCases/agencies/UpdateAgencyStatus.ts
@@ -1,4 +1,8 @@
 import { UpdateAgencyRequestDto, updateAgencyRequestSchema } from "shared";
+import {
+  ConflictError,
+  NotFoundError,
+} from "../../../../adapters/primary/helpers/httpErrors";
 import { CreateNewEvent } from "../../../core/eventBus/EventBus";
 import {
   UnitOfWork,
@@ -26,16 +30,31 @@ export class UpdateAgencyStatus extends TransactionalUseCase<
     { status, id }: UpdateAgencyRequestDto,
     uow: UnitOfWork,
   ): Promise<void> {
+    const existingAgency = await uow.agencyRepository.getById(id);
+    if (!existingAgency)
+      throw new NotFoundError(`No agency found with id ${id}`);
+
+    const hasSimilarAgency =
+      await uow.agencyRepository.alreadyHasActiveAgencyWithSameAddressAndKind({
+        address: existingAgency.address,
+        kind: existingAgency.kind,
+        idToIgnore: existingAgency.id,
+      });
+
+    if (hasSimilarAgency)
+      throw new ConflictError(
+        "An other agency exists with the same address and kind",
+      );
+
     if (status) await uow.agencyRepository.update({ id, status });
+
     if (status === "active") {
-      const [agency] = await uow.agencyRepository.getByIds([id]);
-      if (agency)
-        await uow.outboxRepository.save(
-          this.#createNewEvent({
-            topic: "AgencyActivated",
-            payload: { agency },
-          }),
-        );
+      await uow.outboxRepository.save(
+        this.#createNewEvent({
+          topic: "AgencyActivated",
+          payload: { agency: { ...existingAgency, status } },
+        }),
+      );
     }
   }
 }

--- a/back/src/domain/convention/useCases/agencies/UpdateAgencyStatus.unit.test.ts
+++ b/back/src/domain/convention/useCases/agencies/UpdateAgencyStatus.unit.test.ts
@@ -1,5 +1,12 @@
-import { AgencyDtoBuilder } from "shared";
-import { createInMemoryUow } from "../../../../adapters/primary/config/uowConfig";
+import { AgencyDtoBuilder, expectPromiseToFailWithError } from "shared";
+import {
+  createInMemoryUow,
+  InMemoryUnitOfWork,
+} from "../../../../adapters/primary/config/uowConfig";
+import {
+  ConflictError,
+  NotFoundError,
+} from "../../../../adapters/primary/helpers/httpErrors";
 import { CustomTimeGateway } from "../../../../adapters/secondary/core/TimeGateway/CustomTimeGateway";
 import { TestUuidGenerator } from "../../../../adapters/secondary/core/UuidGeneratorImplementations";
 import { InMemoryUowPerformer } from "../../../../adapters/secondary/InMemoryUowPerformer";
@@ -9,49 +16,82 @@ import { UpdateAgencyStatus } from "./UpdateAgencyStatus";
 const nextDate = new Date("2022-01-01T10:00:00.000");
 const nextUuid = "event-uuid";
 
-const prepareUseCase = () => {
-  const uow = createInMemoryUow();
-  const uuidGenerator = new TestUuidGenerator();
-  const timeGateway = new CustomTimeGateway();
-  timeGateway.setNextDate(nextDate);
-  uuidGenerator.setNextUuid(nextUuid);
+describe("Update agency status", () => {
+  let updateAgencyStatus: UpdateAgencyStatus;
+  let uow: InMemoryUnitOfWork;
 
-  const createNewEvent = makeCreateNewEvent({
-    uuidGenerator,
-    timeGateway,
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    const uuidGenerator = new TestUuidGenerator();
+    const timeGateway = new CustomTimeGateway();
+    timeGateway.setNextDate(nextDate);
+    uuidGenerator.setNextUuid(nextUuid);
+
+    const createNewEvent = makeCreateNewEvent({
+      uuidGenerator,
+      timeGateway,
+    });
+
+    updateAgencyStatus = new UpdateAgencyStatus(
+      new InMemoryUowPerformer(uow),
+      createNewEvent,
+    );
   });
 
-  const useCase = new UpdateAgencyStatus(
-    new InMemoryUowPerformer(uow),
-    createNewEvent,
-  );
-
-  return {
-    useCase,
-    outboxRepository: uow.outboxRepository,
-    agencyRepository: uow.agencyRepository,
-    uuidGenerator,
-  };
-};
-
-describe("Update agency status", () => {
-  it("Updates an agency status in repository and publishes an event to notify if status becomes active", async () => {
-    // Prepare
-    const { useCase, agencyRepository, outboxRepository } = prepareUseCase();
+  describe("right path", () => {
     const existingAgency = AgencyDtoBuilder.create("agency-123")
       .withStatus("needsReview")
       .build();
-    agencyRepository.setAgencies([existingAgency]);
 
-    // Act
-    await useCase.execute({ id: "agency-123", status: "active" });
+    it("Updates an agency status in repository and publishes an event to notify if status becomes active", async () => {
+      // Prepare
+      uow.agencyRepository.setAgencies([existingAgency]);
 
-    // Assert
-    expect(agencyRepository.agencies[0].status).toBe("active");
-    expect(outboxRepository.events[0]).toMatchObject({
-      id: nextUuid,
-      topic: "AgencyActivated",
-      payload: { agency: { ...existingAgency, status: "active" } },
+      // Act
+      await updateAgencyStatus.execute({
+        id: existingAgency.id,
+        status: "active",
+      });
+
+      // Assert
+      expect(uow.agencyRepository.agencies[0].status).toBe("active");
+      expect(uow.outboxRepository.events[0]).toMatchObject({
+        id: nextUuid,
+        topic: "AgencyActivated",
+        payload: { agency: { ...existingAgency, status: "active" } },
+      });
+    });
+  });
+
+  describe("wrong paths", () => {
+    const existingAgency = AgencyDtoBuilder.create("agency-123")
+      .withStatus("active")
+      .build();
+
+    it("returns 404 if agency not found", async () => {
+      const agencyId = "not-found-id";
+      await expectPromiseToFailWithError(
+        updateAgencyStatus.execute({ id: agencyId }),
+        new NotFoundError(`No agency found with id ${agencyId}`),
+      );
+    });
+
+    it("returns HTTP 409 if attempt to update to another existing agency (with same address and kind, and a status 'active' or 'from-api-PE'", async () => {
+      const agencyToUpdate = new AgencyDtoBuilder()
+        .withId("agency-to-update-id")
+        .withStatus("needsReview")
+        .withAddress(existingAgency.address)
+        .withKind(existingAgency.kind)
+        .build();
+
+      uow.agencyRepository.setAgencies([agencyToUpdate, existingAgency]);
+
+      await expectPromiseToFailWithError(
+        updateAgencyStatus.execute({ id: agencyToUpdate.id, status: "active" }),
+        new ConflictError(
+          "An other agency exists with the same address and kind",
+        ),
+      );
     });
   });
 });

--- a/front/src/app/components/forms/agency/AddAgencyForm.tsx
+++ b/front/src/app/components/forms/agency/AddAgencyForm.tsx
@@ -113,11 +113,13 @@ const AgencyForm = ({ refersToOtherAgency }: AgencyFormProps) => {
         questionnaireUrl:
           values.kind === "pole-emploi" ? "" : values.questionnaireUrl,
       })
-      .then(() => setSubmitFeedback({ kind: "agencyAdded" }))
+      .then(() => {
+        setSubmitFeedback({ kind: "agencyAdded" });
+      })
       .catch((e) => {
         //eslint-disable-next-line  no-console
         console.log("AddAgencyPage", e);
-        setSubmitFeedback(e);
+        setSubmitFeedback({ kind: "errored", errorMessage: e.message });
       });
   };
 

--- a/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
@@ -24,7 +24,14 @@ export class HttpAgencyGateway implements AgencyGateway {
   constructor(private readonly httpClient: HttpClient<AgencyRoutes>) {}
 
   public async addAgency(createAgencyParams: CreateAgencyDto): Promise<void> {
-    await this.httpClient.addAgency({ body: createAgencyParams });
+    await this.httpClient
+      .addAgency({ body: createAgencyParams })
+      .then((response) =>
+        match(response)
+          .with({ status: 200 }, ({ body }) => body)
+          .with({ status: 409 }, logBodyAndThrow)
+          .otherwise(otherwiseThrow),
+      );
   }
 
   public getAgencyAdminById$(
@@ -166,6 +173,7 @@ export class HttpAgencyGateway implements AgencyGateway {
           match(response)
             .with({ status: 200 }, () => undefined)
             .with({ status: 401 }, logBodyAndThrow)
+            .with({ status: 409 }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
     );

--- a/shared/src/routes/agencyRoutes.ts
+++ b/shared/src/routes/agencyRoutes.ts
@@ -11,7 +11,10 @@ import {
   withAgencyStatusSchema,
 } from "../agency/agency.schema";
 import { withAuthorizationHeaders } from "../headers";
-import { legacyUnauthenticatedErrorSchema } from "../httpClient/errors/httpErrors.schema";
+import {
+  legacyHttpErrorSchema,
+  legacyUnauthenticatedErrorSchema,
+} from "../httpClient/errors/httpErrors.schema";
 import { expressEmptyResponseBody } from "../zodUtils";
 
 const agencyWithIdForAdminUrl = `/admin/agencies/:agencyId` as const;
@@ -39,6 +42,7 @@ export const agencyRoutes = defineRoutes({
     responses: {
       200: expressEmptyResponseBody,
       401: legacyUnauthenticatedErrorSchema,
+      409: legacyHttpErrorSchema,
     },
   }),
   listAgenciesWithStatus: defineRoute({
@@ -63,6 +67,7 @@ export const agencyRoutes = defineRoutes({
     requestBodySchema: createAgencySchema,
     responses: {
       200: expressEmptyResponseBody,
+      409: legacyHttpErrorSchema,
     },
   }),
   getImmersionFacileAgencyId: defineRoute({

--- a/shared/src/routes/agencyRoutes.ts
+++ b/shared/src/routes/agencyRoutes.ts
@@ -32,7 +32,10 @@ export const agencyRoutes = defineRoutes({
     url: agencyWithIdForAdminUrl,
     requestBodySchema: withActiveOrRejectedAgencyStatusSchema,
     ...withAuthorizationHeaders,
-    responses: { 200: expressEmptyResponseBody },
+    responses: {
+      200: expressEmptyResponseBody,
+      409: legacyHttpErrorSchema,
+    },
   }),
   updateAgency: defineRoute({
     method: "put",


### PR DESCRIPTION
## Description

Refuser la création ou mise à jour d'une agence qui aurait le **même type + adresse** qu'une agence **active** déjà existante en DB.

## Pour tester

Sur la page de création d'agence /ajouter-prescripteur:
1. créer une agence ayant le même type + même adresse qu'une agence active existante en DB
2. constater que la création d'agence est refusée

Sur la page de modification d'agence /admin/agencies:
1. modifier une agence en reprenant le type + adresse d'une autre agence active existante en DB
2. constater que la création d'agence est refusée