### PR TITLE
TECH - fix erreur 500 non repertoriée dans les routes

### DIFF
--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -129,7 +129,11 @@ export class HttpConventionGateway implements ConventionGateway {
             .with({ status: 403 }, ({ body }) => {
               throw new Error("message" in body ? body.message : body.errors);
             })
-
+            .with({ status: 500 }, ({ body }) => {
+              throw new Error(
+                body.errors.map((error) => error.message).join(", "),
+              );
+            })
             .otherwise(otherwiseThrow),
         ),
     );

--- a/shared/src/convention/convention.routes.ts
+++ b/shared/src/convention/convention.routes.ts
@@ -1,4 +1,5 @@
 import { defineRoute, defineRoutes } from "shared-routes";
+import { z } from "zod";
 import { shareLinkByEmailSchema } from "../ShareLinkByEmailDto";
 import { assessmentSchema } from "../assessment/assessment.schema";
 import { dashboardUrlAndNameSchema } from "../dashboard/dashboard.schema";
@@ -45,6 +46,15 @@ export const conventionMagicLinkRoutes = defineRoutes({
       400: httpErrorSchema,
       403: renewMagicLinkResponseSchema.or(legacyHttpErrorSchema),
       404: legacyHttpErrorSchema,
+      500: z.object({
+        errors: z.array(
+          z.object({
+            code: z.string(),
+            message: z.string(),
+            path: z.array(z.string()),
+          }),
+        ),
+      }),
     },
   }),
   getConventionStatusDashboard: defineRoute({


### PR DESCRIPTION
## 🌈 Description

Sur la route getCOnvention, l'erreur 500 n'est pas repertoriée.
Il s'agit d'une erreur zod.

## ✏️ Remarques

Je n'ai pas trouvé si on avait déjà un type qui existait pour les erreurs axios.