### PR TITLE
TECH Aligner le schéma DB des colonnes businessContact et professions de la table formEstablishments

### DIFF
--- a/back/src/config/pg/migrations/1712236423427_update-form-establishments-business-contact.ts
+++ b/back/src/config/pg/migrations/1712236423427_update-form-establishments-business-contact.ts
@@ -8,3 +8,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     WHERE business_contact ->> 'copyEmails' is null
   `);
 }
+
+export async function down(): Promise<void> {}

--- a/back/src/config/pg/migrations/1712236423427_update-form-establishments-business-contact.ts
+++ b/back/src/config/pg/migrations/1712236423427_update-form-establishments-business-contact.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE form_establishments
+    SET business_contact = business_contact::jsonb || ('{"copyEmails": []}' )::jsonb
+    WHERE business_contact ->> 'copyEmails' is null
+  `);
+}

--- a/back/src/config/pg/migrations/1712238124292_update-form-establishments-profession.ts
+++ b/back/src/config/pg/migrations/1712238124292_update-form-establishments-profession.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  addRomeLabelInProfessions(pgm);
+  addAppellationLabelInProfessions(pgm);
+  renameAndDropProfessionsFields(pgm);
+}
+
+export async function down(): Promise<void> {}
+
+const addRomeLabelInProfessions = (pgm: MigrationBuilder) => {
+  pgm.sql(`
+      UPDATE form_establishments
+      SET professions = (
+          SELECT jsonb_agg(
+               CASE
+                   WHEN element->>'romeCodeAppellation' is not null and element->>'romeCodeMetier' is null
+                       THEN
+                       jsonb_set(
+                               element,
+                               '{romeCodeMetier}',
+                               (SELECT '"' || code_rome || '"' FROM public_appellations_data WHERE ogr_appellation = (element->>'romeCodeAppellation')::integer)::jsonb
+                       )
+                   WHEN element->>'romeCodeMetier' is not null and element->>'romeCodeAppellation' is null
+                       THEN
+                       jsonb_set(
+                               element,
+                               '{romeCodeAppellation}',
+                               (SELECT '"' || ogr_appellation || '"' FROM public_appellations_data WHERE code_rome = element->>'romeCodeMetier' LIMIT 1)::jsonb
+                       )
+                   ELSE element
+                   END
+               )
+          FROM jsonb_array_elements(professions) AS element
+      )
+      WHERE professions::text like '%"description"%';
+  `);
+  pgm.sql(`
+    UPDATE form_establishments
+    SET professions = (
+        SELECT jsonb_agg(
+                       jsonb_set(
+                               element,
+                               '{romeLabel}',
+                               (SELECT '"' || libelle_rome || '"' FROM public_romes_data WHERE code_rome = element->>'romeCodeMetier')::jsonb
+                       )
+               )
+        FROM jsonb_array_elements(professions) AS element
+    )
+    WHERE professions::text like '%romeCodeMetier%';`);
+};
+
+const addAppellationLabelInProfessions = (pgm: MigrationBuilder) => {
+  pgm.sql(`
+    UPDATE form_establishments
+    SET professions = (
+      SELECT jsonb_agg(
+         jsonb_set(
+             element,
+             '{appellationLabel}',
+             (SELECT '"' || public_appellations_data.libelle_appellation_court || '"' FROM public_appellations_data WHERE ogr_appellation = (element->>'romeCodeAppellation')::integer)::jsonb
+         )
+     )
+      FROM jsonb_array_elements(professions) AS element
+    )
+    WHERE professions::text like '%romeCodeAppellation%';
+  `);
+};
+
+const renameAndDropProfessionsFields = (pgm: MigrationBuilder) => {
+  pgm.sql(`
+    UPDATE form_establishments
+    SET professions = (
+        SELECT jsonb_agg(
+           jsonb_set(
+             jsonb_set(
+               element,
+               '{romeCode}',
+               element->'romeCodeMetier'
+             ) - 'romeCodeMetier',
+             '{appellationCode}',
+             element->'romeCodeAppellation'
+           ) - 'romeCodeAppellation' - 'description'
+     )
+      FROM jsonb_array_elements(professions) AS element
+    )
+    WHERE professions::text like '%romeCodeAppellation%';
+  `);
+};


### PR DESCRIPTION
## 📔 Problème

Dans la table form_establishments, nous avons des données qui ne sont pas uniformes pour les colonnes professions et businessContact.

Cette différence casse nos schémas Zod lorsque nous requêtons la table form_establishments.

| Colonne | Ancien schéma      | Nouveau schéma |
| ----------- | ----------- | ----------- |
| professions | [{"description": "Jardinier / Jardinière", "romeCodeMetier": "A1203", "romeCodeAppellation": "16067"}]      | [{"romeCode": "G1601", "romeLabel": "Management du personnel de cuisine", "appellationCode": "12110", "appellationLabel": "Chef de cuisine"}] |
| businessContact | {"job": "testeur", "email": "nathaliereyre@aol.com", "phone": "5656767", "lastName": "Reyre", "firstName": "Nath",  "contactMethod": "EMAIL"}   | {"job": "testeur", "email": "nathaliereyre@aol.com", "phone": "5656767", "lastName": "Reyre", "firstName": "Nath", "copyEmails": ["test@test.fr"], "contactMethod": "EMAIL"} |

## 💯 Solution

| Colonne | Solution |
| ----------- | ----------- | 
| professions | ajouter les champs romeLabel et appellationLabel, renommer romeCodeMetier -> romeCode et romeCodeAppellation -> appellationCode, supprimer le champ "description" | 
| businessContact | pour les businessContact qui n'ont pas de champ copyEmails, le créer et l'initialiser à [] | 

## 🦄 Remarque

Je n'ai rien mis dans le `down` des fichiers de migrations car pas simple de revenir en arrière: sur quoi se baserait la clause `where` ?