### PR TITLE
TECH - Fix crawler quand plusieurs publications avec failures

### DIFF
--- a/back/src/domains/core/events/adapters/InMemoryEventBus.unit.test.ts
+++ b/back/src/domains/core/events/adapters/InMemoryEventBus.unit.test.ts
@@ -1,3 +1,4 @@
+import { addMinutes } from "date-fns";
 import {
   ConventionDtoBuilder,
   expectObjectsToMatch,
@@ -181,6 +182,15 @@ describe("InMemoryEventBus", () => {
             },
           ],
         },
+        {
+          publishedAt: addMinutes(initialPublishDate, 15).toISOString(),
+          failures: [
+            {
+              subscriptionId: "other-id",
+              errorMessage: "Initially Failed",
+            },
+          ],
+        },
       ],
     };
 
@@ -201,21 +211,7 @@ describe("InMemoryEventBus", () => {
       const expectedEvent: DomainEvent = {
         ...domainEvt,
         wasQuarantined: false,
-        publications: [
-          {
-            publishedAt: initialPublishDate.toISOString(),
-            failures: [
-              {
-                subscriptionId: failedSubscriptionId,
-                errorMessage: "Initially Failed",
-              },
-            ],
-          },
-          {
-            publishedAt: rePublishDate.toISOString(),
-            failures: [],
-          },
-        ],
+        publications: eventToRePublish.publications,
         status: "published",
       };
 

--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -363,7 +363,7 @@ export const calculateWeeklyHours = (
             : previousValue,
         0,
       )
-      .toFixed(1),
+      .toFixed(2),
   );
 
 export const defaultTimePeriods: TimePeriodsDto = [

--- a/shared/src/schedule/ScheduleUtils.unit.test.ts
+++ b/shared/src/schedule/ScheduleUtils.unit.test.ts
@@ -380,6 +380,52 @@ describe("ScheduleUtils", () => {
         );
       });
     });
+
+    it("calculate and shows totals hours correctly", () => {
+      const interval: DateIntervalDto = {
+        start: new Date("2024-06-03"),
+        end: new Date("2024-06-06"),
+      };
+      const schedule = new ScheduleDtoBuilder()
+        .withDateInterval(interval)
+        .withComplexSchedule([
+          {
+            date: new Date("2024-06-03").toISOString(),
+            timePeriods: [
+              { start: "09:00", end: "12:45" },
+              { start: "13:15", end: "17:00" },
+            ],
+          },
+          {
+            date: new Date("2024-06-04").toISOString(),
+            timePeriods: [
+              { start: "09:00", end: "12:45" },
+              { start: "13:15", end: "17:30" },
+            ],
+          },
+          {
+            date: new Date("2024-06-05").toISOString(),
+            timePeriods: [{ start: "09:00", end: "12:15" }],
+          },
+          {
+            date: new Date("2024-06-06").toISOString(),
+            timePeriods: [
+              { start: "09:00", end: "12:45" },
+              { start: "13:15", end: "17:00" },
+            ],
+          },
+        ])
+        .build();
+
+      expectToEqual(
+        prettyPrintSchedule(schedule, interval),
+        `Heures de travail hebdomadaires : 26.25
+lundi : 09:00-12:45, 13:15-17:00
+mardi : 09:00-12:45, 13:15-17:30
+mercredi : 09:00-12:15
+jeudi : 09:00-12:45, 13:15-17:00`,
+      );
+    });
   });
 
   describe("calculateTotalDurationInDays", () => {


### PR DESCRIPTION
## Description

Lorsque l'on resynchronise une convention avec i-milo via les requêtes suivantes https://metabase.immersion-facile.beta.gouv.fr/question/1704-resynchroniser-une-convention-i-milo?conventionId=, il se peut que l'évènement outbox reste coincé en statut "failed-but-will-retry".