### PR TITLE
Renommer Pôle emploi par France Travail

### DIFF
--- a/back/src/adapters/secondary/InMemoryConventionPoleEmploiAdvisorRepository.ts
+++ b/back/src/adapters/secondary/InMemoryConventionPoleEmploiAdvisorRepository.ts
@@ -73,7 +73,7 @@ export class InMemoryConventionPoleEmploiAdvisorRepository
         .find(isOpenEntity);
     if (entity) return entity;
     throw new NotFoundError(
-      "There is no open pole emploi advisor entity linked to this OAuth peExternalId",
+      "There is no open France Travail advisor entity linked to this OAuth peExternalId",
     );
   }
 

--- a/back/src/adapters/secondary/PeConnectGateway/peConnectApi.error.ts
+++ b/back/src/adapters/secondary/PeConnectGateway/peConnectApi.error.ts
@@ -27,14 +27,14 @@ export const peConnectErrorStrategy = (
     [
       isHttpClientError4XX(error),
       makeRawRedirectError(
-        "Une erreur est survenue lors de la connexion aux service pole emploi",
+        "Une erreur est survenue lors de la connexion aux services France Travail",
         error,
       ),
     ],
     [
       isHttpServerError5XX(error),
       makeRawRedirectError(
-        "Une erreur est survenue lors de la connexion aux service pole emploi",
+        "Une erreur est survenue lors de la connexion aux services France Travail",
         error,
       ),
     ],
@@ -43,7 +43,7 @@ export const peConnectErrorStrategy = (
     [
       error instanceof ConnectionRefusedError,
       makeRawRedirectError(
-        "Le serveur distant pôle emploi refuse la connexion.",
+        "Le serveur distant de France Travail refuse la connexion.",
         error,
       ),
     ],

--- a/back/src/adapters/secondary/PeConnectGateway/peConnectApi.schema.ts
+++ b/back/src/adapters/secondary/PeConnectGateway/peConnectApi.schema.ts
@@ -17,7 +17,7 @@ export const externalPeConnectUserSchema: z.Schema<ExternalPeConnectUser> =
   z.object({
     email: z
       .string()
-      .email("L'addresse email pole emploi doit être remplie valide")
+      .email("L'addresse email France Travail doit être remplie valide")
       .optional(),
     family_name: zTrimmedString,
     gender: z.enum(["male", "female"]),

--- a/back/src/adapters/secondary/notificationGateway/BrevoNotificationGateway.unit.test.ts
+++ b/back/src/adapters/secondary/notificationGateway/BrevoNotificationGateway.unit.test.ts
@@ -228,9 +228,8 @@ describe("SendingBlueHtmlNotificationGateway unit", () => {
       <tr>
       <td align="center" style="padding: 20px;">
       <img 
-      src="https://immersion.cellar-c2.services.clever-cloud.com/d0cfdb84-881a-40d5-b228-7e14c185fb68.png" 
-      alt="" 
-      width="290" />
+      src="https://immersion.cellar-c2.services.clever-cloud.com/email_footer.png" 
+      alt=""/>
       </td>
       </tr>
       </table>

--- a/back/src/domain/peConnect/useCases/NotifyPoleEmploiUserAdvisorOnConventionFullySigned.unit.test.ts
+++ b/back/src/domain/peConnect/useCases/NotifyPoleEmploiUserAdvisorOnConventionFullySigned.unit.test.ts
@@ -50,7 +50,7 @@ describe("NotifyPoleEmploiUserAdvisorOnConventionFullySigned", () => {
     );
   });
 
-  it("should resolve to undefined if the convention pole emploi OAuth advisor is not found", async () => {
+  it("should resolve to undefined if the convention France Travail OAuth advisor is not found", async () => {
     const conventionDtoFromEvent: ConventionDto = new ConventionDtoBuilder()
       .withId("add5c20e-6dd2-45af-affe-927358005251")
       .withFederatedIdentity({ provider: "peConnect", token: "blop" })

--- a/front/src/app/components/InitiateConventionSection.tsx
+++ b/front/src/app/components/InitiateConventionSection.tsx
@@ -25,7 +25,7 @@ export const InitiateConventionSection = ({
           desc={
             <>
               Je suis <strong>une entreprise</strong>,{" "}
-              <strong>un candidat</strong> sans identifiants Pôle emploi,{" "}
+              <strong>un candidat</strong> sans identifiants France Travail,{" "}
               <strong>un conseiller accompagnant un candidat</strong>.
             </>
           }
@@ -37,7 +37,7 @@ export const InitiateConventionSection = ({
             id: domElementIds.conventionImmersionRoute.showFormButton,
           }}
           size="medium"
-          title="Je remplis une convention sans identifiants Pôle emploi"
+          title="Je remplis une convention sans identifiants France Travail (anciennement Pôle emploi)"
           titleAs="h2"
         />
       </div>
@@ -48,8 +48,8 @@ export const InitiateConventionSection = ({
           border
           desc={
             <>
-              Je suis <strong>un candidat inscrit à Pôle emploi</strong>. Je me
-              connecte avec Pôle emploi pour accélérer les démarches.
+              Je suis <strong>un candidat inscrit à France Travail</strong>. Je
+              me connecte avec France Travail pour accélérer les démarches.
             </>
           }
           enlargeLink
@@ -59,7 +59,7 @@ export const InitiateConventionSection = ({
             href: `/api/${loginPeConnect}`,
           }}
           size="medium"
-          title="Je remplis une convention avec mes identifiants Pôle emploi"
+          title="Je remplis une convention avec mes identifiants France Travail (anciennement Pôle emploi)"
           titleAs="h2"
         />
       </div>

--- a/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
+++ b/front/src/app/components/forms/agency/AgencyFormCommonFields.tsx
@@ -192,8 +192,8 @@ export const AgencyFormCommonFields = ({
 
 const agencyErrorMessage = (
   <span>
-    Attention, toutes les agences Pôle emploi ont déjà été ajoutées par notre
-    équipe sur Immersion.{" "}
+    Attention, toutes les agences France Travail ont déjà été ajoutées par notre
+    équipe sur Immersion Facilitée.{" "}
     <LinkHome {...routes.agencyDashboard().link}>
       Accéder à votre espace prescripteur.
     </LinkHome>

--- a/front/src/app/components/forms/commons/AgencySelector.tsx
+++ b/front/src/app/components/forms/commons/AgencySelector.tsx
@@ -223,7 +223,7 @@ export const AgencySelector = ({
           label={agencyKindField.label}
           hint={
             shouldLockToPeAgencies
-              ? "Cette convention a été initié par un utilisateur connecté via PE Connect, vous ne pouvez choisir qu'une agence de rattachement de type Pole emploi"
+              ? "Cette convention a été initié par un utilisateur connecté via PE Connect, vous ne pouvez choisir qu'une agence de rattachement de type France Travail (anciennement Pôle emploi)"
               : agencyKindField.hintText
           }
           options={agencyKindOptions}

--- a/front/src/app/contents/error/textSetup.tsx
+++ b/front/src/app/contents/error/textSetup.tsx
@@ -21,7 +21,8 @@ export const contentsMapper = (
 ): Record<ManagedErrorKind, HTTPFrontErrorContents> => ({
   peConnectConnectionAborted: {
     overtitle: peConnectErrorKind,
-    title: "La connexion à Pôle Emploi Connect a été interrompue.",
+    title:
+      "La connexion à France Travail (anciennement Pôle emploi) Connect a été interrompue.",
     subtitle: "Veuillez réessayer.",
     description: ``,
     buttons: [redirectToHomePageButtonContent, contactUsButtonContent],
@@ -39,7 +40,7 @@ export const contentsMapper = (
     overtitle: peConnectErrorKind,
     title: "Impossible d'identifier votre conseiller référent",
     subtitle:
-      "Les données retournées par Pôle Emploi ne permettent pas d'identifier le conseiller référent qui vous est dédié.",
+      "Les données retournées par France Travail (anciennement Pôle emploi) ne permettent pas d'identifier le conseiller référent qui vous est dédié.",
     description: ``,
     buttons: [
       redirectToConventionWithoutIdentityProvider(
@@ -53,7 +54,7 @@ export const contentsMapper = (
     title:
       "Les données retournées par Pôle Emploi Connect ne permettent pas de vous identifier.",
     subtitle:
-      "Les données retournées par Pôle Emploi ne permettent pas de vous identifier.",
+      "Les données retournées par France Travail (anciennement Pôle emploi) ne permettent pas de vous identifier.",
     description: ``,
     buttons: [
       redirectToConventionWithoutIdentityProvider(
@@ -66,7 +67,7 @@ export const contentsMapper = (
     overtitle: peConnectErrorKind,
     title: "Pôle Emploi Connect - Identifiants invalides",
     subtitle:
-      "Le code d'autorisation retourné par Pôle Emploi ne permet pas d'avoir accès aux droits nécessaires pour lier votre compte.",
+      "Le code d'autorisation retourné par France Travail (anciennement Pôle emploi) ne permet pas d'avoir accès aux droits nécessaires pour lier votre compte.",
     description: ``,
     buttons: [
       redirectToConventionWithoutIdentityProvider(
@@ -159,7 +160,7 @@ const redirectToConventionWithoutIdentityProvider = (
 ): ErrorButton => ({
   kind: "primary",
   label:
-    "Vous pouvez quand même remplir votre demande de convention en indiquant l'agence Pole Emploi à laquelle vous êtes rattaché ici.",
+    "Vous pouvez quand même remplir votre demande de convention en indiquant l'agence France Travail à laquelle vous êtes rattaché ici.",
   onClick,
 });
 const contactUsButtonContent: ErrorButton = {
@@ -170,4 +171,4 @@ const contactUsButtonContent: ErrorButton = {
 };
 const httpClientErrorKind = "Erreur Http Client";
 const peConnectErrorKind = "Erreur Pôle Emploi Connect";
-const peTechnicalTeamForwardDescription = `Nous travaillons activement à la résolution de ce problème avec le service technique Pôle Emploi.`;
+const peTechnicalTeamForwardDescription = `Nous travaillons activement à la résolution de ce problème avec le service technique France Travail (anciennement Pôle emploi).`;

--- a/front/src/app/contents/home/content.ts
+++ b/front/src/app/contents/home/content.ts
@@ -198,7 +198,7 @@ export const sectionStatsData: Record<UserType, Stat[]> = {
       value: "7",
       subtitle: "demandeurs d’emploi sur 10",
       description:
-        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude Pôle emploi en 2021.",
+        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude France Travail (anciennement Pôle emploi) en 2021.",
     },
   ],
   candidate: [
@@ -219,7 +219,7 @@ export const sectionStatsData: Record<UserType, Stat[]> = {
       value: "7",
       subtitle: "demandeurs d’emploi sur 10",
       description:
-        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude Pôle emploi en 2021.",
+        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude France Travail (anciennement Pôle emploi) en 2021.",
     },
   ],
   establishment: [
@@ -240,7 +240,7 @@ export const sectionStatsData: Record<UserType, Stat[]> = {
       value: "95%",
       subtitle: "",
       description:
-        "des entreprises qui bénéficient du dispositif le recommandent, selon une étude publiée en mars 2021 par Pôle emploi",
+        "des entreprises qui bénéficient du dispositif le recommandent, selon une étude publiée en mars 2021 par France Travail (anciennement Pôle emploi).",
     },
   ],
   agency: [
@@ -261,7 +261,7 @@ export const sectionStatsData: Record<UserType, Stat[]> = {
       value: "7",
       subtitle: "demandeurs d’emploi sur 10",
       description:
-        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude Pôle emploi en 2021.",
+        "trouvent un emploi dans les mois qui suivent leur immersion, selon une étude France Travail (anciennement Pôle emploi) en 2021.",
     },
   ],
 };
@@ -287,7 +287,7 @@ export const sectionFaqData: Record<UserType, FaqCardProps[]> = {
   candidate: [
     {
       title: "Qui peut bénéficier d'une Immersion Professionnelle (PMSMP) ?",
-      description: `S’inscrivant dans une démarche préventive (bénéficiaire salarié en recherche d’emploi ou de réorientation professionnelle) et proactive (bénéficiaire privé d’emploi, inscrit ou non auprès de Pôle emploi), les périodes...`,
+      description: `S’inscrivant dans une démarche préventive (bénéficiaire salarié en recherche d’emploi ou de réorientation professionnelle) et proactive (bénéficiaire privé d’emploi, inscrit ou non auprès de France Travail, anciennement Pôle emploi), les périodes...`,
       url: "https://aide.immersion-facile.beta.gouv.fr/fr/article/qui-peut-beneficier-dune-immersion-professionnelle-pmsmp-jz1af4/",
     },
     {

--- a/front/src/app/contents/standard/politique-de-confidentialite.ts
+++ b/front/src/app/contents/standard/politique-de-confidentialite.ts
@@ -24,7 +24,7 @@ La plateforme Immersion Facilitée peut traiter les données à caractère perso
 
 • Données relatives aux représentants des entreprises structures d’accueil de l’immersion, signataires de la convention y compris les tuteurs ou tutrices des structures d’accueil d’immersion (nom, prénom, fonctions, adresse e-mail, téléphone professionnel). Ces données sont susceptibles d'être partagées avec la « Mission interministérielle pour l’apprentissage » et le Groupement d’Intérêt Public « Les Entreprises s’engagent » à des fins de proposition de recueil d’offres de recrutement en alternance ou d’actions pour renforcer l’inclusion dans les entreprises ;
 
-• Données d’identification Pôle Emploi (nom, date de naissance).
+• Données d’identification France Travail, anciennement Pôle emploi (nom, date de naissance).
 
 <strong>Qu’est-ce qui nous autorise à traiter ces données ?</strong>
 
@@ -82,14 +82,14 @@ Le responsable de traitement s’engage à ce que les données à caractères pe
 Les organismes prescripteurs ont accès aux seules données de leurs dossiers lorsqu’ils utilisent « Immersion Facilitée ».
 
 Ces derniers sont :
-• Pôle emploi ;
+• France Travail (anciennement Pôle emploi) ;
 • Les missions locales ;
 • Les Cap Emploi ;
 • Les structures d’insertion par l’activité économique (SIAE), à l’exception des ETTI ;
 • Les Conseils départementaux ;
 • Les organismes de « Prépa Apprentissage » ;
 • Inclusion Connect ;
-• Des prescripteurs mandatés à cet effet par un prescripteur de plein droit : organismes employant ou accompagnant des personnes éligibles aux PMSMP et liés soit à Pôle emploi, soit à une mission locale, soit à un Cap Emploi, par une convention les autorisant à prescrire des PMSMP sur un périmètre donné ;
+• Des prescripteurs mandatés à cet effet par un prescripteur de plein droit : organismes employant ou accompagnant des personnes éligibles aux PMSMP et liés soit à France Travail (anciennement Pôle emploi), soit à une mission locale, soit à un Cap Emploi, par une convention les autorisant à prescrire des PMSMP sur un périmètre donné ;
 • La Mission interministérielle pour l’apprentissage ;
 • Le Groupement d’intérêt public « Les Entreprises s’engagent ».
 

--- a/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
+++ b/front/src/app/pages/agencyDashboard/MarkPartnersErroredConventionAsHandledFormSection.tsx
@@ -55,7 +55,7 @@ export const MarkPartnersErroredConventionAsHandledFormSection = ({
             />
           </div>
           <Button
-            title="Marquer la convention comme saisie dans les applicatifs PE"
+            title="Marquer la convention comme saisie dans les applicatifs France Travail"
             disabled={!formState.isValid}
             className={fr.cx("fr-mt-2w")}
           >

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -303,7 +303,8 @@ export const ConventionDocumentPage = ({
               "peConnect" &&
               convention.signatories.beneficiary.federatedIdentity?.payload && (
                 <li>
-                  conseiller Pôle emploi référent :{" "}
+                  conseiller France Travail (anciennement Pôle emploi) référent
+                  :{" "}
                   <strong>
                     {
                       convention.signatories.beneficiary.federatedIdentity

--- a/front/src/app/pages/search/SearchResultPage.tsx
+++ b/front/src/app/pages/search/SearchResultPage.tsx
@@ -367,9 +367,9 @@ export const SearchResultPage = () => {
                         <p className={fr.cx("fr-mb-2w")}>
                           C’est un stage d’observation, strictement encadré d’un
                           point de vue juridique. Vous conservez votre statut et
-                          êtes couvert par votre Pôle emploi,votre Mission
-                          Locale ou le Conseil départemental (en fonction de
-                          votre situation).
+                          êtes couvert par votre France Travail (anciennement
+                          Pôle emploi), votre Mission Locale ou le Conseil
+                          départemental (en fonction de votre situation).
                         </p>
                         <p className={fr.cx("fr-mb-2w")}>
                           Le rôle de celui qui vous accueillera est de vous

--- a/libs/html-templates/src/components/email/footer.ts
+++ b/libs/html-templates/src/components/email/footer.ts
@@ -12,7 +12,7 @@ const defaultImmersionFooter = () => `<table>
   </tr>
   <tr>
     <td align="center" style="padding: 20px;">
-      <img src="https://immersion.cellar-c2.services.clever-cloud.com/d0cfdb84-881a-40d5-b228-7e14c185fb68.png" alt="" width="290" />
+      <img src="https://immersion.cellar-c2.services.clever-cloud.com/email_footer.png" alt=""/>
     </td>
   </tr>
 </table>`;
@@ -28,7 +28,7 @@ export const cciCustomHtmlFooter = () => `<table>
   </tr>
   <tr>
     <td align="center" style="padding: 20px;">
-      <img src="https://immersion.cellar-c2.services.clever-cloud.com/logo-cci-blanc.png" width="899" height="173" alt="Chambre de Commerce et d'Industrie" style="max-width: 350px; max-height: 120px; height: auto;"/>
+      <img src="https://immersion.cellar-c2.services.clever-cloud.com/logo-cci-blanc.png" alt="Chambre de Commerce et d'Industrie"/>
     </td>
   </tr>
 </table>`;

--- a/libs/react-design-system/src/immersionFacile/components/pe-connect-button/PeConnectButton.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/pe-connect-button/PeConnectButton.tsx
@@ -19,9 +19,9 @@ export const PeConnectButton = ({
         onClick={onClick}
         href={`/api/${peConnectEndpoint}`}
         className={cx("pe-connect__button")}
-        title="Se connecter avec Pôle emploi"
+        title="Se connecter avec France Travail (anciennement Pôle emploi)"
       >
-        Se connecter avec Pôle emploi
+        Se connecter avec France Travail (anciennement Pôle emploi)
       </a>
     </div>
   );

--- a/libs/react-design-system/src/immersionFacile/components/section-accordion/SectionAccordion.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/section-accordion/SectionAccordion.tsx
@@ -54,8 +54,9 @@ export const SectionAccordion = () => {
               <li>
                 C’est un stage d’observation, strictement encadré d’un point de
                 vue juridique. Vous conservez votre statut et êtes couvert par
-                votre Pôle emploi, votre Mission Locale ou le Conseil
-                départemental (en fonction de votre situation).
+                votre France Travail (anciennement Pôle emploi), votre Mission
+                Locale ou le Conseil départemental (en fonction de votre
+                situation).
               </li>
               <li>
                 Le rôle de celui qui vous accueillera est de vous présenter le

--- a/libs/react-design-system/src/immersionFacile/components/section-text-embed/SectionTextEmbed.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/section-text-embed/SectionTextEmbed.tsx
@@ -42,7 +42,7 @@ export const SectionTextEmbed = ({
         </li>
         <li className={`${componentName}__item`}>
           <strong>Vous conservez votre statut initial</strong> et restez couvert
-          par un prescripteur (Pôle emploi, Cap Emploi, Mission Locale, etc.)
+          par un prescripteur (France Travail, Cap Emploi, Mission Locale, etc.)
           grâce à la signature d’une convention.
         </li>
         <li className={`${componentName}__item`}>

--- a/shared/src/agency/agency.dto.ts
+++ b/shared/src/agency/agency.dto.ts
@@ -70,7 +70,7 @@ export type AllowedAgencyKindToAdd = Exclude<AgencyKind, "immersion-facile">;
 
 export const agencyKindToLabel: Record<AllowedAgencyKindToAdd, string> = {
   "mission-locale": "Mission Locale",
-  "pole-emploi": "Pôle Emploi",
+  "pole-emploi": "France Travail (anciennement Pôle emploi)",
   "cap-emploi": "Cap Emploi",
   "conseil-departemental": "Conseil Départemental",
   "prepa-apprentissage": "Prépa Apprentissage",

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -134,7 +134,7 @@ export const emailTemplatesByName =
     },
     POLE_EMPLOI_ADVISOR_ON_CONVENTION_ASSOCIATION: {
       niceName:
-        "Convention - Nouvelle convention à traiter par le conseiller PE lié",
+        "Convention - Nouvelle convention à traiter par le conseiller France Travail lié",
       tags: [],
       createEmailVariables: ({
         advisorFirstName,
@@ -309,7 +309,7 @@ export const emailTemplatesByName =
     },
     POLE_EMPLOI_ADVISOR_ON_CONVENTION_FULLY_SIGNED: {
       niceName:
-        "Convention - Entièrement signée à traiter par le conseiller PE lié",
+        "Convention - Entièrement signée à traiter par le conseiller France Travail lié",
       tags: ["immersion à étudier (mail conseiller)"],
       createEmailVariables: ({
         advisorFirstName,


### PR DESCRIPTION
## Remarques

- Pôle Emploi Connect a gardé le même nom