### PR TITLE
FIX sauvegarder les erreurs au lieu des AxiosError ou AxiosResponse dans savedError afin d'éviter les erreurs circulaires

### DIFF
--- a/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
+++ b/back/src/domains/convention/adapters/pole-emploi-gateway/HttpPoleEmploiGateway.ts
@@ -145,17 +145,16 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
           },
         });
 
-        return {
-          status: response.status,
-          ...([200, 201].includes(response.status)
-            ? {}
-            : {
-                subscriberErrorFeedback: {
-                  message: "Unsupported response status",
-                  response,
-                },
-              }),
-        };
+        if ([200, 201].includes(response.status))
+          return {
+            status: response.status,
+          };
+
+        throw new Error(
+          `Unsupported response status ${
+            response.status
+          } with body '${JSON.stringify(response.body)}'`,
+        );
       })
       .catch((err): PoleEmploiBroadcastResponse => {
         const error = castError(err);
@@ -179,7 +178,8 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
           return {
             status: 500,
             subscriberErrorFeedback: {
-              message: `not an axios error ${error.message}`,
+              message: `Not an axios error: ${error.message}`,
+              error,
             },
           };
         }
@@ -205,7 +205,7 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
             status: 500,
             subscriberErrorFeedback: {
               message: error.message,
-              response: error,
+              error,
             },
           };
         }
@@ -229,7 +229,7 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
             status: 404,
             subscriberErrorFeedback: {
               message,
-              response: error.response,
+              error,
             },
           };
         }
@@ -252,7 +252,7 @@ export class HttpPoleEmploiGateway implements PoleEmploiGateway {
         return {
           status: error.response.status,
           subscriberErrorFeedback: {
-            response: error.response,
+            error,
             message,
           },
         };

--- a/back/src/domains/core/api-consumer/ports/SubscribersGateway.ts
+++ b/back/src/domains/core/api-consumer/ports/SubscribersGateway.ts
@@ -1,4 +1,3 @@
-import { AxiosError, AxiosResponse } from "axios";
 import {
   AbsoluteUrl,
   ConventionId,
@@ -33,7 +32,7 @@ type NotifyResponseSuccess = NotifyResponseCommon & {
 export type SubscriberResponse = NotifyResponseError | NotifyResponseSuccess;
 export type SubscriberErrorFeedback = {
   message: string;
-  response?: AxiosResponse<any, any> | AxiosError<any, any>;
+  error?: Error;
 };
 
 export interface SubscribersGateway {

--- a/back/src/domains/core/saved-errors/adapters/PgSavedErrorRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgSavedErrorRepository.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from "axios";
 import { sql } from "kysely";
 import { ConventionId } from "shared";
 import { NotFoundError } from "../../../../config/helpers/httpErrors";
@@ -45,9 +46,16 @@ export class PgSavedErrorRepository implements SavedErrorRepository {
         service_name: serviceName,
         consumer_name: consumerName,
         consumer_id: consumerId,
-        subscriber_error_feedback: sql`CAST(${JSON.stringify(
-          subscriberErrorFeedback,
-        )} AS JSONB)`,
+        subscriber_error_feedback: JSON.stringify({
+          message: subscriberErrorFeedback.message,
+          ...(subscriberErrorFeedback.error
+            ? {
+                error: isAxiosError(subscriberErrorFeedback.error)
+                  ? subscriberErrorFeedback.error.toJSON()
+                  : JSON.stringify(subscriberErrorFeedback.error),
+              }
+            : {}),
+        }),
         params: params ?? null,
         occurred_at: occurredAt,
         handled_by_agency: handledByAgency,


### PR DESCRIPTION
Il manque le renommage de la prop `response` par `error` dans le JSONB de la table savedError en base pour les records existants mais c'est pas indispensable pour le pilotage des erreurs de synchro et les tableaux de pilotage