### PR TITLE
#1480 - Être redirigé sur le helpdesk sur /aide

### DIFF
--- a/front/scalingo/nginx.conf.erb
+++ b/front/scalingo/nginx.conf.erb
@@ -18,3 +18,13 @@ location /api {
   proxy_buffer_size 16k;
   proxy_busy_buffers_size 16k;
 }
+
+location /aide {
+    proxy_pass https://immersion-facilitee.crisp.help/;
+    proxy_http_version 1.1;
+
+    proxy_ssl_server_name on;
+
+    proxy_set_header Accept-Encoding "";
+    proxy_set_header Access-Control-Allow-Origin "*";
+}


### PR DESCRIPTION
Actuellement l'url du helpdesk est https://aide.immersion-facile.beta.gouv.fr/fr/ 
On voudrait: https://immersion-facile.beta.gouv.fr/aide/ 

Si cette PR fonctionne, next steps:

- changer toutes les URL redirigeant vers le helpdesk
- supprimer le vieux dossier /nginx ?