### PR TITLE
#1766 - suppression des balises script du contenu html envoyé au générateur pdf

### DIFF
--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -146,13 +146,20 @@ export const ConventionDocumentPage = ({
         new RegExp(/<img src="\//gm),
         `<img src="${window.location.origin}/`,
       );
+  const prepareContentForPdfGenerator = (content: string) => {
+    const contentWithoutScripts = content.replace(
+      /((<(\s*)(script)(\s*)(\/*)(\s*)>((.|\n)*?)<(\s*)(\/+)(\s*)(script)(\s*)>)|<(\s*)(\/*)(\s*)(script)(\s*)(\/*)(\s*)>)*/gi,
+      "",
+    );
+    return replaceContentsUrlWithAbsoluteUrl(contentWithoutScripts);
+  };
 
   const onDownloadPdfClick = async () => {
     try {
       setIsPdfLoading(true);
       const pdfContent =
         await outOfReduxDependencies.technicalGateway.htmlToPdf(
-          replaceContentsUrlWithAbsoluteUrl(document.documentElement.outerHTML),
+          prepareContentForPdfGenerator(document.documentElement.outerHTML),
           jwt,
         );
       const downloadLink = document.createElement("a");


### PR DESCRIPTION
Le générateur PDF nous renvoie une timeout (après 2,5 secondes) sans avoir reçu d'événement load de son instance Puppeteer. L'idée est d'alléger les ressources inutiles, tout en conservant le rendu, pour qu'il évite de tomber en timeout. 

Donc déjà, supprimer les balises script, qui ne sont pas très utiles dans un pdf.