### PR TITLE
Ajouts de notifications Discord si timeout axios lors de l'envoi des conventions à PE

### DIFF
--- a/back/src/domains/convention/adapters/pole-emploi-gateway/InMemoryPoleEmploiGateway.ts
+++ b/back/src/domains/convention/adapters/pole-emploi-gateway/InMemoryPoleEmploiGateway.ts
@@ -22,6 +22,9 @@ export class InMemoryPoleEmploiGateway implements PoleEmploiGateway {
   public async notifyOnConventionUpdated(
     convention: PoleEmploiConvention,
   ): Promise<PoleEmploiBroadcastResponse> {
+    if (convention.statut === "DEMANDE_OBSOLETE") {
+      throw new Error("fake axios error");
+    }
     this.notifications.push(convention);
     return this.#nextResponse;
   }

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToPoleEmploiOnConventionUpdates.unit.test.ts
@@ -3,6 +3,7 @@ import {
   ConventionDtoBuilder,
   ConventionId,
   expectObjectsToMatch,
+  expectPromiseToFailWithError,
   expectToEqual,
   reasonableSchedule,
 } from "shared";
@@ -174,5 +175,20 @@ describe("Broadcasts events to pole-emploi", () => {
       statut: "DEMANDE_VALIDÉE",
       codeAppellation: "011111",
     });
+  });
+
+  it("if an axios error happens", async () => {
+    const { broadcastToPe, peAgency } = await prepareUseCase();
+
+    const convention = new ConventionDtoBuilder()
+      .withStatus("DEPRECATED")
+      .withAgencyId(peAgency.id)
+      .withoutFederatedIdentity()
+      .build();
+
+    await expectPromiseToFailWithError(
+      broadcastToPe.execute({ convention }),
+      new Error("fake axios error"),
+    );
   });
 });


### PR DESCRIPTION
## Description

Lié à https://github.com/gip-inclusion/immersion-facile/issues/1387

Nous avons des tiemout axios lors de nos envois de convention à PE.
Dans ce cas, le usecase devrait se rejouer car il tomberait en erreur, ce que prouve notre test unitaire et intégration dans cette PR, mais ce n'est pas le cas en réalité.

Pour le moment nous mettons en place des notifications pour investigations DB aux prochaines occurences.