### PR TITLE
Fix: garder une trace de tous les échecs d'envoi de conventions à PE

### DIFF
--- a/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
+++ b/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
@@ -142,7 +142,10 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
               originalId: poleEmploiConvention.originalId,
             },
           });
-          throw error;
+          return {
+            status: 500,
+            message: JSON.stringify(error),
+          };
         }
 
         const message = !error.response.data?.message


### PR DESCRIPTION
## Problème

Nous envoyons des conventions à PE.
Lorsque des erreurs surviennent dans ce process, nous les loggons dans une table: `saved_errors`.

Problème: certains échecs d'envoi n'y sont pas et nous n'avons pas d'autres moyens d'identifier les conventions qui n'ont pas pu être envoyées à PE

Plus d'infos: https://discord.com/channels/864451835553513474/1216699975476707379

## Solution

Ajouter toutes les erreurs qui peuvent survenir durant le process d'envoi à PE dans la table `saved_errors`.