### PR TITLE
Notifier Discord si plus de 1500 outbox never-published

### DIFF
--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -6,26 +6,27 @@ export interface Database {
   agencies: Agencies;
   agency_groups: AgencyGroups;
   agency_groups__agencies: AgencyGroupsAgencies;
-  convention_external_ids: ConventionExternalIds;
-  conventions: Conventions;
-  discussions: Discussions;
-  exchanges: Exchanges;
-  form_establishments: PgFormEstablishments;
-  groups__sirets: GroupsSirets;
-  groups: Groups;
-  partners_pe_connect: PartnersPeConnect;
-  saved_errors: SavedErrors;
-  view_appellations_dto: ViewAppellationsDto;
-  establishment_lead_events: EstablishmentLeadEvents;
   api_consumers: ApiConsumers;
   api_consumers_subscriptions: ApiConsumersSubscriptions;
   authenticated_users: AuthenticatedUsers;
-  ongoing_oauths: OngoingOauths;
+  convention_external_ids: ConventionExternalIds;
+  conventions: Conventions;
+  discussions: Discussions;
+  establishment_lead_events: EstablishmentLeadEvents;
   establishments: Establishments;
-  establishments_locations: EstablishmentsLocations;
   establishments__immersion_contacts: EstablishmentsImmersionContacts;
+  establishments_locations: EstablishmentsLocations;
+  exchanges: Exchanges;
+  form_establishments: PgFormEstablishments;
+  groups: Groups;
+  groups__sirets: GroupsSirets;
   immersion_contacts: ImmersionContacts;
   immersion_offers: ImmersionOffers;
+  ongoing_oauths: OngoingOauths;
+  outbox: Outbox;
+  partners_pe_connect: PartnersPeConnect;
+  saved_errors: SavedErrors;
+  view_appellations_dto: ViewAppellationsDto;
 }
 
 type JsonArray = JsonValue[];
