### PR TITLE
FIX - accès à une convention via lien magique si l'utilisateur a aussi un compte inclusion connect

### DIFF
--- a/back/src/domains/convention/use-cases/GetConvention.ts
+++ b/back/src/domains/convention/use-cases/GetConvention.ts
@@ -105,11 +105,9 @@ export class GetConvention extends TransactionalUseCase<
     agency: AgencyDto;
     inclusionConnectedUserRepository: InclusionConnectedUserRepository;
   }): Promise<boolean> {
-    const emailsByRole = conventionEmailsByRole(
-      authPayload.role,
-      convention,
-      agency,
-    )[authPayload.role];
+    const emailsByRole = conventionEmailsByRole(convention, agency)[
+      authPayload.role
+    ];
     if (emailsByRole instanceof Error) throw emailsByRole;
     const isEmailMatchingConventionEmails = !!emailsByRole.find(
       (email) => authPayload.emailHash === stringToMd5(email),

--- a/back/src/domains/convention/use-cases/GetConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetConvention.unit.test.ts
@@ -71,6 +71,9 @@ describe("Get Convention", () => {
 
       describe("with ConventionJwtPayload", () => {
         it("When convention id in jwt token does not match provided one", async () => {
+          uow.agencyRepository.setAgencies([agency]);
+          uow.conventionRepository.setConventions([convention]);
+
           await expectPromiseToFailWithError(
             getConvention.execute(
               { conventionId: convention.id },

--- a/back/src/domains/convention/use-cases/RenewConventionMagicLink.ts
+++ b/back/src/domains/convention/use-cases/RenewConventionMagicLink.ts
@@ -18,7 +18,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../../../config/helpers/httpErrors";
-import { conventionEmailsByRole } from "../../../utils/convention";
+import { conventionEmailsByRoleForMagicLinkRenewal } from "../../../utils/convention";
 import { createLogger } from "../../../utils/logger";
 import { TransactionalUseCase } from "../../core/UseCase";
 import { CreateNewEvent } from "../../core/events/ports/EventBus";
@@ -72,7 +72,7 @@ export class RenewConventionMagicLink extends TransactionalUseCase<
     );
 
     const convention = await this.#getConvention(uow, applicationId);
-    const emails = conventionEmailsByRole(
+    const emails = conventionEmailsByRoleForMagicLinkRenewal(
       role,
       convention,
       await this.#getAgency(uow, convention),

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/InMemoryInclusionConnectedUserRepository.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/InMemoryInclusionConnectedUserRepository.ts
@@ -1,10 +1,8 @@
+import { AgencyRight, InclusionConnectedUser, UserId } from "shared";
 import {
-  AgencyRight,
-  InclusionConnectedUser,
-  UserId,
-  WithAgencyRole,
-} from "shared";
-import { InclusionConnectedUserRepository } from "../../../dashboard/port/InclusionConnectedUserRepository";
+  InclusionConnectedFilters,
+  InclusionConnectedUserRepository,
+} from "../../../dashboard/port/InclusionConnectedUserRepository";
 import { InMemoryUserRepository } from "./InMemoryUserRepository";
 
 type AgencyRightsByUserId = Record<UserId, AgencyRight[]>;
@@ -32,11 +30,15 @@ export class InMemoryInclusionConnectedUserRepository
 
   public async getWithFilter({
     agencyRole,
-  }: Partial<WithAgencyRole>): Promise<InclusionConnectedUser[]> {
+    agencyId,
+  }: InclusionConnectedFilters): Promise<InclusionConnectedUser[]> {
+    // TODO: gestion des filtres optionnels à améliorer
     return this.userRepository.users
       .filter((user) =>
-        this.agencyRightsByUserId[user.id].some(
-          ({ role }) => role === agencyRole,
+        this.agencyRightsByUserId[user.id].some(({ role, agency }) =>
+          agencyId
+            ? role === agencyRole && agency.id === agencyId
+            : role === agencyRole,
         ),
       )
       .map((user) => ({

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/PgInclusionConnectedUserRepository.integration.test.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/PgInclusionConnectedUserRepository.integration.test.ts
@@ -49,7 +49,7 @@ describe("PgInclusionConnectedUserRepository", () => {
   let icUserRepository: PgInclusionConnectedUserRepository;
   let agencyRepository: PgAgencyRepository;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     pool = getTestPgPool();
   });
 
@@ -233,6 +233,41 @@ describe("PgInclusionConnectedUserRepository", () => {
         {
           ...user2,
           agencyRights: [{ agency: agency2, role: "toReview" }],
+          establishmentDashboards: {},
+        },
+      ]);
+    });
+
+    it("fetches inclusion connected users given its status 'validator' and agencyId", async () => {
+      await agencyRepository.insert(agency1);
+      await agencyRepository.insert(agency2);
+      await insertUser(user1);
+      await insertUser(user2);
+      await insertAgencyRegistrationToUser({
+        agencyId: agency1.id,
+        userId: user1.id,
+        role: "validator",
+      });
+      await insertAgencyRegistrationToUser({
+        agencyId: agency1.id,
+        userId: user2.id,
+        role: "toReview",
+      });
+      await insertAgencyRegistrationToUser({
+        agencyId: agency2.id,
+        userId: user1.id,
+        role: "validator",
+      });
+
+      const icUsers = await icUserRepository.getWithFilter({
+        agencyRole: "validator",
+        agencyId: agency1.id,
+      });
+
+      expectArraysToEqualIgnoringOrder(icUsers, [
+        {
+          ...user1,
+          agencyRights: [{ agency: agency1, role: "validator" }],
           establishmentDashboards: {},
         },
       ]);

--- a/back/src/domains/core/dashboard/port/InclusionConnectedUserRepository.ts
+++ b/back/src/domains/core/dashboard/port/InclusionConnectedUserRepository.ts
@@ -1,8 +1,12 @@
-import { InclusionConnectedUser, WithAgencyRole } from "shared";
+import { AgencyId, InclusionConnectedUser, WithAgencyRole } from "shared";
+
+export type InclusionConnectedFilters = Partial<WithAgencyRole> & {
+  agencyId?: AgencyId;
+};
 
 export interface InclusionConnectedUserRepository {
   getWithFilter(
-    filter: Partial<WithAgencyRole>,
+    filter: InclusionConnectedFilters,
   ): Promise<InclusionConnectedUser[]>;
   getById(userId: string): Promise<InclusionConnectedUser | undefined>;
   update(user: InclusionConnectedUser): Promise<void>;

--- a/back/src/utils/convention.ts
+++ b/back/src/utils/convention.ts
@@ -2,7 +2,6 @@ import { AgencyDto, ConventionDto, Role } from "shared";
 import { BadRequestError } from "../config/helpers/httpErrors";
 
 export const conventionEmailsByRole = (
-  role: Role,
   convention: ConventionDto,
   agency: AgencyDto,
 ): Record<Role, string[] | Error> => ({
@@ -24,7 +23,19 @@ export const conventionEmailsByRole = (
   "establishment-representative": [
     convention.signatories.establishmentRepresentative.email,
   ],
-  "establishment-tutor": new BadRequestError(
-    `Le rôle ${role} n'est pas supporté pour le renouvellement de lien magique.`,
-  ),
+  "establishment-tutor": [convention.establishmentTutor.email],
 });
+
+export const conventionEmailsByRoleForMagicLinkRenewal = (
+  role: Role,
+  convention: ConventionDto,
+  agency: AgencyDto,
+): Record<Role, string[] | Error> => {
+  return {
+    ...conventionEmailsByRole(convention, agency),
+    backOffice: new BadRequestError("Le backoffice n'a pas de liens magiques."),
+    "establishment-tutor": new BadRequestError(
+      `Le rôle ${role} n'est pas supporté pour le renouvellement de lien magique.`,
+    ),
+  };
+};


### PR DESCRIPTION
## Problème

Un utilisateur qui a un compte inclusion connect mais clique sur un lien magique avec un token ConventionDomainPayload n'arrive plus à accéder à la convention

## Solution 

Dans la PR #1489 on vérifie que le hash de l'email de l'agence dans le token du lien magique correspond bien à un hash de mail toujours utilisé chez nous.

Or pour un conseiller ou validateur, les mails utilisés pour la vérification sont ceux renseignés dans la table agencies.
Nous n'avons pas tenu compte qu'un utilisateur peux aussi accéder à une convention via token ConventionDomainPayload mais avec son email d'utilisateur inclusion connecté.

Dans cette PR, on vérifie que si l'utilisateur est un conseiller ou valideur, alors il faut aussi vérifier s'il a un rôle IC conseiller ou valideur pour l'agence de cette convention.