### PR TITLE
#1472 conserver le nom du conseiller

### DIFF
--- a/back/src/domains/convention/adapters/PgConventionRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionRepository.integration.test.ts
@@ -553,6 +553,7 @@ describe("PgConventionRepository", () => {
       .withId(conventionId)
       .withStatus("ACCEPTED_BY_COUNSELLOR")
       .withValidator({ firstname: "John", lastname: "Doe" })
+      .withCounsellor({ firstname: "Billy", lastname: "Idol" })
       .withBeneficiaryEmail("some.updated@email.com")
       .withStatusJustification("some justification")
       .withDateEnd(new Date("2021-01-20").toISOString())

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.ts
@@ -125,9 +125,18 @@ export class UpdateConventionStatus extends TransactionalUseCase<
       )
       .withStatusJustification(statusJustification);
 
+    const hasCounsellor =
+      params.status === "ACCEPTED_BY_COUNSELLOR" &&
+      (params.lastname || params.firstname);
+    if (hasCounsellor) {
+      conventionBuilder.withCounsellor({
+        firstname: params.firstname,
+        lastname: params.lastname,
+      });
+    }
+
     const hasValidator =
-      (params.status === "ACCEPTED_BY_COUNSELLOR" ||
-        params.status === "ACCEPTED_BY_VALIDATOR") &&
+      params.status === "ACCEPTED_BY_VALIDATOR" &&
       (params.lastname || params.firstname);
     if (hasValidator)
       conventionBuilder.withValidator({

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -343,6 +343,16 @@ export const ConventionDocumentPage = ({
                   </strong>
                 </li>
               )}
+            {convention.validators?.agencyCounsellor && (
+              <li>
+                Examinée par :{" "}
+                <strong>
+                  {convention.validators?.agencyCounsellor.firstname}{" "}
+                  {convention.validators?.agencyCounsellor.lastname}
+                </strong>{" "}
+                (conseiller qui examine préalablement la demande de convention)
+              </li>
+            )}
             {convention.validators?.agencyValidator && (
               <li>
                 Validée par :{" "}
@@ -350,7 +360,7 @@ export const ConventionDocumentPage = ({
                   {convention.validators?.agencyValidator.firstname}{" "}
                   {convention.validators?.agencyValidator.lastname}
                 </strong>{" "}
-                (conseiller valideur)
+                (conseiller qui valide définitivement la demande de convention)
               </li>
             )}
           </ul>

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -647,22 +647,27 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   }
 
   public withValidator(
-    validator: ConventionValidatorInputName,
+    agencyValidator: ConventionValidatorInputName,
   ): ConventionDtoBuilder {
-    const validatorKind: keyof ConventionValidatorInputNames =
-      this.dto.status === "ACCEPTED_BY_COUNSELLOR"
-        ? "agencyCounsellor"
-        : "agencyValidator";
     this.dto = {
       ...this.dto,
-      validators: this.dto.validators
-        ? {
-            ...this.dto.validators,
-            [validatorKind]: validator,
-          }
-        : {
-            [validatorKind]: validator,
-          },
+      validators: {
+        ...this.dto.validators,
+        agencyValidator,
+      },
+    };
+    return new ConventionDtoBuilder(this.dto);
+  }
+
+  public withCounsellor(
+    agencyCounsellor: ConventionValidatorInputName,
+  ): ConventionDtoBuilder {
+    this.dto = {
+      ...this.dto,
+      validators: {
+        ...this.dto.validators,
+        agencyCounsellor,
+      },
     };
     return new ConventionDtoBuilder(this.dto);
   }


### PR DESCRIPTION
Actuellement en prod sans la présente PR, on retrouve déjà le conseiller en DB. Les précédents dev ont fait le taf pour conserver le conseiller.