### PR TITLE
Désabonnement relance entreprise pour devenir accueillante (partie 3)

### DIFF
--- a/back/src/adapters/primary/config/createUseCases.ts
+++ b/back/src/adapters/primary/config/createUseCases.ts
@@ -92,6 +92,7 @@ import { GetOffersByGroupSlug } from "../../../domain/offer/useCases/GetGroupByS
 import { GetSearchResultBySiretAndAppellationCode } from "../../../domain/offer/useCases/GetSearchResultBySiretAndAppellationCode";
 import { InsertEstablishmentAggregateFromForm } from "../../../domain/offer/useCases/InsertEstablishmentAggregateFromFormEstablishement";
 import { MarkEstablishmentLeadAsRegistrationAccepted } from "../../../domain/offer/useCases/MarkEstablishmentLeadAsRegistrationAccepted";
+import { MarkEstablishmentLeadAsRegistrationRejected } from "../../../domain/offer/useCases/MarkEstablishmentLeadAsRegistrationRejected";
 import { NotifyConfirmationEstablishmentCreated } from "../../../domain/offer/useCases/notifications/NotifyConfirmationEstablishmentCreated";
 import { NotifyContactRequest } from "../../../domain/offer/useCases/notifications/NotifyContactRequest";
 import { NotifyPassEmploiOnNewEstablishmentAggregateInsertedFromForm } from "../../../domain/offer/useCases/notifications/NotifyPassEmploiOnNewEstablishmentAggregateInsertedFromForm";
@@ -328,6 +329,11 @@ export const createUseCases = (
       ),
       markEstablishmentLeadAsRegistrationAccepted:
         new MarkEstablishmentLeadAsRegistrationAccepted(
+          uowPerformer,
+          gateways.timeGateway,
+        ),
+      markEstablishmentLeadAsRegistrationRejected:
+        new MarkEstablishmentLeadAsRegistrationRejected(
           uowPerformer,
           gateways.timeGateway,
         ),

--- a/back/src/adapters/primary/routers/establishment/createEstablishmentRouter.ts
+++ b/back/src/adapters/primary/routers/establishment/createEstablishmentRouter.ts
@@ -76,6 +76,17 @@ export const createEstablishmentRouter = (deps: AppDependencies) => {
       ),
   );
 
+  establishmentSharedRouter.unregisterEstablishmentLead(
+    deps.conventionMagicLinkAuthMiddleware,
+    async (req, res) =>
+      sendHttpResponse(req, res.status(200), () =>
+        deps.useCases.markEstablishmentLeadAsRegistrationRejected.execute(
+          undefined,
+          req.payloads?.convention,
+        ),
+      ),
+  );
+
   return establishmentRouter;
 };
 

--- a/back/src/adapters/primary/routers/establishment/unregisterEstablishmentLead.e2e.test.ts
+++ b/back/src/adapters/primary/routers/establishment/unregisterEstablishmentLead.e2e.test.ts
@@ -1,0 +1,87 @@
+import { subDays } from "date-fns";
+import { SuperTest, Test } from "supertest";
+import {
+  ConventionDtoBuilder,
+  ConventionJwt,
+  createConventionMagicLinkPayload,
+  displayRouteName,
+  EstablishmentRoutes,
+  establishmentRoutes,
+  expectHttpResponseToEqual,
+} from "shared";
+import { HttpClient } from "shared-routes";
+import { createSupertestSharedClient } from "shared-routes/supertest";
+import { GenerateConventionJwt } from "../../../../domain/auth/jwt";
+import { EstablishmentLead } from "../../../../domain/offer/entities/EstablishmentLeadEntity";
+import { buildTestApp } from "../../../../utils/buildTestApp";
+import {
+  authorizedUnJeuneUneSolutionApiConsumer,
+  outdatedApiConsumer,
+  unauthorizedApiConsumer,
+} from "../../../secondary/InMemoryApiConsumerRepository";
+import { InMemoryUnitOfWork } from "../../config/uowConfig";
+
+const convention = new ConventionDtoBuilder().build();
+const alreadySavedLead: EstablishmentLead = {
+  siret: convention.siret,
+  lastEventKind: "reminder-sent",
+  events: [
+    {
+      conventionId: convention.id,
+      kind: "to-be-reminded",
+      occurredAt: subDays(new Date(), 2),
+    },
+    {
+      kind: "reminder-sent",
+      occurredAt: new Date(),
+      notification: { id: "my-fake-notification-id", kind: "email" },
+    },
+  ],
+};
+
+describe("Unregister establishment lead", () => {
+  let request: SuperTest<Test>;
+  let httpClient: HttpClient<EstablishmentRoutes>;
+  let inMemoryUow: InMemoryUnitOfWork;
+  let generateConventionJwt: GenerateConventionJwt;
+  let conventionJwt: ConventionJwt;
+
+  beforeEach(async () => {
+    ({ request, inMemoryUow, generateConventionJwt } = await buildTestApp());
+    httpClient = createSupertestSharedClient(establishmentRoutes, request);
+    inMemoryUow.apiConsumerRepository.consumers = [
+      authorizedUnJeuneUneSolutionApiConsumer,
+      unauthorizedApiConsumer,
+      outdatedApiConsumer,
+    ];
+    inMemoryUow.conventionRepository.setConventions([convention]);
+    inMemoryUow.establishmentLeadRepository.establishmentLeads = [
+      alreadySavedLead,
+    ];
+
+    conventionJwt = generateConventionJwt(
+      createConventionMagicLinkPayload({
+        id: convention.id,
+        role: "establishment-representative",
+        email: convention.signatories.establishmentRepresentative.email,
+        now: new Date(),
+      }),
+    );
+  });
+
+  describe(`${displayRouteName(
+    establishmentRoutes.unregisterEstablishmentLead,
+  )}`, () => {
+    it("200 - Success", async () => {
+      const response = await httpClient.unregisterEstablishmentLead({
+        headers: { authorization: conventionJwt },
+        body: {},
+      });
+
+      expectHttpResponseToEqual(response, {
+        body: "",
+        status: 200,
+      });
+    });
+  });
+});

