### PR TITLE
Fix renouvellement de lien magique

### DIFF
--- a/back/src/adapters/primary/routers/convention/createConventionRouter.ts
+++ b/back/src/adapters/primary/routers/convention/createConventionRouter.ts
@@ -30,5 +30,11 @@ export const createConventionRouter = (deps: AppDependencies) => {
     ),
   );
 
+  conventionSharedRouter.renewMagicLink(async (req, res) =>
+    sendHttpResponse(req, res, () =>
+      deps.useCases.renewConventionMagicLink.execute(req.query),
+    ),
+  );
+
   return expressRouter;
 };

--- a/back/src/adapters/primary/routers/technical/createTechnicalRouter.ts
+++ b/back/src/adapters/primary/routers/technical/createTechnicalRouter.ts
@@ -66,12 +66,6 @@ export const createTechnicalRouter = (
     sendHttpResponse(req, res, deps.useCases.getFeatureFlags.execute),
   );
 
-  technicalSharedRouter.renewMagicLink(async (req, res) =>
-    sendHttpResponse(req, res, () =>
-      deps.useCases.renewConventionMagicLink.execute(req.query),
-    ),
-  );
-
   technicalSharedRouter.htmlToPdf(
     deps.conventionMagicLinkAuthMiddleware,
     async (req, res) =>

--- a/back/src/domain/convention/useCases/notifications/NotifyActorThatConventionNeedsModifications.ts
+++ b/back/src/domain/convention/useCases/notifications/NotifyActorThatConventionNeedsModifications.ts
@@ -62,7 +62,7 @@ export class NotifyActorThatConventionNeedsModifications extends TransactionalUs
       kind: "email",
       templatedContent: await this.#prepareEmail(
         payload.convention,
-        payload.requesterRole,
+        payload.modifierRole,
         recipientOrError,
         uow,
         payload.justification,
@@ -79,7 +79,7 @@ export class NotifyActorThatConventionNeedsModifications extends TransactionalUs
 
   async #prepareEmail(
     convention: ConventionDto,
-    role: Role,
+    recipientRole: Role,
     recipient: string,
     uow: UnitOfWork,
     justification: string,
@@ -89,11 +89,11 @@ export class NotifyActorThatConventionNeedsModifications extends TransactionalUs
     const conventionMagicLinkPayload: CreateConventionMagicLinkPayloadProperties =
       {
         id: convention.id,
-        role,
+        role: recipientRole,
         email: recipient,
         now: this.timeGateway.now(),
         // UGLY : need to rework, handling of JWT payloads
-        ...(role === "backOffice"
+        ...(recipientRole === "backOffice"
           ? { sub: this.config.backofficeUsername }
           : {}),
       };

--- a/back/src/domain/convention/useCases/notifications/NotifyActorThatConventionNeedsModifications.unit.test.ts
+++ b/back/src/domain/convention/useCases/notifications/NotifyActorThatConventionNeedsModifications.unit.test.ts
@@ -164,8 +164,8 @@ describe("NotifyActorThatConventionNeedsModifications", () => {
       }) => {
         shortLinkIdGateway.addMoreShortLinkIds(
           expectedRecipients.flatMap((expectedRecipient) => [
-            `shortLinkId_${expectedRecipient}_1`,
-            `shortLinkId_${expectedRecipient}_2`,
+            `shortLinkId_${expectedRecipient}_1_${modifierRole}`,
+            `shortLinkId_${expectedRecipient}_2_${modifierRole}`,
           ]),
         );
         const justification = "Change required.";
@@ -185,20 +185,22 @@ describe("NotifyActorThatConventionNeedsModifications", () => {
           const magicLinkCommonFields: CreateConventionMagicLinkPayloadProperties =
             {
               id: convention.id,
-              role: requesterRole,
+              role: modifierRole,
               email: expectedRecipient,
               now: timeGateway.now(),
             };
           return {
             ...prev,
-            [`shortLinkId_${expectedRecipient}_1`]: fakeGenerateMagicLinkUrlFn({
-              ...magicLinkCommonFields,
-              targetRoute: frontRoutes.conventionImmersionRoute,
-            }),
-            [`shortLinkId_${expectedRecipient}_2`]: fakeGenerateMagicLinkUrlFn({
-              ...magicLinkCommonFields,
-              targetRoute: frontRoutes.conventionStatusDashboard,
-            }),
+            [`shortLinkId_${expectedRecipient}_1_${modifierRole}`]:
+              fakeGenerateMagicLinkUrlFn({
+                ...magicLinkCommonFields,
+                targetRoute: frontRoutes.conventionImmersionRoute,
+              }),
+            [`shortLinkId_${expectedRecipient}_2_${modifierRole}`]:
+              fakeGenerateMagicLinkUrlFn({
+                ...magicLinkCommonFields,
+                targetRoute: frontRoutes.conventionStatusDashboard,
+              }),
           };
         }, {});
 
@@ -218,11 +220,11 @@ describe("NotifyActorThatConventionNeedsModifications", () => {
               justification,
               magicLink: makeShortLinkUrl(
                 config,
-                `shortLinkId_${expectedRecipient}_1`,
+                `shortLinkId_${expectedRecipient}_1_${modifierRole}`,
               ),
               conventionStatusLink: makeShortLinkUrl(
                 config,
-                `shortLinkId_${expectedRecipient}_2`,
+                `shortLinkId_${expectedRecipient}_2_${modifierRole}`,
               ),
               signature: agency.signature,
               agencyLogoUrl: agency.logoUrl,

--- a/shared/src/routes/technicalRoutes.ts
+++ b/shared/src/routes/technicalRoutes.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { defineRoute, defineRoutes } from "shared-routes";
-import { renewMagicLinkRequestSchema } from "../convention/convention.schema";
 import {
   validateEmailInputSchema,
   validateEmailResponseSchema,
@@ -52,11 +51,6 @@ export const technicalRoutes = defineRoutes({
     method: "get",
     url: `/feature-flags`,
     responses: { 200: featureFlagsSchema },
-  }),
-  renewMagicLink: defineRoute({
-    method: "get",
-    url: `/renew-magic-link`,
-    queryParamsSchema: renewMagicLinkRequestSchema,
   }),
   inboundEmailParsing: defineRoute({
     method: "post",


### PR DESCRIPTION
## Description

Lorsque l'on demande un renouvellement de lien magique, on transmet dans le token le role du demandeur + hash du receveur. Cela pose problème lorsque l'on reçoit la demande de renouvellement dans l'api car 