### PR TITLE
Accepter les HTTP 201 de Pole emploi

### DIFF
--- a/back/scalingo/cron.json
+++ b/back/scalingo/cron.json
@@ -13,10 +13,6 @@
       "size": "M"
     },
     {
-      "command": "02 3 * * * pnpm back run trigger-resync-old-conventions-to-pe",
-      "size": "M"
-    },
-    {
       "command": "00 6 * * * pnpm back run trigger-establishment-leads-reminders",
       "size": "M"
     },

--- a/back/src/domains/convention/adapters/pole-emploi-gateway/PoleEmploiRoutes.ts
+++ b/back/src/domains/convention/adapters/pole-emploi-gateway/PoleEmploiRoutes.ts
@@ -22,6 +22,7 @@ export const createPoleEmploiRoutes = (peApiUrl: AbsoluteUrl) => {
       ...withAuthorizationHeaders,
       responses: {
         200: z.literal(""),
+        201: z.literal(""),
       },
     }),
   });


### PR DESCRIPTION
## Description

Le POST à l'api PE peut nous renvoyer une 201: cette PR ajoute cette possibilité dans le schéma attendu.

## Remarque

Lors d'un échec d'envoi PE, il n'y a pas d'ajout à la table `conventions_to_sync_with_pe`.  
Or si l'échec était ajouté à cette table, le cron `trigger-resync-old-conventions-to-pe` aurait quotidiennement tenté de rejouer l'envoi à PE.

Est-ce que l'on voudrait avoir ce comportement ?
Si oui, il nous suffirait de supprimer l'usage de la variable `resyncMode` dans le usecase `BroadcastToPoleEmploiOnConventionUpdates`.