### PR TITLE
Tech: renommer la propriété response en error dans saved errors et fix de la serialization error dans le repo

### DIFF
--- a/back/src/config/pg/migrations/1717072048544_rename-saved-errors-message-prop.ts
+++ b/back/src/config/pg/migrations/1717072048544_rename-saved-errors-message-prop.ts
@@ -1,24 +1,20 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { MigrationBuilder } from "node-pg-migrate";
 
 const tableName = "saved_errors";
 const columnName = "subscriber_error_feedback";
 
-const oldProperty = "response";
-const newProperty = "error";
-
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(`
     UPDATE ${tableName}
-    SET ${columnName} = ${columnName} - '${oldProperty}'  || jsonb_build_object('${newProperty}', ${columnName} -> '${oldProperty}')
-    WHERE ${columnName} ? '${oldProperty}'
+    SET ${columnName} = ${columnName} - 'response'  || jsonb_build_object('error', ${columnName} -> 'response')
+    WHERE ${columnName} ? 'response'
   `);
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.sql(`
     UPDATE ${tableName}
-    SET ${columnName} = ${columnName} - '${newProperty}'  || jsonb_build_object('${oldProperty}', ${columnName} -> '${newProperty}')
-    WHERE ${columnName} ? '${newProperty}'
+    SET ${columnName} = ${columnName} - 'error'  || jsonb_build_object('response', ${columnName} -> 'error')
+    WHERE ${columnName} ? 'error'
   `);
 }

--- a/back/src/config/pg/migrations/1717072048544_rename-saved-errors-message-prop.ts
+++ b/back/src/config/pg/migrations/1717072048544_rename-saved-errors-message-prop.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+const tableName = "saved_errors";
+const columnName = "subscriber_error_feedback";
+
+const oldProperty = "response";
+const newProperty = "error";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE ${tableName}
+    SET ${columnName} = ${columnName} - '${oldProperty}'  || jsonb_build_object('${newProperty}', ${columnName} -> '${oldProperty}')
+    WHERE ${columnName} ? '${oldProperty}'
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE ${tableName}
+    SET ${columnName} = ${columnName} - '${newProperty}'  || jsonb_build_object('${oldProperty}', ${columnName} -> '${newProperty}')
+    WHERE ${columnName} ? '${newProperty}'
+  `);
+}

--- a/back/src/domains/core/saved-errors/adapters/PgSavedErrorRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgSavedErrorRepository.ts
@@ -52,7 +52,11 @@ export class PgSavedErrorRepository implements SavedErrorRepository {
             ? {
                 error: isAxiosError(subscriberErrorFeedback.error)
                   ? subscriberErrorFeedback.error.toJSON()
-                  : JSON.stringify(subscriberErrorFeedback.error),
+                  : // Why?  >> https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
+                    JSON.stringify(
+                      subscriberErrorFeedback.error,
+                      Object.getOwnPropertyNames(subscriberErrorFeedback.error),
+                    ),
               }
             : {}),
         }),

--- a/back/src/scripts/seed.ts
+++ b/back/src/scripts/seed.ts
@@ -14,6 +14,7 @@ import {
 } from "shared";
 import { AppConfig } from "../config/bootstrap/appConfig";
 import { createAppDependencies } from "../config/bootstrap/createAppDependencies";
+import { ForbiddenError } from "../config/helpers/httpErrors";
 import { KyselyDb, makeKyselyDb } from "../config/pg/kysely/kyselyUtils";
 import { SavedError } from "../domains/core/saved-errors/ports/SavedErrorRepository";
 import { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
@@ -341,7 +342,10 @@ const conventionSeed = async (uow: UnitOfWork) => {
 
   const savedError: SavedError = {
     handledByAgency: false,
-    subscriberErrorFeedback: { message: "message de la seed" },
+    subscriberErrorFeedback: {
+      message: "message de la seed",
+      error: new ForbiddenError("Une erreur dans la seed"),
+    },
     consumerId: null,
     consumerName: "Fake consumer",
     occurredAt: addDays(new Date(peConvention.dateSubmission), 2),


### PR DESCRIPTION
L'ancienne sérialisation quand on avait une Error stockait `{}` dans la base au lieu d'indiquer le détail.
Les AxiosError ne sont pas impacté car AxiosError a sa propre fonction de sérialisation.