### PR TITLE
Notifier Discord si trop d'outbox en in-process

### DIFF
--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -388,6 +388,7 @@ export interface AgencyGroupsAgencies {
 export type EventStatus =
   | "failed-but-will-retry"
   | "failed-to-many-times"
+  | "in-process"
   | "never-published"
   | "published"
   | "to-republish";

--- a/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
+++ b/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
@@ -24,7 +24,7 @@ export class BasicEventCrawler implements EventCrawler {
 
   protected async notifyDiscordOnTooManyNeverPublishedOutbox() {
     const neverPublishedCount = await this.uowPerformer.perform((uow) =>
-      uow.outboxRepository.countAllNeverPublishedEvents(),
+      uow.outboxRepository.countAllEvents({ status: "never-published" }),
     );
     if (neverPublishedCount < neverPublishedOutboxLimit) return;
     logger.error(

--- a/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
@@ -1,4 +1,5 @@
 import { values } from "ramda";
+import { EventStatus } from "../../../../config/pg/kysely/model/database";
 import { createLogger } from "../../../../utils/logger";
 import { DomainEvent } from "../events";
 import { OutboxRepository } from "../ports/OutboxRepository";
@@ -8,9 +9,10 @@ const logger = createLogger(__filename);
 export class InMemoryOutboxRepository implements OutboxRepository {
   constructor(private readonly _events: Record<string, DomainEvent> = {}) {}
 
-  public async countAllNeverPublishedEvents(): Promise<number> {
-    return this.events.filter((event) => event.status === "never-published")
-      .length;
+  public async countAllEvents({
+    status,
+  }: { status: EventStatus }): Promise<number> {
+    return this.events.filter((event) => event.status === status).length;
   }
 
   //test purposes

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.integration.test.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.integration.test.ts
@@ -40,7 +40,7 @@ describe("PgOutboxRepository", () => {
     outboxRepository = new PgOutboxRepository(makeKyselyDb(pool));
   });
 
-  it("countAllNeverPublishedEvents", async () => {
+  it("countAllEvents", async () => {
     await client.query(
       `INSERT INTO outbox(id, status, occurred_at, topic, payload) VALUES ('aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa', 'never-published','2021-11-15T08:30:00.000Z', 'PeConnectFederatedIdentityAssociated', '{"exp": 1652054423, "iat": 1651881623, "siret": "my-siret", "version": 1}')`,
     );
@@ -51,7 +51,9 @@ describe("PgOutboxRepository", () => {
       `INSERT INTO outbox(id, status, occurred_at, topic, payload) VALUES ('aaaaac99-9c0b-1aaa-aa6d-6bb9bd38bbbb', 'in-process','2021-11-15T08:30:00.000Z', 'PeConnectFederatedIdentityAssociated', '{"exp": 1652054423, "iat": 1651881623, "siret": "my-siret", "version": 1}')`,
     );
 
-    const total = await outboxRepository.countAllNeverPublishedEvents();
+    const total = await outboxRepository.countAllEvents({
+      status: "never-published",
+    });
 
     expect(total).toBe(2);
   });

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.ts
@@ -33,11 +33,13 @@ const logger = createLogger(__filename);
 export class PgOutboxRepository implements OutboxRepository {
   constructor(private transaction: KyselyDb) {}
 
-  public async countAllNeverPublishedEvents(): Promise<number> {
+  public async countAllEvents({
+    status,
+  }: { status: EventStatus }): Promise<number> {
     const result = (await this.transaction
       .selectFrom("outbox")
       .select((eb) => eb.fn.countAll().as("total"))
-      .where("status", "=", "never-published")
+      .where("status", "=", status)
       .executeTakeFirst()) as { total: string };
 
     return parseInt(result.total);

--- a/back/src/domains/core/events/ports/OutboxRepository.ts
+++ b/back/src/domains/core/events/ports/OutboxRepository.ts
@@ -1,7 +1,8 @@
+import { EventStatus } from "../../../../config/pg/kysely/model/database";
 import { DomainEvent } from "../events";
 
 export interface OutboxRepository {
-  countAllNeverPublishedEvents(): Promise<number>;
+  countAllEvents(params: { status: EventStatus }): Promise<number>;
   save: (event: DomainEvent) => Promise<void>;
   markEventsAsInProcess: (events: DomainEvent[]) => Promise<void>;
 }


### PR DESCRIPTION
## Problème

Il arrive que notre crawler d'évènements "freeze" et s'arrête de traiter les évènements.
La cause est toujours en cours d'investigation.

Lorsque le crawler freeze, les outbox qui étaient en cours de traitement sont au status `in-process` et leur nombre devrait augmenter et $etre plus grand que la taille de batch traité (300).

A ce moment, nous voudrions être notifier de cet état anormal sur Discord.

Cette PR fait suite à https://github.com/gip-inclusion/immersion-facile/pull/1334