### PR TITLE
Supprimer les review apps à sa fermeture/merge

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -2,6 +2,7 @@ name: "Review app"
 
 on:
   pull_request:
+    types: [opened, ready_for_review, review_requested, synchronize]
 
 jobs:
   validation:
@@ -34,6 +35,7 @@ jobs:
   notify-pr:
     if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
+    needs: deploy-review-app
     steps:
       - name: Find existing notification
         uses: peter-evans/find-comment@v2

--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -1,4 +1,4 @@
-name: "Generic workflow to deploy to scalingo, given arguments"
+name: "Deploy review app"
 
 on:
   workflow_call:

--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -1,0 +1,21 @@
+name: "Destroy review apps"
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  destroy-review-apps:
+    runs-on: ubuntu-latest
+    environment: review-app
+    steps:
+      - name: Install scalingo CLI
+        run: |
+          wget -qO- https://cli-dl.scalingo.com/install.sh | bash
+          echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Login to scalingo
+        run: scalingo login --api-token ${{ secrets.SCALINGO_API_TOKEN }}
+      - name: Destroy review apps
+        run: |
+          scalingo --app if-dev-front-pr${{ github.event.number }} destroy --force
+          scalingo --app if-dev-back-pr${{ github.event.number }} destroy --force


### PR DESCRIPTION
## Description

Cette PR permet de:
- trigger la pipeline lorsque le status de la PR change à "Ready for review" (plus besoin de la trigger manuellement)
- supprimer les review app front + back liés à PR lors de la clôture de celle-ci

## Remarque

Vérifier après merge de cette PR que le job de suppression des RA est bien déclenché.