### PR TITLE
#1579 - Ajouter un lien vers l'annuaire des entreprises sur le champ siret du form de convention

### DIFF
--- a/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
@@ -1,3 +1,4 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import React, { useEffect } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
@@ -61,7 +62,17 @@ export const EstablishmentBusinessFields = ({
         disabled={disabled}
         state={siretErrorToDisplay ? "error" : undefined}
         stateRelatedMessage={siretErrorToDisplay}
+        className={fr.cx("fr-mb-1w")}
       />
+      <a
+        href="https://annuaire-entreprises.data.gouv.fr/"
+        target="_blank"
+        rel="noreferrer"
+        className={fr.cx("fr-link")}
+      >
+        <i className={fr.cx("fr-icon-information-fill", "fr-icon--sm")} />
+        Retrouver votre siret sur l'Annuaire des Entreprises
+      </a>
       <Input
         label={formContents.businessName.label}
         hintText={formContents.businessName.hintText}
@@ -72,6 +83,7 @@ export const EstablishmentBusinessFields = ({
             establishmentInfos?.businessName || convention?.businessName || "",
         }}
         disabled={true}
+        className={fr.cx("fr-mt-3w")}
       />
     </>
   );

--- a/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
@@ -31,9 +31,12 @@ export const EstablishmentBusinessFields = ({
     control,
     name: "siret",
   });
+
   useEffect(() => {
-    updateSiret(currentSiretOnSiretField);
-  }, [currentSiretOnSiretField]);
+    if (currentSiret !== currentSiretOnSiretField) {
+      updateSiret(currentSiretOnSiretField);
+    }
+  }, [currentSiretOnSiretField, currentSiret]);
   // ====================
 
   useSiretRelatedField("businessName", {


### PR DESCRIPTION
## 📔  Description

- Ajouter un lien vers l'annuaire des entreprises sur le champ siret du form de convention
- Fix ne pas afficher d'erreur sur le siret manquant si on vient d'arriver sur le formulaire