### PR TITLE
Fix suppression des review-app

### DIFF
--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -50,6 +50,7 @@ jobs:
           else
             echo "Review app for PR_ID ${{ inputs.pull_request_id }} does not exist. Creating now."
             scalingo --app if-dev-back integration-link-manual-review-app ${{ inputs.pull_request_id }}
+            scalingo --app if-dev-back-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
           fi
       - name: Create front review app
         run: |
@@ -58,13 +59,8 @@ jobs:
           else
             echo "Review app for PR_ID ${{ inputs.pull_request_id }} does not exist. Creating now."
             scalingo --app if-dev-front integration-link-manual-review-app ${{ inputs.pull_request_id }}
+            scalingo --app if-dev-front-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
           fi
-      - name: Deactivate back review app autodeploy
-        run: |
-          scalingo --app if-dev-back-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
-      - name: Deactivate front review app autodeploy
-        run: |
-          scalingo --app if-dev-front-pr${{ inputs.pull_request_id }} integration-link-update --no-auto-deploy
       - name: Wait for the postgresql to be ready
         run: sleep 60
       - name: Remove sslmode from $SCALINGO_POSTGRESQL_URL

--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+concurrency:
+  group: review-app
+  cancel-in-progress: true
+
 jobs:
   destroy-review-apps:
     runs-on: ubuntu-latest

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, ready_for_review, review_requested, synchronize]
 
+concurrency:
+  group: review-app
+
 jobs:
   validation:
     uses: ./.github/workflows/fullcheck.yml


### PR DESCRIPTION
## Problème

Nos review apps ne sont pas supprimés à la cloture de la PR. Elles s'accumulent et on atteint le nombre maximum d'applications sur Scalingo pour le compte du gip, empêchant aussi la création de nouvelles review-app pour les autres équipes.

## Cause

Les étapes pour reproduire le bug:
- mise à jour de la PR: cela va trigger du workflow de création de review-app 
- sans attendre la fin du workflow de création de review-app, merger/fermer la PR: cela va trigger le workflow de suppression de review-app
- résultat: le workflow de suppression de review-app terminera avant le workflow de création de review-app

## Solution 

Utiliser la fonctionnalité de `concurrency` pour interrompre le workflow de création de review-app s'il a été précédemment déclenché.