### PR TITLE
review app: ajouter un temps d'attente dans la pipeline avant de trigger le déploiements des review app

### DIFF
--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Deactivate front review app autodeploy
         run: |
           scalingo --app if-dev-front-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
+      - name: Wait for the postgresql to be ready
+        run: sleep 60
       - name: Remove sslmode from $SCALINGO_POSTGRESQL_URL
         run: |
           current_db_url=$(scalingo --app if-dev-back-pr${{ inputs.pull_request_id }} env | grep 'SCALINGO_POSTGRESQL_URL=' | cut -d '=' -f2-)


### PR DESCRIPTION
## Problème

Le premier déploiement des review-apps est systématiquement en erreur car on récupère la variable `$SCALINGO_POSTGRESQL_URL` depuis Scalingo.
Or cette variable n'existe que lorsque Postgresql est prêt.

Puisque le premier run de la pipeline créé la review app et son environnement, Postgresql n'est pas prêt à ce moment.

Cette PR évite de toujours avoir une ❌ au premier run de la pipeline 🥳 

## Solution

Vu que le déploiement de la review-app n'est pas requis pour merger la PR, j'ai mis un temps d'attente un peu long de 60s (peut-être à réajuster).