### PR TITLE
fix email

### DIFF
--- a/back/src/adapters/primary/routers/admin/getLastNotifications.e2e.test.ts
+++ b/back/src/adapters/primary/routers/admin/getLastNotifications.e2e.test.ts
@@ -61,6 +61,7 @@ describe(`${adminRoutes.getLastNotifications.url} route`, () => {
           params: {
             agencyName: "Agence du Grand Est",
             agencyLogoUrl: "http://:)",
+            refersToOtherAgency: false,
           },
         },
       };

--- a/back/src/adapters/secondary/InMemoryNotificationRepository.ts
+++ b/back/src/adapters/secondary/InMemoryNotificationRepository.ts
@@ -216,6 +216,7 @@ export const expectNotifyConventionCancelled = (
       agencyLogoUrl: agency.logoUrl,
       dateStart: convention.dateStart,
       dateEnd: convention.dateEnd,
+      justification: convention.statusJustification || "non renseigné",
     },
   });
 };

--- a/back/src/adapters/secondary/notificationGateway/BrevoNotificationGateway.unit.test.ts
+++ b/back/src/adapters/secondary/notificationGateway/BrevoNotificationGateway.unit.test.ts
@@ -113,6 +113,7 @@ describe("SendingBlueHtmlNotificationGateway unit", () => {
         params: {
           agencyName: "AGENCY_NAME",
           agencyLogoUrl: "https://beta.gouv.fr/img/logo_twitter_image-2019.jpg",
+          refersToOtherAgency: false,
         },
       });
 
