### PR TITLE
TECH récupérer les évènements outbox triés par occurredAt plutôt que publishedAt

### DIFF
--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
@@ -275,7 +275,7 @@ const expectNewEvent = async <T extends DomainTopic>(
 ) => {
   const allEvents = await new InMemoryOutboxQueries(
     outboxRepository,
-  ).getAllUnpublishedEvents();
+  ).getEventsToPublish();
   expect(allEvents).toHaveLength(1);
   expect(allEvents[0]).toMatchObject(expectedEvent);
 };

--- a/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
+++ b/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
@@ -100,7 +100,7 @@ export class BasicEventCrawler implements EventCrawler {
     try {
       const events = await this.uowPerformer.perform((uow) =>
         type === "unpublished"
-          ? uow.outboxQueries.getAllUnpublishedEvents({
+          ? uow.outboxQueries.getEventsToPublish({
               limit: crawlerMaxBatchSize,
             })
           : uow.outboxQueries.getFailedEvents({ limit: crawlerMaxBatchSize }),

--- a/back/src/domains/core/events/adapters/InMemoryOutboxQueries.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxQueries.ts
@@ -22,7 +22,7 @@ export class InMemoryOutboxQueries implements OutboxQueries {
     });
   }
 
-  public async getAllUnpublishedEvents() {
+  public async getEventsToPublish() {
     const allEvents = this.outboxRepository.events;
     logger.debug(
       { allEvents: eventsToDebugInfo(allEvents) },

--- a/back/src/domains/core/events/adapters/PgOutboxQueries.crawling.integration.test.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxQueries.crawling.integration.test.ts
@@ -183,10 +183,11 @@ describe("PgOutboxQueries for crawling purposes", () => {
       alreadyProcessedEvent,
       quarantinedEvent,
       inProcessEvent,
+      eventToRepublish,
     ]);
 
     // act
-    const events = await outboxQueries.getAllUnpublishedEvents({ limit: 2 });
+    const events = await outboxQueries.getEventsToPublish({ limit: 2 });
 
     // assert
     expect(events.length).toBe(2);
@@ -240,7 +241,7 @@ describe("PgOutboxQueries for crawling purposes", () => {
 
     await storeInOutbox([
       eventFailedToRerun,
-      event1,
+      neverPublished1,
       withFailureButEventuallySuccessfulEvent,
       failedButQuarantinedEvent,
       anotherEventFailedToRerun,

--- a/back/src/domains/core/events/adapters/PgOutboxQueries.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxQueries.ts
@@ -76,7 +76,7 @@ export class PgOutboxQueries implements OutboxQueries {
     LEFT JOIN outbox_publications ON outbox.id = outbox_publications.event_id
     LEFT JOIN outbox_failures ON outbox_failures.publication_id = outbox_publications.id
     WHERE was_quarantined = false AND status IN ('never-published', 'to-republish')
-    ORDER BY published_at ASC
+    ORDER BY occurred_at ASC
     LIMIT ${params.limit}
     `,
     );

--- a/back/src/domains/core/events/adapters/PgOutboxQueries.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxQueries.ts
@@ -63,7 +63,7 @@ export class PgOutboxQueries implements OutboxQueries {
     return convertRowsToDomainEvents(rows);
   }
 
-  public async getAllUnpublishedEvents(params: { limit: number }): Promise<
+  public async getEventsToPublish(params: { limit: number }): Promise<
     DomainEvent[]
   > {
     const { rows } = await executeKyselyRawSqlQuery<StoredEventRow>(

--- a/back/src/domains/core/events/ports/OutboxQueries.ts
+++ b/back/src/domains/core/events/ports/OutboxQueries.ts
@@ -1,8 +1,6 @@
 import { DomainEvent } from "../events";
 
 export interface OutboxQueries {
-  getAllUnpublishedEvents: (params: { limit: number }) => Promise<
-    DomainEvent[]
-  >;
+  getEventsToPublish: (params: { limit: number }) => Promise<DomainEvent[]>;
   getFailedEvents: (params: { limit: number }) => Promise<DomainEvent[]>;
 }


### PR DESCRIPTION
## Description

Actuellement, lorsque le crawler récupère tous les outbox à publier, il fait une jointure entre la table outbox et la table outbox_publications ordonné par publishedAt.

Le champ publishedAt que pour les outbox to-republished, ce qui fait que le crawler traitera en priorité les events à "re-published".

Ensuite il n'y a pas d'ordre défini pour traiter les never-published.

On suppose que ce sont toujours les derniers arrivés dans la table qui sont alors traités.

## Solution

Pour corriger cela, on utilise le orderBy sur occurredAt plutôt que publishedAt.