--- a/back/src/domain/offer/useCases/MarkEstablishmentLeadAsRegistrationRejected.ts
+++ b/back/src/domain/offer/useCases/MarkEstablishmentLeadAsRegistrationRejected.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { ConventionJwtPayload } from "shared";
+import { NotFoundError } from "../../../adapters/primary/helpers/httpErrors";
+import { TimeGateway } from "../../core/ports/TimeGateway";
+import { UnitOfWork, UnitOfWorkPerformer } from "../../core/ports/UnitOfWork";
+import { TransactionalUseCase } from "../../core/UseCase";
+import { EstablishmentLead } from "../entities/EstablishmentLeadEntity";
+
+export class MarkEstablishmentLeadAsRegistrationRejected extends TransactionalUseCase<
+  void,
+  void,
+  ConventionJwtPayload
+> {
+  protected inputSchema = z.void();
+
+  #timeGateway: TimeGateway;
+
+  constructor(uowPerformer: UnitOfWorkPerformer, timeGateway: TimeGateway) {
+    super(uowPerformer);
+    this.#timeGateway = timeGateway;
+  }
+
+  public async _execute(
+    _: void,
+    uow: UnitOfWork,
+    jwtPayload: ConventionJwtPayload,
+  ): Promise<void> {
+    const convention = await uow.conventionRepository.getById(
+      jwtPayload.applicationId,
+    );
+
+    if (!convention)
+      throw new NotFoundError(
+        `No convention were found with id ${jwtPayload.applicationId}`,
+      );
+
+    const establishmentLead = await uow.establishmentLeadRepository.getBySiret(
+      convention.siret,
+    );
+
+    if (!establishmentLead)
+      throw new NotFoundError(
+        `No establishment lead were found with siret ${convention.siret}`,
+      );
+
+    const { siret, events } = establishmentLead;
+    const updatedEstablishmentLead: EstablishmentLead = {
+      siret,
+      lastEventKind: "registration-refused",
+      events: [
+        ...events,
+        { kind: "registration-refused", occurredAt: this.#timeGateway.now() },
+      ],
+    };
+
+    await uow.establishmentLeadRepository.save(updatedEstablishmentLead);
+  }
+}

--- a/back/src/domain/offer/useCases/MarkEstablishmentLeadAsRegistrationRejected.unit.test.ts
+++ b/back/src/domain/offer/useCases/MarkEstablishmentLeadAsRegistrationRejected.unit.test.ts
@@ -1,0 +1,98 @@
+import { subDays } from "date-fns";
+import {
+  ConventionDtoBuilder,
+  ConventionJwtPayload,
+  createConventionMagicLinkPayload,
+  expectPromiseToFailWithError,
+  expectToEqual,
+} from "shared";
+import {
+  createInMemoryUow,
+  InMemoryUnitOfWork,
+} from "../../../adapters/primary/config/uowConfig";
+import { NotFoundError } from "../../../adapters/primary/helpers/httpErrors";
+import { CustomTimeGateway } from "../../../adapters/secondary/core/TimeGateway/CustomTimeGateway";
+import { InMemoryUowPerformer } from "../../../adapters/secondary/InMemoryUowPerformer";
+import { EstablishmentLead } from "../entities/EstablishmentLeadEntity";
+import { MarkEstablishmentLeadAsRegistrationRejected } from "./MarkEstablishmentLeadAsRegistrationRejected";
+
+const convention = new ConventionDtoBuilder().build();
+
+describe("MarkEstablishmentLeadAsRegistrationRejected", () => {
+  let uow: InMemoryUnitOfWork;
+  let usecase: MarkEstablishmentLeadAsRegistrationRejected;
+  let timeGateway: CustomTimeGateway;
+  let conventionJwt: ConventionJwtPayload;
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
+
+    usecase = new MarkEstablishmentLeadAsRegistrationRejected(
+      new InMemoryUowPerformer(uow),
+      timeGateway,
+    );
+
+    conventionJwt = createConventionMagicLinkPayload({
+      id: convention.id,
+      role: "establishment-representative",
+      email: convention.signatories.establishmentRepresentative.email,
+      now: timeGateway.now(),
+    });
+  });
+
+  it("throw not found error when convention not found", async () => {
+    await expectPromiseToFailWithError(
+      usecase.execute(undefined, conventionJwt),
+      new NotFoundError(`No convention were found with id ${convention.id}`),
+    );
+  });
+
+  it("throw not found error when establishment lead not found", async () => {
+    uow.conventionRepository.setConventions([convention]);
+
+    await expectPromiseToFailWithError(
+      usecase.execute(undefined, conventionJwt),
+      new NotFoundError(
+        `No establishment lead were found with siret ${convention.siret}`,
+      ),
+    );
+  });
+
+  it("update establishmentLead's kind", async () => {
+    const alreadySavedLead: EstablishmentLead = {
+      siret: convention.siret,
+      lastEventKind: "reminder-sent",
+      events: [
+        {
+          conventionId: convention.id,
+          kind: "to-be-reminded",
+          occurredAt: subDays(new Date(), 2),
+        },
+        {
+          kind: "reminder-sent",
+          occurredAt: new Date(),
+          notification: { id: "my-fake-notification-id", kind: "email" },
+        },
+      ],
+    };
+    uow.conventionRepository.setConventions([convention]);
+    uow.establishmentLeadRepository.establishmentLeads = [alreadySavedLead];
+
+    await usecase.execute(undefined, conventionJwt);
+
+    expectToEqual(uow.establishmentLeadRepository.establishmentLeads, [
+      {
+        ...alreadySavedLead,
+        lastEventKind: "registration-refused",
+        events: [
+          ...alreadySavedLead.events,
+          {
+            kind: "registration-refused",
+            occurredAt: timeGateway.now(),
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/shared/src/routes/establishementRoutes.ts
+++ b/shared/src/routes/establishementRoutes.ts
@@ -68,6 +68,9 @@ export const establishmentRoutes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       200: expressEmptyResponseBody,
+      400: httpErrorSchema,
+      401: legacyUnauthenticatedErrorSchema,
+      403: renewMagicLinkResponseSchema,
       404: httpErrorSchema,
     },
   }),

--- a/shared/src/routes/establishementRoutes.ts
+++ b/shared/src/routes/establishementRoutes.ts
@@ -9,13 +9,11 @@ import {
 } from "../httpClient/httpErrors.schema";
 import { emptyObjectSchema, expressEmptyResponseBody } from "../zodUtils";
 
-const formEstablishmentsUrl = "/form-establishments";
-
 export type EstablishmentRoutes = typeof establishmentRoutes;
 export const establishmentRoutes = defineRoutes({
   addFormEstablishment: defineRoute({
     method: "post",
-    url: formEstablishmentsUrl,
+    url: "/form-establishments",
     requestBodySchema: formEstablishmentSchema,
     responses: {
       200: expressEmptyResponseBody,
@@ -23,7 +21,7 @@ export const establishmentRoutes = defineRoutes({
   }),
   updateFormEstablishment: defineRoute({
     method: "put",
-    url: formEstablishmentsUrl,
+    url: "/form-establishments",
     requestBodySchema: formEstablishmentSchema,
     ...withAuthorizationHeaders,
     responses: {
@@ -36,7 +34,7 @@ export const establishmentRoutes = defineRoutes({
   }),
   getFormEstablishment: defineRoute({
     method: "get",
-    url: `${formEstablishmentsUrl}/:siret`,
+    url: `/form-establishments/:siret`,
     ...withAuthorizationHeaders,
     responses: {
       200: formEstablishmentSchema,
@@ -55,13 +53,22 @@ export const establishmentRoutes = defineRoutes({
   }),
   deleteEstablishment: defineRoute({
     method: "delete",
-    url: `${formEstablishmentsUrl}/:siret`,
+    url: `/form-establishments/:siret`,
     ...withAuthorizationHeaders,
     responses: {
       204: emptyObjectSchema,
       400: httpErrorSchema,
       403: renewMagicLinkResponseSchema,
       404: legacyHttpErrorSchema,
+    },
+  }),
+  unregisterEstablishmentLead: defineRoute({
+    method: "post",
+    url: `/establishment-lead/unregister`,
+    ...withAuthorizationHeaders,
+    responses: {
+      200: expressEmptyResponseBody,
+      404: httpErrorSchema,
     },
   }),
 });


### PR DESCRIPTION
## Description

Ajout d'une route `/establishment-lead/unregister` pour se désabonner des mails de relance pour devenir entreprise accueillante.