### PR TITLE
Fix pouvoir valider une convention

### DIFF
--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -54,7 +54,11 @@ export const doesStatusNeedsValidators = (
   const isValidatorRequired = conventionStatusesWithValidator.includes(
     targetStatus as ConventionStatusWithValidator,
   );
-  return isValidatorRequired && initialStatus === "IN_REVIEW";
+  return (
+    isValidatorRequired &&
+    (initialStatus === "IN_REVIEW" ||
+      initialStatus === "ACCEPTED_BY_COUNSELLOR")
+  );
 };
 
 export const conventionStatusesWithJustificationWithoutModifierRole = [


### PR DESCRIPTION
## Description

Impossible de valider une convention: pas d'appel api après clic sur le bouton "valider" d'un lien magique

## Pour reproduire

1. Avoir une agence à double validation
2. Créer une convention liée à cette agence
3. Aller jusqu'à la validation valideur et essayer de valider
4. Constater que rien ne se passe