### PR TITLE
Fix erreur en prod searches_made__appellation_code_unicity

### DIFF
--- a/back/src/adapters/secondary/pg/repositories/PgSearchMadeRepository.ts
+++ b/back/src/adapters/secondary/pg/repositories/PgSearchMadeRepository.ts
@@ -1,4 +1,5 @@
 import format from "pg-format";
+import { uniq } from "ramda";
 import { AppellationCode } from "shared";
 import {
   SearchMadeEntity,
@@ -54,11 +55,13 @@ export class PgSearchMadeRepository implements SearchMadeRepository {
     id: SearchMadeId,
     appellationCodes: AppellationCode[],
   ) {
+    const uniqAppellationCodes = uniq(appellationCodes);
+
     return executeKyselyRawSqlQuery(
       this.transaction,
       format(
         "INSERT INTO searches_made__appellation_code(search_made_id, appellation_code) VALUES %L",
-        appellationCodes.map((appellationCode) => [id, appellationCode]),
+        uniqAppellationCodes.map((appellationCode) => [id, appellationCode]),
       ),
     );
   }


### PR DESCRIPTION
## Problème

Nous avons beaucoup eu l'erreur "searches_made__appellation_code_unicity" aujourd'hui.

## Investigation et solution

Cela est dû au paramètres `appellationCodes` fournit en entrée de la route qui contient des doublons.
La solution proposée ici est de filtrer ces doublons avant l'insertion pour ne plus enfreindre la contrainte db `searches_made__appellation_code_unicity`.

Closes #1266 