### PR TITLE
Fix affichage des logs de cron

### DIFF
--- a/back/src/scripts/triggerEstablishmentLeadReminders.ts
+++ b/back/src/scripts/triggerEstablishmentLeadReminders.ts
@@ -76,10 +76,10 @@ handleEndOfScriptNotification(
   ({ firstReminderResult, secondReminderResult }) =>
     [
       "First reminder:",
-      ...reminderReport(firstReminderResult),
+      reminderReport(firstReminderResult),
       "---",
       "Second reminder:",
-      ...reminderReport(secondReminderResult),
+      reminderReport(secondReminderResult),
     ].join("\n"),
   logger,
 );


### PR DESCRIPTION
## Problème

Nos logs de cron sur les relance d'entreprises accueillantes s'affichent une lettre par ligne.

Par exemple:
```
First reminder:
T
o
t
a
l
 
o
f
[...]
```