### PR TITLE
#1542 blocker les formulaire quand emailable indique que le mail n'est pas valide

### DIFF
--- a/back/src/domains/core/email-validation/adapters/EmailableEmailValidationGateway.manual.test.ts
+++ b/back/src/domains/core/email-validation/adapters/EmailableEmailValidationGateway.manual.test.ts
@@ -1,20 +1,18 @@
 import axios from "axios";
-import { ValidateEmailStatus } from "shared";
+import { ValidateEmailStatus, expectToEqual } from "shared";
 import { createAxiosSharedClient } from "shared-routes/axios";
 import { AppConfig } from "../../../../config/bootstrap/appConfig";
 import { EmailValidationGetaway } from "../ports/EmailValidationGateway";
 import { EmailableEmailValidationGateway } from "./EmailableEmailValidationGateway";
 import { emailableValidationRoutes } from "./EmailableEmailValidationGateway.routes";
 
-describe("Emailable email validation gateway", () => {
+describe("EmailableEmailValidationGateway", () => {
   let emailableEmailValidationGateway: EmailValidationGetaway;
 
   beforeEach(() => {
-    const apiKeyEmailable = AppConfig.createFromEnv().emailableApiKey;
-
     emailableEmailValidationGateway = new EmailableEmailValidationGateway(
       createAxiosSharedClient(emailableValidationRoutes, axios),
-      apiKeyEmailable,
+      AppConfig.createFromEnv().emailableApiKey,
     );
   });
 
@@ -27,6 +25,7 @@ describe("Emailable email validation gateway", () => {
         candidateEmail: "enguerran.weiss@beta.gouv.fr",
         expectedStatus: {
           isValid: true,
+          proposal: null,
           reason: "accepted_email",
         },
       },
@@ -34,6 +33,7 @@ describe("Emailable email validation gateway", () => {
         candidateEmail: "enguerranweiss@beta.gouv.fr",
         expectedStatus: {
           isValid: false,
+          proposal: null,
           reason: "rejected_email",
         },
       },
@@ -50,9 +50,10 @@ describe("Emailable email validation gateway", () => {
     it.each(candidates)(
       "Candidate email '$candidateEmail' should match expected given status",
       async ({ candidateEmail, expectedStatus }) => {
-        const emailStatus =
-          await emailableEmailValidationGateway.validateEmail(candidateEmail);
-        expect(emailStatus).toEqual(expectedStatus);
+        expectToEqual(
+          await emailableEmailValidationGateway.validateEmail(candidateEmail),
+          expectedStatus,
+        );
       },
       10000,
     );

--- a/back/src/domains/core/email-validation/adapters/InMemoryEmailValidationGateway.ts
+++ b/back/src/domains/core/email-validation/adapters/InMemoryEmailValidationGateway.ts
@@ -13,6 +13,24 @@ export class InMemoryEmailValidationGateway implements EmailValidationGetaway {
 
   public async validateEmail(email: string): Promise<ValidateEmailStatus> {
     if (this.#emailValidationStatus) return this.#emailValidationStatus;
+    if (email.includes("@donotexist"))
+      return {
+        isValid: false,
+        reason: "invalid_domain",
+        proposal: null,
+      };
+    if (email.includes("donotexist@"))
+      return {
+        isValid: false,
+        reason: "rejected_email",
+        proposal: null,
+      };
+    if (email.includes("error@"))
+      return {
+        isValid: false,
+        reason: "unexpected_error",
+        proposal: null,
+      };
     if (email === "email-with-typo@gamil.com")
       return {
         isValid: false,
@@ -21,6 +39,7 @@ export class InMemoryEmailValidationGateway implements EmailValidationGetaway {
       };
     return {
       isValid: true,
+      proposal: null,
       reason: "accepted_email",
     };
   }

--- a/front/src/app/components/forms/commons/EmailValidationInput.tsx
+++ b/front/src/app/components/forms/commons/EmailValidationInput.tsx
@@ -1,7 +1,7 @@
 import { Input, InputProps } from "@codegouvfr/react-dsfr/Input";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
-import { Email, ValidateEmailReason, ValidateEmailStatus } from "shared";
+import { ValidateEmailReason, ValidateEmailStatus } from "shared";
 import { outOfReduxDependencies } from "src/config/dependencies";
 
 type EmailValidationInputProps = InputProps.RegularInput & {
@@ -14,44 +14,56 @@ type StateRelated = {
 };
 
 const defaultErrorMessage =
-  "L'adresse email ne semble pas valide. Si vous êtes sûr de ne pas avoir fait d'erreur, vous pouvez tout de même faire une demande de convention.";
+  "L'adresse email ne semble pas valide. Si vous êtes sûr de ne pas avoir fait d'erreur, vous pouvez tout de même la proposer.";
 const emailSeemsValidMessage = "L'adresse email a l'air valide";
+const noVerifyMessage =
+  "Il y a un problème de connexion qui ne nous permet pas de vérifier votre email. Veuillez vous assurer de n'avoir pas fait une erreur.";
 
-const feedbackMessages = (
+// https://help.emailable.com/en-us/article/verification-results-all-possible-states-and-reasons-fjsjn2/
+export const feedbackMessages = (
   proposal: string | null | undefined,
 ): Record<ValidateEmailReason, string> => ({
   accepted_email: emailSeemsValidMessage,
   disposable_email: "L'adresse email semble être une adresse jetable",
   low_deliverability: emailSeemsValidMessage,
   low_quality: emailSeemsValidMessage,
-  unexpected_error: defaultErrorMessage,
-  invalid_domain: defaultErrorMessage,
-  invalid_email: defaultErrorMessage,
-  rejected_email: proposal
-    ? `Cette adresse email ne semble pas valide, avez-vous voulu taper : ${proposal} ?`
-    : defaultErrorMessage,
-  invalid_smtp: defaultErrorMessage,
-  unavailable_smtp: defaultErrorMessage,
-  no_connect:
-    "Il y a un problème de connexion qui ne nous permet pas de vérifier votre email.  Si vous êtes sûr de ne pas avoir fait d'erreur, vous pouvez tout de même faire une demande de convention.",
+  invalid_domain:
+    "Le domaine de l'email proposé ( après @ ) n'est pas valide ou n'existe pas.",
+  invalid_email: "L'email n'est pas valide.",
+  rejected_email: `Cette adresse email n'existe pas ${
+    proposal ? `, avez-vous voulu taper : ${proposal} ?` : "."
+  }`,
+  invalid_smtp:
+    "Le système propriétaire de l'email fourni n'est pas disponible pour vérifier la validité de l'email",
+  unavailable_smtp:
+    "Le système propriétaire de l'email fourni n'est pas disponible pour vérifier la validité de l'email",
+  unexpected_error:
+    "L'email n'a pas pu être vérifié suite à une erreur inconnue, veuillez bien vérifier par vous même que l'email soit valide.",
+  no_connect: noVerifyMessage,
+  service_unavailable: noVerifyMessage,
 });
 
+export const validateEmailBlockReasons: ValidateEmailReason[] = [
+  "invalid_domain",
+  "invalid_email",
+  "rejected_email",
+];
+
 const getStateRelatedFromStatus = (
-  status: ValidateEmailStatus,
-  stateRelated: StateRelated,
-): StateRelated => {
-  if (stateRelated.state === "error")
-    return {
-      state: stateRelated.state,
-      stateRelatedMessage: stateRelated.stateRelatedMessage,
-    };
-  return {
-    state: status.isValid ? "success" : "error",
-    stateRelatedMessage: status.reason
-      ? feedbackMessages(status.proposal)[status.reason]
-      : defaultErrorMessage,
-  };
-};
+  { isValid, proposal, reason }: ValidateEmailStatus,
+  { state, stateRelatedMessage }: StateRelated,
+): StateRelated =>
+  state === "error"
+    ? {
+        state,
+        stateRelatedMessage,
+      }
+    : {
+        state: isValid ? "success" : "error",
+        stateRelatedMessage: reason
+          ? feedbackMessages(proposal)[reason]
+          : defaultErrorMessage,
+      };
 
 export const EmailValidationInput = (props: EmailValidationInputProps) => {
   const [currentInputValue, setCurrentInputValue] = useState<string>("");
@@ -61,30 +73,33 @@ export const EmailValidationInput = (props: EmailValidationInputProps) => {
     state,
     stateRelatedMessage,
   });
-  const onInputBlur = async () => {
-    try {
-      const isFieldValid = await trigger(props.nativeInputProps?.name);
-      if (currentInputValue && isFieldValid) {
-        await sendEmailValidationRequest(currentInputValue);
-      }
-    } catch (error: any) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
-  };
-  const sendEmailValidationRequest = async (email: Email) => {
-    const emailValidationStatus =
-      await outOfReduxDependencies.technicalGateway.getEmailStatus(email);
-    props.onEmailValidationFeedback?.(emailValidationStatus);
-    setStateRelated(
-      getStateRelatedFromStatus(emailValidationStatus, {
-        state: stateRelated.state,
-        stateRelatedMessage: stateRelated.stateRelatedMessage,
-      }),
-    );
-  };
 
-  const onInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onBlur = async (): Promise<void> =>
+    trigger(props.nativeInputProps?.name)
+      .then((isFieldValid) =>
+        currentInputValue && isFieldValid
+          ? outOfReduxDependencies.technicalGateway.getEmailStatus(
+              currentInputValue,
+            )
+          : undefined,
+      )
+      .then((emailValidationStatus) => {
+        if (emailValidationStatus) {
+          props.onEmailValidationFeedback?.(emailValidationStatus);
+          setStateRelated(
+            getStateRelatedFromStatus(emailValidationStatus, {
+              state: stateRelated.state,
+              stateRelatedMessage: stateRelated.stateRelatedMessage,
+            }),
+          );
+        }
+      })
+      .catch((error) => {
+        //eslint-disable-next-line no-console
+        console.error(error);
+      });
+
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setCurrentInputValue(event.target.value);
     setStateRelated({
       state: "default",
@@ -98,8 +113,8 @@ export const EmailValidationInput = (props: EmailValidationInputProps) => {
       {...props}
       nativeInputProps={{
         ...props.nativeInputProps,
-        onBlur: onInputBlur,
-        onChange: onInputChange,
+        onBlur,
+        onChange,
         type: "email",
       }}
       {...stateRelated}

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryCurrentEmployerFields.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryCurrentEmployerFields.tsx
@@ -4,6 +4,15 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import { ConventionDto, addressDtoToString } from "shared";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "src/app/components/forms/commons/EmailValidationInput";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import {
   getFormContents,
@@ -11,7 +20,13 @@ import {
 } from "src/app/hooks/formContents.hooks";
 import { AddressAutocomplete } from "../../../autocomplete/AddressAutocomplete";
 
-export const BeneficiaryCurrentEmployerFields = (): JSX.Element => {
+export const BeneficiaryCurrentEmployerFields = ({
+  setEmailValidationErrors,
+  emailValidationErrors,
+}: {
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
+}): JSX.Element => {
   const { setValue, getValues, register, formState } =
     useFormContext<ConventionDto>();
   const values = getValues();
@@ -143,16 +158,30 @@ export const BeneficiaryCurrentEmployerFields = (): JSX.Element => {
         }}
         {...getFieldError("signatories.beneficiaryCurrentEmployer.phone")}
       />
-      <Input
-        label={formFields["signatories.beneficiaryCurrentEmployer.email"].label}
+      <EmailValidationInput
         hintText={
           formFields["signatories.beneficiaryCurrentEmployer.email"].hintText
         }
+        label={formFields["signatories.beneficiaryCurrentEmployer.email"].label}
         nativeInputProps={{
           ...formFields["signatories.beneficiaryCurrentEmployer.email"],
           ...register("signatories.beneficiaryCurrentEmployer.email"),
         }}
         {...getFieldError("signatories.beneficiaryCurrentEmployer.email")}
+        onEmailValidationFeedback={({ isValid, reason, proposal }) => {
+          const { "Employeur actuel du bénéficiaire": _, ...rest } =
+            emailValidationErrors;
+
+          setEmailValidationErrors({
+            ...rest,
+            ...(!isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? {
+                  "Employeur actuel du bénéficiaire":
+                    feedbackMessages(proposal)[reason],
+                }
+              : {}),
+          });
+        }}
       />
     </>
   );

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
@@ -13,6 +13,10 @@ import {
   levelsOfEducation,
 } from "shared";
 import { ConventionEmailWarning } from "src/app/components/forms/convention/ConventionEmailWarning";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { booleanSelectOptions } from "src/app/contents/forms/common/values";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import {
@@ -23,16 +27,25 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { conventionSelectors } from "src/core-logic/domain/convention/convention.selectors";
 import { conventionSlice } from "src/core-logic/domain/convention/convention.slice";
-import { EmailValidationInput } from "../../../commons/EmailValidationInput";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "../../../commons/EmailValidationInput";
 import { BeneficiaryCurrentEmployerFields } from "./BeneficiaryCurrentEmployerFields";
 import { BeneficiaryEmergencyContactFields } from "./BeneficiaryEmergencyContactFields";
 import { BeneficiaryRepresentativeFields } from "./BeneficiaryRepresentativeFields";
 
 type beneficiaryFormSectionProperties = {
   internshipKind: InternshipKind;
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
 };
+
 export const BeneficiaryFormSection = ({
   internshipKind,
+  setEmailValidationErrors,
+  emailValidationErrors,
 }: beneficiaryFormSectionProperties): JSX.Element => {
   const [isMinorAccordingToAge, setIsMinorAccordingToAge] = useState(false);
   const isMinorOrProtected = useAppSelector(conventionSelectors.isMinor);
@@ -161,6 +174,18 @@ export const BeneficiaryFormSection = ({
           ...(userFieldsAreFilled ? { value: connectedUser.email } : {}),
         }}
         {...getFieldError("signatories.beneficiary.email")}
+        onEmailValidationFeedback={({ isValid, reason, proposal }) => {
+          const { Bénéficiaire: _, ...rest } = emailValidationErrors;
+
+          setEmailValidationErrors({
+            ...rest,
+            ...(!isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? {
+                  Bénéficiaire: feedbackMessages(proposal)[reason],
+                }
+              : {}),
+          });
+        }}
       />
 
       {values.signatories.beneficiary.email && <ConventionEmailWarning />}
@@ -255,7 +280,12 @@ export const BeneficiaryFormSection = ({
         />
       )}
 
-      {isMinorOrProtected && <BeneficiaryRepresentativeFields />}
+      {isMinorOrProtected && (
+        <BeneficiaryRepresentativeFields
+          emailValidationErrors={emailValidationErrors}
+          setEmailValidationErrors={setEmailValidationErrors}
+        />
+      )}
 
       <RadioButtons
         legend={formContents["signatories.beneficiary.isRqth"].label}
@@ -303,7 +333,12 @@ export const BeneficiaryFormSection = ({
             }))}
           />
 
-          {hasCurrentEmployer && <BeneficiaryCurrentEmployerFields />}
+          {hasCurrentEmployer && (
+            <BeneficiaryCurrentEmployerFields
+              emailValidationErrors={emailValidationErrors}
+              setEmailValidationErrors={setEmailValidationErrors}
+            />
+          )}
         </>
       )}
     </>

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryRepresentativeFields.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryRepresentativeFields.tsx
@@ -3,17 +3,31 @@ import React, { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { ConventionReadDto, filterNotFalsy } from "shared";
 import { ConventionEmailWarning } from "src/app/components/forms/convention/ConventionEmailWarning";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import {
   getFormContents,
   makeFieldError,
 } from "src/app/hooks/formContents.hooks";
-import { EmailValidationInput } from "../../../commons/EmailValidationInput";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "../../../commons/EmailValidationInput";
 
-type BeneficiaryRepresentativeFieldsProps = { disabled?: boolean };
+type BeneficiaryRepresentativeFieldsProps = {
+  disabled?: boolean;
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
+};
 
 export const BeneficiaryRepresentativeFields = ({
   disabled,
+  setEmailValidationErrors,
+  emailValidationErrors,
 }: BeneficiaryRepresentativeFieldsProps) => {
   const { register, getValues, setValue, watch, formState } =
     useFormContext<ConventionReadDto>();
@@ -104,6 +118,20 @@ export const BeneficiaryRepresentativeFields = ({
           ...register("signatories.beneficiaryRepresentative.email"),
         }}
         {...getFieldError("signatories.beneficiaryRepresentative.email")}
+        onEmailValidationFeedback={({ isValid, reason, proposal }) => {
+          const { "Représentant légal du bénéficiaire": _, ...rest } =
+            emailValidationErrors;
+
+          setEmailValidationErrors({
+            ...rest,
+            ...(!isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? {
+                  "Représentant légal du bénéficiaire":
+                    feedbackMessages(proposal)[reason],
+                }
+              : {}),
+          });
+        }}
       />
       {values.signatories.beneficiaryRepresentative?.email && (
         <ConventionEmailWarning />

--- a/front/src/app/components/forms/convention/sections/establishment/EstablishementTutorFields.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishementTutorFields.tsx
@@ -2,18 +2,33 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useSelector } from "react-redux";
-import { ConventionDto } from "shared";
+import { ConventionReadDto } from "shared";
 import { ConventionEmailWarning } from "src/app/components/forms/convention/ConventionEmailWarning";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import {
   getFormContents,
   makeFieldError,
 } from "src/app/hooks/formContents.hooks";
 import { siretSelectors } from "src/core-logic/domain/siret/siret.selectors";
-import { EmailValidationInput } from "../../../commons/EmailValidationInput";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "../../../commons/EmailValidationInput";
 
-export const EstablishementTutorFields = (): JSX.Element => {
-  const { register, getValues, formState } = useFormContext<ConventionDto>();
+export const EstablishementTutorFields = ({
+  setEmailValidationErrors,
+  emailValidationErrors,
+}: {
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
+}): JSX.Element => {
+  const { register, getValues, formState } =
+    useFormContext<ConventionReadDto>();
   const values = getValues();
   const getFieldError = makeFieldError(formState);
   const { getFormFields } = getFormContents(
@@ -71,6 +86,19 @@ export const EstablishementTutorFields = (): JSX.Element => {
           ...register("establishmentTutor.email"),
         }}
         {...getFieldError("establishmentTutor.email")}
+        onEmailValidationFeedback={({ isValid, reason, proposal }) => {
+          const { "Tuteur de l'entreprise": _, ...rest } =
+            emailValidationErrors;
+
+          setEmailValidationErrors({
+            ...rest,
+            ...(!isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? {
+                  "Tuteur de l'entreprise": feedbackMessages(proposal)[reason],
+                }
+              : {}),
+          });
+        }}
       />
       {values.establishmentTutor?.email && <ConventionEmailWarning />}
     </>

--- a/front/src/app/components/forms/convention/sections/establishment/EstablishmentFormSection.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishmentFormSection.tsx
@@ -5,6 +5,10 @@ import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useDispatch, useSelector } from "react-redux";
 import { ConventionDto } from "shared";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { booleanSelectOptions } from "src/app/contents/forms/common/values";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import { useConventionTexts } from "src/app/contents/forms/convention/textSetup";
@@ -18,7 +22,13 @@ import { EstablishementTutorFields } from "./EstablishementTutorFields";
 import { EstablishmentBusinessFields } from "./EstablishmentBusinessFields";
 import { EstablishmentRepresentativeFields } from "./EstablishmentRepresentativeFields";
 
-export const EstablishmentFormSection = (): JSX.Element => {
+export const EstablishmentFormSection = ({
+  setEmailValidationErrors,
+  emailValidationErrors,
+}: {
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
+}): JSX.Element => {
   useTutorIsEstablishmentRepresentative();
 
   const dispatch = useDispatch();
@@ -70,9 +80,15 @@ export const EstablishmentFormSection = (): JSX.Element => {
         }))}
         disabled={isFetchingSiret}
       />
-      <EstablishementTutorFields />
+      <EstablishementTutorFields
+        emailValidationErrors={emailValidationErrors}
+        setEmailValidationErrors={setEmailValidationErrors}
+      />
       {!isTutorEstablishmentRepresentative && (
-        <EstablishmentRepresentativeFields />
+        <EstablishmentRepresentativeFields
+          emailValidationErrors={emailValidationErrors}
+          setEmailValidationErrors={setEmailValidationErrors}
+        />
       )}
     </>
   );

--- a/front/src/app/components/forms/convention/sections/establishment/EstablishmentRepresentativeFields.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishmentRepresentativeFields.tsx
@@ -3,15 +3,29 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useSelector } from "react-redux";
-import { ConventionDto } from "shared";
+import { ConventionReadDto } from "shared";
 import { ConventionEmailWarning } from "src/app/components/forms/convention/ConventionEmailWarning";
+import {
+  EmailValidationErrorsState,
+  SetEmailValidationErrorsState,
+} from "src/app/components/forms/convention/ConventionFormFields";
 import { formConventionFieldsLabels } from "src/app/contents/forms/convention/formConvention";
 import { getFormContents } from "src/app/hooks/formContents.hooks";
 import { siretSelectors } from "src/core-logic/domain/siret/siret.selectors";
-import { EmailValidationInput } from "../../../commons/EmailValidationInput";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "../../../commons/EmailValidationInput";
 
-export const EstablishmentRepresentativeFields = (): JSX.Element => {
-  const { getValues, register } = useFormContext<ConventionDto>();
+export const EstablishmentRepresentativeFields = ({
+  setEmailValidationErrors,
+  emailValidationErrors,
+}: {
+  setEmailValidationErrors: SetEmailValidationErrorsState;
+  emailValidationErrors: EmailValidationErrorsState;
+}): JSX.Element => {
+  const { getValues, register } = useFormContext<ConventionReadDto>();
   const values = getValues();
   const { getFormFields } = getFormContents(
     formConventionFieldsLabels(values.internshipKind),
@@ -53,6 +67,20 @@ export const EstablishmentRepresentativeFields = (): JSX.Element => {
           ...register("signatories.establishmentRepresentative.email"),
         }}
         disabled={isFetchingSiret}
+        onEmailValidationFeedback={({ isValid, reason, proposal }) => {
+          const { "Responsable d'entreprise": _, ...rest } =
+            emailValidationErrors;
+
+          setEmailValidationErrors({
+            ...rest,
+            ...(!isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? {
+                  "Responsable d'entreprise":
+                    feedbackMessages(proposal)[reason],
+                }
+              : {}),
+          });
+        }}
       />
       {values.signatories.establishmentRepresentative?.email && (
         <ConventionEmailWarning />

--- a/front/src/app/components/forms/establishment/BusinessContact.tsx
+++ b/front/src/app/components/forms/establishment/BusinessContact.tsx
@@ -4,7 +4,7 @@ import {
   RadioButtons,
   RadioButtonsProps,
 } from "@codegouvfr/react-dsfr/RadioButtons";
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { UseFormRegisterReturn, useFormContext } from "react-hook-form";
 import { DotNestedKeys, FormEstablishmentDto, emailSchema } from "shared";
 import { MultipleEmailsInput } from "src/app/components/forms/commons/MultipleEmailsInput";
@@ -13,9 +13,12 @@ import {
   getFormContents,
   makeFieldError,
 } from "src/app/hooks/formContents.hooks";
+import {
+  EmailValidationInput,
+  feedbackMessages,
+  validateEmailBlockReasons,
+} from "../commons/EmailValidationInput";
 import { Mode } from "./EstablishmentForm";
-
-import { EmailValidationInput } from "../commons/EmailValidationInput";
 
 const preferredContactMethodOptions = (
   register: UseFormRegisterReturn<string>,
@@ -48,7 +51,12 @@ const preferredContactMethodOptions = (
 export const BusinessContact = ({
   readOnly,
   mode,
-}: { readOnly?: boolean; mode: Mode }) => {
+  setInvalidEmailMessage,
+}: {
+  readOnly?: boolean;
+  mode: Mode;
+  setInvalidEmailMessage: Dispatch<SetStateAction<string | null>>;
+}) => {
   const { getFormFields } = getFormContents(
     formEstablishmentFieldsLabels(mode),
   );
@@ -112,6 +120,13 @@ export const BusinessContact = ({
         {...getFieldError(
           "businessContact.email" as DotNestedKeys<FormEstablishmentDto>,
         )} // seems we have an issue with our DotNestedKeys
+        onEmailValidationFeedback={({ isValid, reason, proposal }) =>
+          setInvalidEmailMessage(
+            !isValid && reason && validateEmailBlockReasons.includes(reason)
+              ? feedbackMessages(proposal)[reason]
+              : null,
+          )
+        }
       />
       <MultipleEmailsInput
         disabled={readOnly}

--- a/front/src/app/components/forms/establishment/EstablishmentForm.tsx
+++ b/front/src/app/components/forms/establishment/EstablishmentForm.tsx
@@ -115,6 +115,9 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
   const [availableForImmersion, setAvailableForImmersion] = useState<
     boolean | undefined
   >(undefined);
+  const [invalidEmailMessage, setInvalidEmailMessage] = useState<string | null>(
+    null,
+  );
 
   const [currentStep, setCurrentStep] = useState<Step>(
     isEstablishmentAdmin || isEstablishmentDashboard ? null : 0,
@@ -416,6 +419,7 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                   mode={mode}
                   onStepChange={onStepChange}
                   currentStep={currentStep}
+                  setInvalidEmailMessage={setInvalidEmailMessage}
                 />
                 <h2>{steps[4].title}</h2>
                 <DetailsSection
@@ -423,6 +427,7 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                   isEstablishmentAdmin={isEstablishmentAdmin}
                   currentStep={currentStep}
                   onStepChange={onStepChange}
+                  invalidEmailMessage={invalidEmailMessage}
                 />
               </>
             ))
@@ -459,6 +464,7 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                       mode={mode}
                       onStepChange={onStepChange}
                       currentStep={currentStep}
+                      setInvalidEmailMessage={setInvalidEmailMessage}
                     />
                   ))
                   .with(4, () => (
@@ -467,6 +473,7 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                       mode={mode}
                       currentStep={currentStep}
                       onStepChange={onStepChange}
+                      invalidEmailMessage={invalidEmailMessage}
                     />
                   ))
                   .exhaustive()}

--- a/front/src/app/components/forms/establishment/sections/BusinessContactSection.tsx
+++ b/front/src/app/components/forms/establishment/sections/BusinessContactSection.tsx
@@ -1,6 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { domElementIds } from "shared";
 import { BusinessContact } from "../BusinessContact";
 import { Mode, OnStepChange, Step } from "../EstablishmentForm";
@@ -9,15 +9,20 @@ export const BusinessContactSection = ({
   onStepChange,
   currentStep,
   mode,
+  setInvalidEmailMessage,
 }: {
   onStepChange: OnStepChange;
   currentStep: Step;
   mode: Mode;
+  setInvalidEmailMessage: Dispatch<SetStateAction<string | null>>;
 }) => {
   const isStepMode = currentStep !== null;
   return (
     <section className={fr.cx("fr-mb-4w")}>
-      <BusinessContact mode={mode} />
+      <BusinessContact
+        mode={mode}
+        setInvalidEmailMessage={setInvalidEmailMessage}
+      />
       {isStepMode && (
         <ButtonsGroup
           inlineLayoutWhen="always"

--- a/front/src/app/components/forms/establishment/sections/DetailsSection.tsx
+++ b/front/src/app/components/forms/establishment/sections/DetailsSection.tsx
@@ -43,11 +43,13 @@ export const DetailsSection = ({
   isEstablishmentAdmin,
   currentStep,
   onStepChange,
+  invalidEmailMessage,
 }: {
   isEstablishmentAdmin: boolean;
   mode: Mode;
   currentStep: Step;
   onStepChange: OnStepChange;
+  invalidEmailMessage: string | null;
 }) => {
   const adminJwt = useAdminToken();
   const dispatch = useDispatch();
@@ -93,7 +95,7 @@ export const DetailsSection = ({
       iconId: "fr-icon-checkbox-circle-line",
       iconPosition: "right",
       type: "submit",
-      disabled: isSubmitting,
+      disabled: isSubmitting || invalidEmailMessage !== null,
       id: domElementIds.establishment[mode].submitFormButton,
     },
   ];
@@ -273,6 +275,14 @@ export const DetailsSection = ({
           severity="error"
           title="Erreur lors de la suppression"
           description="Veuillez nous excuser. Un problème est survenu lors de la suppression de l'entreprise."
+        />
+      )}
+
+      {invalidEmailMessage !== null && (
+        <Alert
+          severity="error"
+          title="Email invalide"
+          description={`L'émail de contact de l'entreprise a été invalidé par notre vérificateur d'émail pour la raison suivante: ${invalidEmailMessage}`}
         />
       )}
 

--- a/shared/src/email/validateEmail.dto.ts
+++ b/shared/src/email/validateEmail.dto.ts
@@ -12,14 +12,15 @@ export const validateEmailReason = [
   "unavailable_smtp",
   "unexpected_error",
   "no_connect",
+  "service_unavailable",
 ] as const;
 
 export type ValidateEmailReason = (typeof validateEmailReason)[number];
 
 export type ValidateEmailStatus = {
   isValid: boolean;
-  proposal?: string | null;
-  reason?: ValidateEmailReason | null;
+  proposal: string | null;
+  reason: ValidateEmailReason | null;
 };
 
 export const validateMultipleEmailRegex =

--- a/shared/src/email/validateEmail.schema.ts
+++ b/shared/src/email/validateEmail.schema.ts
@@ -15,6 +15,6 @@ export const validateEmailReasonSchema = z.enum(validateEmailReason);
 export const validateEmailResponseSchema: z.Schema<ValidateEmailStatus> =
   z.object({
     isValid: z.boolean(),
-    proposal: z.string().nullable().optional(),
+    proposal: z.string().or(z.null()),
     reason: validateEmailReasonSchema,
   });


### PR DESCRIPTION
- Formulaire convention
- Formulaire entreprise
- Formulaire Mise en Relation par email



Le bouton d'envoi du form est désactivé avec un message sur les champs email comme avant mais aussi un message de rappel au niveau du bouton

![image](https://github.com/gip-inclusion/immersion-facile/assets/58432308/c1521310-d9a7-49ee-ab43-c8f487fef4e5)
![image](https://github.com/gip-inclusion/immersion-facile/assets/58432308/c1d70f38-a449-4fbe-85a6-c2aac07f9146)

Si il y a un problème pour vérifier l'email, on indique le feedback sur le champ MAIS on ne bloque pas le formulaire

![image](https://github.com/gip-inclusion/immersion-facile/assets/58432308/a6a98a4a-2f8b-44b7-9645-a61246d921f9)
![image](https://github.com/gip-inclusion/immersion-facile/assets/58432308/8a1849e5-1ffb-4eba-9caf-69646a88b874)




