### PR TITLE
TECH - ajouter toutes les erreurs de synchro de conventions PE dans la table saved_errors

### DIFF
--- a/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
+++ b/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
@@ -189,7 +189,10 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
             }: ${JSON.stringify(error)}`,
           );
 
-          throw error;
+          return {
+            status: 500,
+            message: JSON.stringify(error),
+          };
         }
 
         const message = !error.response.data?.message


### PR DESCRIPTION
## 🦄 Description

Lors d'un erreur d'envoi de convention à PE de type "noResponseInAxiosError", l'erreur est seulement visible dans les logs.
Pour savoir que cette convention n'a pas été envoyée à PE, il faut parser les logs 😬 

## 🤖 Solution

Pour éviter de parser les log, ajouter cette erreur dans la table saved_erros.