### PR TITLE
TECH Fix envoi des notifications sur discord

### DIFF
--- a/.github/workflows/deploy-to-scalingo.yml
+++ b/.github/workflows/deploy-to-scalingo.yml
@@ -52,11 +52,14 @@ jobs:
       - name: Send Discord notification
         run: |
           newChanges="${{ inputs.version-new-features }}"
-          formattedNewChanges="${newChanges//$'\n'/\\n/}"
-          formattedNewChanges="${formattedNewChanges//[\"\\\`]/'}"
+          newChangesWithExplicitNewLines="${newChanges//$'\n'/\\n}"
+          newChangesWithoutBacktickAndDoubleQuote="${newChangesWithExplicitNewLines//\"/‘}"
+          newChangesWithoutBacktickAndDoubleQuote="${newChangesWithoutBacktickAndDoubleQuote//\'/‘}"
+          newChangesWithoutBacktickAndDoubleQuote="${newChangesWithoutBacktickAndDoubleQuote//\`/‘}"
+          echo -E "$newChangesWithBacktickAndDoubleQuote"
           curl -X POST -H "Content-Type: application/json" -d @- ${{ secrets.DISCORD_WEBHOOK_URL }} <<EOF 
           {
-            "content": "La ${{ inputs.tag }} est deployée en ${{ inputs.environment }}.\n\n $formattedNewChanges",
+            "content": "La ${{ inputs.tag }} est deployée en ${{ inputs.environment }}.\n\n $newChangesWithoutBacktickAndDoubleQuote",
             "embeds": [
               {
                 "title": "Liens utiles :",


### PR DESCRIPTION
## Problème

L'envoi des notifications de déploiement à Discord échoue lorsque le contenu contient des backticks et des double quotes

## Solution

Remplacer les backticks, quotes et double quotes par des apostrophes.