@@ -190,7 +191,7 @@ describe("SendingBlueHtmlNotificationGateway unit", () => {
       <td>
       <p><strong>Votre structure prescriptrice d'immersion est activée !</strong> 
       <br/>
-      <br/>Nous avons bien activé l'accès à la demande de convention dématérialisée pour des immersions professionnelles pour: AGENCY_NAME. 
+      <br/>Nous avons bien activé l'accès à la demande de convention dématérialisée pour des immersions professionnelles pour: AGENCY_NAME.
       <br/>
       <br/>Merci à vous !</p>
       </td>
@@ -287,6 +288,7 @@ describe("SendingBlueHtmlNotificationGateway unit", () => {
         params: {
           agencyName: "AGENCY_NAME",
           agencyLogoUrl: "https://beta.gouv.fr/img/logo_twitter_image-2019.jpg",
+          refersToOtherAgency: false,
         },
       });
       expectToEqual(sentEmails, []);
@@ -300,6 +302,7 @@ describe("SendingBlueHtmlNotificationGateway unit", () => {
         params: {
           agencyName: "AGENCY_NAME",
           agencyLogoUrl: "https://beta.gouv.fr/img/logo_twitter_image-2019.jpg",
+          refersToOtherAgency: false,
         },
       });
 

--- a/back/src/adapters/secondary/pg/repositories/PgNotificationRepository.integration.test.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgNotificationRepository.integration.test.ts
@@ -27,6 +27,7 @@ const emailNotifications: EmailNotification[] = [
       params: {
         agencyName: "My agency",
         agencyLogoUrl: "http://logo.com",
+        refersToOtherAgency: false,
       },
       attachments: [
         {
@@ -356,7 +357,11 @@ const createTemplatedEmailAndNotification = ({
     recipients,
     sender,
     cc,
-    params: { agencyName: "My agency", agencyLogoUrl: "https://my-logo.com" },
+    params: {
+      agencyName: "My agency",
+      agencyLogoUrl: "https://my-logo.com",
+      refersToOtherAgency: false,
+    },
     attachments,
   };
 

--- a/back/src/domain/convention/useCases/SendEmailWhenAgencyIsActivated.ts
+++ b/back/src/domain/convention/useCases/SendEmailWhenAgencyIsActivated.ts
@@ -23,6 +23,13 @@ export class SendEmailWhenAgencyIsActivated extends TransactionalUseCase<WithAge
     { agency }: WithAgency,
     uow: UnitOfWork,
   ): Promise<void> {
+    const refersToOtherAgencyParams = agency.refersToAgencyId
+      ? {
+          refersToOtherAgency: true as const,
+          validatorEmails: agency.validatorEmails,
+        }
+      : { refersToOtherAgency: false as const };
+
     await this.#saveNotificationAndRelatedEvent(uow, {
       kind: "email",
       templatedContent: {
@@ -31,6 +38,7 @@ export class SendEmailWhenAgencyIsActivated extends TransactionalUseCase<WithAge
         params: {
           agencyName: agency.name,
           agencyLogoUrl: agency.logoUrl,
+          ...refersToOtherAgencyParams,
         },
       },
       followedIds: {

--- a/back/src/domain/convention/useCases/SendEmailWhenAgencyIsActivated.unit.test.ts
+++ b/back/src/domain/convention/useCases/SendEmailWhenAgencyIsActivated.unit.test.ts
@@ -45,6 +45,7 @@ describe("SendEmailWhenAgencyIsActivated", () => {
           params: {
             agencyName: "just-activated-agency",
             agencyLogoUrl: "https://logo.com",
+            refersToOtherAgency: false,
           },
         },
       ],

--- a/back/src/domain/convention/useCases/notifications/NotifyAllActorsThatConventionIsCancelled.ts
+++ b/back/src/domain/convention/useCases/notifications/NotifyAllActorsThatConventionIsCancelled.ts
@@ -51,6 +51,7 @@ export class NotifyAllActorsThatConventionIsCancelled extends TransactionalUseCa
           agencyLogoUrl: agency.logoUrl,
           dateEnd: convention.dateEnd,
           dateStart: convention.dateStart,
+          justification: convention.statusJustification || "non renseigné",
         },
       },
       followedIds: {

--- a/back/src/domain/generic/notifications/useCases/SendNotification.unit.test.ts
+++ b/back/src/domain/generic/notifications/useCases/SendNotification.unit.test.ts
@@ -65,7 +65,11 @@ describe("SendNotification UseCase", () => {
   it("should send an email", async () => {
     const email: TemplatedEmail = {
       kind: "AGENCY_WAS_ACTIVATED",
-      params: { agencyName: "My agency", agencyLogoUrl: undefined },
+      params: {
+        agencyName: "My agency",
+        agencyLogoUrl: undefined,
+        refersToOtherAgency: false,
+      },
       recipients: ["bob@mail.com"],
       cc: [],
       replyTo: {

--- a/front/src/app/contents/standard/politique-de-confidentialite.ts
+++ b/front/src/app/contents/standard/politique-de-confidentialite.ts
@@ -41,11 +41,15 @@ Données relatives au formulaire de demande d’immersion professionnelle:
 
 • Si la personne concernée n’a pas signé de convention d’immersion professionnelle, mais qu’elle avait reçu une réponse positive du prescripteur, durant toute la durée de la recherche d’immersion professionnelle, et <strong>dans un délai de 2 ans après la dernière recherche (durée de conservation)</strong>
 
-• Si la personne concernée n’a pas signé de convention d’immersion professionnelle, mais qu’elle avait reçu une réponse négative du prescripteur, <strong>dans un délai de 2 ans à compter du refus (durée de conservation)</strong> de la demande d’immersion professionnelle. 
+• Si la personne concernée n’a pas signé de convention d’immersion professionnelle, mais qu’elle avait reçu une réponse négative du prescripteur, <strong>dans un délai de 2 ans à compter du refus (durée de conservation)</strong> de la demande d’immersion professionnelle.
+
 
 Données relatives aux représentants des entreprises structures d’accueil de l’immersion, signataires de la convention y compris les tuteurs ou tutrices des structures d’accueil d’immersion:
 
 • <strong>Jusqu’à la fin du contrat du tuteur ou de la tutrice avec la structure d’immersion professionnelle</strong> ou le cas échéant, jusqu’à la dissolution de la structure, dès lors qu’Immersion Facilitée en prend connaissance.
+
+Données de suivi des statistiques des échanges lors des mises en relation :
+• Les données sont automatiquement supprimées 6 mois après leur collecte.
 
 <strong>Quels sont vos droits ?</strong>
 

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -223,6 +223,8 @@ export const defaultEmailValueByEmailKind: {
   AGENCY_WAS_ACTIVATED: {
     agencyName: "AGENCY_NAME",
     agencyLogoUrl: defaultEmailPreviewUrl,
+    refersToOtherAgency: true,
+    validatorEmails: ["VALIDATOR_EMAIL1", "VALIDATOR_EMAIL2"],
   },
   BENEFICIARY_ASSESSMENT_NOTIFICATION: {
     conventionId: "CONVENTION_ID",

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -258,6 +258,7 @@ export const defaultEmailValueByEmailKind: {
     signature: "SIGNATURE",
     dateStart: "DATE_START",
     dateEnd: "DATE_END",
+    justification: "JUSTIFICATION",
   },
   CONTACT_BY_EMAIL_REQUEST: {
     replyToEmail: "REPLY_TO_EMAIL",

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -30,7 +30,13 @@ export type EmailParamsByEmailType = {
   AGENCY_WAS_ACTIVATED: {
     agencyName: string;
     agencyLogoUrl: AbsoluteUrl | undefined;
-  };
+  } & (
+    | { refersToOtherAgency: false }
+    | {
+        refersToOtherAgency: true;
+        validatorEmails: string[];
+      }
+  );
   AGENCY_WAS_REJECTED: {
     agencyName: string;
     rejectionJustification: string;

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -69,6 +69,7 @@ export type EmailParamsByEmailType = {
     signature: string;
     dateEnd: string;
     dateStart: string;
+    justification: string;
   };
   CONTACT_BY_EMAIL_REQUEST: {
     businessName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1100,13 +1100,19 @@ export const emailTemplatesByName =
     AGENCY_WAS_ACTIVATED: {
       niceName: "Agence - Activée",
       tags: ["activation prescripteur"],
-      createEmailVariables: ({ agencyLogoUrl, agencyName }) => ({
+      createEmailVariables: ({ agencyLogoUrl, agencyName, ...rest }) => ({
         subject: `Immersion Facilitée - Votre structure a été activée`,
         greetings: "Bonjour,",
         content: `<strong>Votre structure prescriptrice d'immersion est activée !</strong> 
 
-        Nous avons bien activé l'accès à la demande de convention dématérialisée pour des immersions professionnelles pour: ${agencyName}. 
-        
+        Nous avons bien activé l'accès à la demande de convention dématérialisée pour des immersions professionnelles pour: ${agencyName}.
+        ${
+          rest.refersToOtherAgency
+            ? `Les demandes de convention pour les personnes que vous accompagnées seront examinées en première étape par vous puis validées par ${rest.validatorEmails.join(
+                ", ",
+              )}.\n`
+            : ""
+        }  
         Merci à vous !`,
         agencyLogoUrl,
         subContent: defaultSignature("immersion"),

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -838,6 +838,7 @@ export const emailTemplatesByName =
         signature,
         dateEnd,
         dateStart,
+        justification,
       }) => ({
         subject:
           internshipKind === "immersion"
@@ -859,7 +860,9 @@ export const emailTemplatesByName =
             : "DATE INVALIDE"
         } a été annulée par ${agencyName}.
       
-      Cette demande de convention était devenue obsolète car une autre demande a déjà été traitée.
+      La demande a été annulée pour la raison suivante :
+      
+      ${justification}
       
       Vous pouvez vous rapprocher de votre conseiller${
         internshipKind === "immersion"


### PR DESCRIPTION
- make it impossible to create a duplicate of agency, regadless of the status. And add playwright tests
- fix email convention was canceled, to include justification
