### PR TITLE
#1388 - Bloquer les créations de conventions avec des dates de naissances qui font des ages > 120 ans

### DIFF
--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -333,7 +333,7 @@ describe("conventionDtoSchema", () => {
     ]);
   });
 
-  describe("constraint on dates", () => {
+  describe("constraints on convention start and end dates", () => {
     it("rejects misformatted submission dates", () => {
       const convention = new ConventionDtoBuilder()
         .withDateSubmission("not-a-date")
@@ -862,7 +862,7 @@ describe("conventionDtoSchema", () => {
     });
   });
 
-  describe("when beneficiary is too young", () => {
+  describe("constraints on beneficiary birthdate", () => {
     it('rejects when beneficiary age is under 16yr with internship kind "immersion"', () => {
       const immersionStartDate = new Date("2022-01-01");
       const beneficiary: Beneficiary<"immersion"> = {
@@ -912,6 +912,31 @@ describe("conventionDtoSchema", () => {
 
       expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
         "L'âge du bénéficiaire doit être au minimum de 10ans",
+      ]);
+    });
+
+    it("rejects when beneficiary age is greater than 120yr", () => {
+      const immersionStartDate = new Date("2022-01-01");
+      const beneficiary: Beneficiary<"immersion"> = {
+        birthdate: addDays(subYears(immersionStartDate, 300), 1).toISOString(),
+        email: "a@a.com",
+        firstName: "sdfgf",
+        lastName: "sdfs",
+        phone: "0011223344",
+        role: "beneficiary",
+        isRqth: false,
+      };
+
+      const convention = new ConventionDtoBuilder()
+        .withInternshipKind("immersion")
+        .withDateStart(immersionStartDate.toISOString())
+        .withDateEnd(new Date("2022-01-02").toISOString())
+        .withSchedule(reasonableSchedule)
+        .withBeneficiary(beneficiary)
+        .build();
+
+      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+        "Merci de vérifier votre date de naissance: avez-vous 299 ans ?",
       ]);
     });
 

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -915,7 +915,7 @@ describe("conventionDtoSchema", () => {
       ]);
     });
 
-    it("rejects when beneficiary age is greater than 120yr", () => {
+    describe("when beneficiary age is greater than 120yr", () => {
       const immersionStartDate = new Date("2022-01-01");
       const beneficiary: Beneficiary<"immersion"> = {
         birthdate: addDays(subYears(immersionStartDate, 300), 1).toISOString(),
@@ -927,17 +927,25 @@ describe("conventionDtoSchema", () => {
         isRqth: false,
       };
 
-      const convention = new ConventionDtoBuilder()
-        .withInternshipKind("immersion")
-        .withDateStart(immersionStartDate.toISOString())
-        .withDateEnd(new Date("2022-01-02").toISOString())
-        .withSchedule(reasonableSchedule)
-        .withBeneficiary(beneficiary)
-        .build();
+      it("accepts when convention is created before 2024-04-30", () => {
+        const convention = new ConventionDtoBuilder()
+          .withBeneficiary(beneficiary)
+          .withDateSubmission("2024-04-29")
+          .build();
 
-      expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
-        "Merci de vérifier votre date de naissance: avez-vous 299 ans ?",
-      ]);
+        expectConventionDtoToBeValid(convention);
+      });
+
+      it("rejects when convention is created after 2024-04-30", () => {
+        const convention = new ConventionDtoBuilder()
+          .withBeneficiary(beneficiary)
+          .withDateSubmission("2024-04-30 14:00:00")
+          .build();
+
+        expectConventionInvalidWithIssueMessages(conventionSchema, convention, [
+          "Merci de vérifier votre date de naissance: avez-vous 299 ans ?",
+        ]);
+      });
     });
 
     describe("convention with no beneficiary representative for a beneficiary under 18", () => {

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -97,6 +97,7 @@ export const maximumCalendarDayByInternshipKind: Record<
   immersion: 30,
   "mini-stage-cci": 5,
 };
+export const BENEFICIARY_MAXIMUM_AGE_REQUIREMENT = 120;
 export const IMMERSION_BENEFICIARY_MINIMUM_AGE_REQUIREMENT = 16;
 export const MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT = 10;
 export const IMMERSION_WEEKLY_LIMITED_SCHEDULE_HOURS = 48;

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -23,7 +23,7 @@ import {
 import { siretSchema } from "../siret/siret.schema";
 import { expiredMagicLinkErrorMessage } from "../tokens/jwt.dto";
 import { OmitFromExistingKeys, phoneRegExp } from "../utils";
-import { dateRegExp } from "../utils/date";
+import { DateString, dateRegExp } from "../utils/date";
 import { addressWithPostalCodeSchema } from "../utils/postalCode";
 import {
   localization,
@@ -344,6 +344,7 @@ export const conventionSchema: z.Schema<ConventionDto> = conventionCommonSchema
     addIssueIfAgeMoreThanMaximumAge(
       addIssue,
       beneficiaryAgeAtConventionStart,
+      convention.dateSubmission,
       BENEFICIARY_MAXIMUM_AGE_REQUIREMENT,
     );
 
@@ -582,9 +583,14 @@ const addIssueIfAgeLessThanMinimumAge = (
 const addIssueIfAgeMoreThanMaximumAge = (
   addIssue: (message: string, path: string) => void,
   beneficiaryAgeAtConventionStart: number,
+  dateSubmission: DateString,
   maximumAgeRequirement: number,
 ) => {
-  if (beneficiaryAgeAtConventionStart > maximumAgeRequirement)
+  const onlyCheckConventionsCreatedBeforeDate = new Date("2024-04-30");
+  if (
+    beneficiaryAgeAtConventionStart > maximumAgeRequirement &&
+    new Date(dateSubmission) > onlyCheckConventionsCreatedBeforeDate
+  )
     addIssue(
       `Merci de vérifier votre date de naissance: avez-vous ${beneficiaryAgeAtConventionStart} ans ?`,
       getConventionFieldName("signatories.beneficiary.birthdate"),

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -37,6 +37,7 @@ import {
 } from "../zodUtils";
 import { getConventionFieldName } from "./convention";
 import {
+  BENEFICIARY_MAXIMUM_AGE_REQUIREMENT,
   Beneficiary,
   BeneficiaryCurrentEmployer,
   BeneficiaryRepresentative,
@@ -340,6 +341,12 @@ export const conventionSchema: z.Schema<ConventionDto> = conventionCommonSchema
       );
     }
 
+    addIssueIfAgeMoreThanMaximumAge(
+      addIssue,
+      beneficiaryAgeAtConventionStart,
+      BENEFICIARY_MAXIMUM_AGE_REQUIREMENT,
+    );
+
     const message = validateSchedule({
       dateEnd: convention.dateEnd,
       dateStart: convention.dateStart,
@@ -568,6 +575,18 @@ const addIssueIfAgeLessThanMinimumAge = (
   if (beneficiaryAgeAtConventionStart < miniumAgeRequirement)
     addIssue(
       `L'âge du bénéficiaire doit être au minimum de ${miniumAgeRequirement}ans`,
+      getConventionFieldName("signatories.beneficiary.birthdate"),
+    );
+};
+
+const addIssueIfAgeMoreThanMaximumAge = (
+  addIssue: (message: string, path: string) => void,
+  beneficiaryAgeAtConventionStart: number,
+  maximumAgeRequirement: number,
+) => {
+  if (beneficiaryAgeAtConventionStart > maximumAgeRequirement)
+    addIssue(
+      `Merci de vérifier votre date de naissance: avez-vous ${beneficiaryAgeAtConventionStart} ans ?`,
       getConventionFieldName("signatories.beneficiary.birthdate"),
     );
 };


### PR DESCRIPTION
## 📔 Problème

Sur le formulaire deb convention, l'utilisateur peut affecter une date de naissance incohérente au bénéficiaire. On constate en prod de dates de naissance "1674-06-18", "1881-01-01", "0075-09-28", etc.

## 💯 Solution

Bloquer les soumissions de bénéficiaire ayant plus de 120 ans:
![Screenshot 2024-04-26 at 16 50 15](https://github.com/gip-inclusion/immersion-facile/assets/11294487/d41ebaf3-0aa1-4f4b-bb93-d42c3d266944)

## 🦄  Remarques

En prod, nous avons actuellement 17 conventions à venir avec des bénéficiaires à année de naissance < 1900.

```sql
SELECT conventions.status, actors.extra_fields, conventions.created_at, conventions.date_start FROM conventions
LEFT JOIN actors on conventions.beneficiary_id = actors.id
WHERE (actors.extra_fields ->> 'birthdate')::date < '1904-04-26' and conventions.date_start > '2024-04-26' and conventions.status != 'REJECTED';
```
Certaines de ces conventions sont même validées au statut "ACCEPTED_BY_VALIDATOR".
Qu'en fait-on ?