### PR TITLE
Ajouts de logs AuthenticateWithInclusionCode

### DIFF
--- a/back/src/domain/inclusionConnect/useCases/AuthenticateWithInclusionCode.ts
+++ b/back/src/domain/inclusionConnect/useCases/AuthenticateWithInclusionCode.ts
@@ -15,6 +15,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../../../adapters/primary/helpers/httpErrors";
+import { createLogger } from "../../../utils/logger";
 import { GenerateInclusionConnectJwt } from "../../auth/jwt";
 import { TransactionalUseCase } from "../../core/UseCase";
 import { CreateNewEvent } from "../../core/eventBus/EventBus";
@@ -27,6 +28,8 @@ import { InclusionConnectGateway } from "../port/InclusionConnectGateway";
 import { InclusionConnectConfig } from "./InitiateInclusionConnect";
 
 type ConnectedRedirectUrl = AbsoluteUrl;
+
+const logger = createLogger(__filename);
 
 export class AuthenticateWithInclusionCode extends TransactionalUseCase<
   AuthenticateWithInclusionCodeConnectParams,
@@ -136,6 +139,11 @@ export class AuthenticateWithInclusionCode extends TransactionalUseCase<
         id: existingAuthenticatedUser.id,
       }),
     };
+
+    logger.info(`Usecase AuthenticateWithInclusionCode: 
+      AuthenticatedUser id: ${newOrUpdatedAuthenticatedUser.id}
+      OngoingOAuth externalId: ${icIdTokenPayload.sub}
+    `);
 
     const ongoingOAuth: OngoingOAuth = {
       ...existingOngoingOAuth,


### PR DESCRIPTION
## Problème

A chaque connexion à Inclusion Connect, nous sauvegardons des données dans la table `ongoing_oauths` puis `authenticated_users`.

Sauf que nous avons actuellement en DB des `authenticated_users` sans `ongoing_oauths` associé.

Cette PR ajoute des logs pour tenter de trouver l'origine du problème.