### PR TITLE
Fix annulation de la pipeline d'une autre PR

### DIFF
--- a/.github/workflows/review-app-destroy.yml
+++ b/.github/workflows/review-app-destroy.yml
@@ -2,10 +2,10 @@ name: "Destroy review apps"
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
 
 concurrency:
-  group: review-app
+  group: review-app-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, ready_for_review, review_requested, synchronize ]
 
 concurrency:
-  group: review-app
+  group: review-app-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problème

Nous avons deux PR: 
- la PR A où la pipeline de CI est en cours
- la PR B qui vient d'être mise à jour et la CI va démarrer
- la PR A voit sa pipeline s'annuler car la PR B a une priorité plus importante