@@ -382,4 +383,20 @@ export interface AgencyGroups {
 export interface AgencyGroupsAgencies {
   agency_group_id: number;
   agency_id: string;
+}
+
+export type EventStatus =
+  | "failed-but-will-retry"
+  | "failed-to-many-times"
+  | "never-published"
+  | "published"
+  | "to-republish";
+
+export interface Outbox {
+  id: string;
+  occurred_at: Timestamp;
+  was_quarantined: Generated<boolean | null>;
+  topic: string;
+  payload: Json;
+  status: EventStatus;
 }

--- a/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
+++ b/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
@@ -104,7 +104,7 @@ export class BasicEventCrawler implements EventCrawler {
           ? uow.outboxQueries.getAllUnpublishedEvents({
               limit: crawlerMaxBatchSize,
             })
-          : uow.outboxQueries.getAllFailedEvents({ limit: crawlerMaxBatchSize }),
+          : uow.outboxQueries.getFailedEvents({ limit: crawlerMaxBatchSize }),
       );
       return events;
     } catch (error: any) {

--- a/back/src/domains/core/events/adapters/InMemoryOutboxQueries.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxQueries.ts
@@ -8,7 +8,7 @@ const logger = createLogger(__filename);
 export class InMemoryOutboxQueries implements OutboxQueries {
   constructor(private readonly outboxRepository: InMemoryOutboxRepository) {}
 
-  public async getAllFailedEvents(): Promise<DomainEvent[]> {
+  public async getFailedEvents(): Promise<DomainEvent[]> {
     const allEvents = this.outboxRepository.events;
     logger.debug(
       { allEvents: eventsToDebugInfo(allEvents) },

--- a/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
@@ -8,6 +8,11 @@ const logger = createLogger(__filename);
 export class InMemoryOutboxRepository implements OutboxRepository {
   constructor(private readonly _events: Record<string, DomainEvent> = {}) {}
 
+  public async countAllNeverPublishedEvents(): Promise<number> {
+    return this.events.filter((event) => event.status === "never-published")
+      .length;
+  }
+
   //test purposes
   public get events(): DomainEvent[] {
     return values(this._events);

--- a/back/src/domains/core/events/adapters/PgOutboxQueries.crawling.integration.test.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxQueries.crawling.integration.test.ts
@@ -198,7 +198,7 @@ describe("PgOutboxQueries for crawling purposes", () => {
     ]);
 
     // act
-    const eventsToRerun = await outboxQueries.getAllFailedEvents({ limit: 10 });
+    const eventsToRerun = await outboxQueries.getFailedEvents({ limit: 10 });
 
     // assert
     expectToEqual(eventsToRerun, [eventFailedToRerun]);
@@ -234,7 +234,7 @@ describe("PgOutboxQueries for crawling purposes", () => {
     ]);
 
     // act
-    const eventsToRerun = await outboxQueries.getAllFailedEvents({ limit: 1 });
+    const eventsToRerun = await outboxQueries.getFailedEvents({ limit: 1 });
 
     // assert
     expectToEqual(eventsToRerun, [

--- a/back/src/domains/core/events/adapters/PgOutboxQueries.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxQueries.ts
@@ -14,7 +14,7 @@ import {
 export class PgOutboxQueries implements OutboxQueries {
   constructor(private transaction: KyselyDb) {}
 
-  public async getAllFailedEvents(params: { limit: number }): Promise<
+  public async getFailedEvents(params: { limit: number }): Promise<
     DomainEvent[]
   > {
     const selectEventIdsWithFailure = `(

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.integration.test.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.integration.test.ts
@@ -40,6 +40,22 @@ describe("PgOutboxRepository", () => {
     outboxRepository = new PgOutboxRepository(makeKyselyDb(pool));
   });
 
+  it("countAllNeverPublishedEvents", async () => {
+    await client.query(
+      `INSERT INTO outbox(id, status, occurred_at, topic, payload) VALUES ('aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa', 'never-published','2021-11-15T08:30:00.000Z', 'PeConnectFederatedIdentityAssociated', '{"exp": 1652054423, "iat": 1651881623, "siret": "my-siret", "version": 1}')`,
+    );
+    await client.query(
+      `INSERT INTO outbox(id, status, occurred_at, topic, payload) VALUES ('aaaaac99-9c0b-1aaa-aa6d-6bb9bd38cccc', 'never-published','2021-11-15T08:30:00.000Z', 'PeConnectFederatedIdentityAssociated', '{"exp": 1652054423, "iat": 1651881623, "siret": "my-siret", "version": 1}')`,
+    );
+    await client.query(
+      `INSERT INTO outbox(id, status, occurred_at, topic, payload) VALUES ('aaaaac99-9c0b-1aaa-aa6d-6bb9bd38bbbb', 'in-process','2021-11-15T08:30:00.000Z', 'PeConnectFederatedIdentityAssociated', '{"exp": 1652054423, "iat": 1651881623, "siret": "my-siret", "version": 1}')`,
+    );
+
+    const total = await outboxRepository.countAllNeverPublishedEvents();
+
+    expect(total).toBe(2);
+  });
+
   describe("save", () => {
     it("saves an event with published data", async () => {
       const convention = new ConventionDtoBuilder().build();

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.ts
@@ -33,6 +33,16 @@ const logger = createLogger(__filename);
 export class PgOutboxRepository implements OutboxRepository {
   constructor(private transaction: KyselyDb) {}
 
+  public async countAllNeverPublishedEvents(): Promise<number> {
+    const result = (await this.transaction
+      .selectFrom("outbox")
+      .select((eb) => eb.fn.countAll().as("total"))
+      .where("status", "=", "never-published")
+      .executeTakeFirst()) as { total: string };
+
+    return parseInt(result.total);
+  }
+
   public async markEventsAsInProcess(events: DomainEvent[]): Promise<void> {
     if (!events.length) return;
     const query = format(

--- a/back/src/domains/core/events/ports/OutboxQueries.ts
+++ b/back/src/domains/core/events/ports/OutboxQueries.ts
@@ -4,5 +4,5 @@ export interface OutboxQueries {
   getAllUnpublishedEvents: (params: { limit: number }) => Promise<
     DomainEvent[]
   >;
-  getAllFailedEvents: (params: { limit: number }) => Promise<DomainEvent[]>;
+  getFailedEvents: (params: { limit: number }) => Promise<DomainEvent[]>;
 }

--- a/back/src/domains/core/events/ports/OutboxRepository.ts
+++ b/back/src/domains/core/events/ports/OutboxRepository.ts
@@ -1,6 +1,7 @@
 import { DomainEvent } from "../events";
 
 export interface OutboxRepository {
+  countAllNeverPublishedEvents(): Promise<number>;
   save: (event: DomainEvent) => Promise<void>;
   markEventsAsInProcess: (events: DomainEvent[]) => Promise<void>;
 }


### PR DESCRIPTION
## Problème

Il arrive que notre crawler d'évènements "freeze" et s'arrête de traiter les évènements.
La cause est toujours en cours d'investigation.

Lorsque le crawler freeze, le fix actuel est de manuellement le container depuis Scalingo et le crawler repart.
Nous aimerions être notifier dès que le crawler freeze, c'est-à-dire quand le jombre d'éléments dans la table outbox dépasse 1500.