### PR TITLE
TECH POC création d'un helper de creation de use case : `createTransactionnalUseCase` 

### DIFF
--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -15,7 +15,7 @@ import { UpdateAgencyReferringToUpdatedAgency } from "../../domains/agency/use-c
 import { UpdateAgencyStatus } from "../../domains/agency/use-cases/UpdateAgencyStatus";
 import { AddConvention } from "../../domains/convention/use-cases/AddConvention";
 import { AddValidatedConventionNps } from "../../domains/convention/use-cases/AddValidatedConventionNps";
-import { CreateAssessment } from "../../domains/convention/use-cases/CreateAssessment";
+import { makeCreateAssessment } from "../../domains/convention/use-cases/CreateAssessment";
 import { GetAgencyPublicInfoById } from "../../domains/convention/use-cases/GetAgencyPublicInfoById";
 import { GetConvention } from "../../domains/convention/use-cases/GetConvention";
 import { GetConventionForApiConsumer } from "../../domains/convention/use-cases/GetConventionForApiConsumer";
@@ -52,7 +52,7 @@ import { LookupLocation } from "../../domains/core/address/use-cases/LookupLocat
 import { LookupStreetAddress } from "../../domains/core/address/use-cases/LookupStreetAddress";
 import { BroadcastToPartnersOnConventionUpdates } from "../../domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates";
 import { DeleteSubscription } from "../../domains/core/api-consumer/use-cases/DeleteSubscription";
-import { ListActiveSubscriptions } from "../../domains/core/api-consumer/use-cases/ListActiveSubscriptions";
+import { makeListActiveSubscriptions } from "../../domains/core/api-consumer/use-cases/ListActiveSubscriptions";
 import { SaveApiConsumer } from "../../domains/core/api-consumer/use-cases/SaveApiConsumer";
 import { SubscribeToWebhook } from "../../domains/core/api-consumer/use-cases/SubscribeToWebhook";
 import { AuthenticateWithInclusionCode } from "../../domains/core/authentication/inclusion-connect/use-cases/AuthenticateWithInclusionCode";
@@ -250,7 +250,6 @@ export const createUseCases = (
       ),
 
       // Conventions
-      createAssessment: new CreateAssessment(uowPerformer, createNewEvent),
       addConvention,
       getConvention: new GetConvention(uowPerformer),
       getConventionForApiConsumer: new GetConventionForApiConsumer(
@@ -536,7 +535,6 @@ export const createUseCases = (
           gateways.subscribersGateway,
           gateways.timeGateway,
         ),
-      listActiveSubscriptions: new ListActiveSubscriptions(uowPerformer),
       subscribeToWebhook: new SubscribeToWebhook(
         uowPerformer,
         uuidGenerator,
@@ -602,6 +600,13 @@ export const createUseCases = (
             await uow.conventionQueries.findSimilarConventions(params),
         })),
     }),
+    createAssessment: makeCreateAssessment({
+      uowPerformer,
+      deps: { createNewEvent },
+    }),
+    listActiveSubscriptions: makeListActiveSubscriptions({
+      uowPerformer,
+    }),
   } satisfies Record<string, InstantiatedUseCase<any, any, any>>;
 };
 
@@ -638,7 +643,7 @@ const createInstantiatedUseCase = <Input = void, Output = void>(params: {
 }): InstantiatedUseCase<Input, Output, unknown> => params;
 
 const instantiatedUseCasesFromFunctions = <
-  T extends Record<string, (params: any) => Promise<unknown>>,
+  T extends Record<string, (...params: any[]) => Promise<unknown>>,
 >(
   lamdas: T,
 ): {

--- a/back/src/domains/convention/use-cases/CreateAssessment.ts
+++ b/back/src/domains/convention/use-cases/CreateAssessment.ts
@@ -21,7 +21,7 @@ export const makeCreateAssessment = createTransactionalUseCase<
   ConventionJwtPayload | undefined,
   WithCreateNewEvent
 >(
-  { useCaseName: "CreateAssessment", inputSchema: assessmentSchema },
+  { name: "CreateAssessment", inputSchema: assessmentSchema },
   async (dto, { uow, deps }, conventionJwtPayload) => {
     if (!conventionJwtPayload)
       throw new ForbiddenError("No magic link provided");

--- a/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
+++ b/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
@@ -24,7 +24,7 @@ import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGenera
 import { InMemoryAssessmentRepository } from "../adapters/InMemoryAssessmentRepository";
 import { InMemoryConventionRepository } from "../adapters/InMemoryConventionRepository";
 import { AssessmentEntity } from "../entities/AssessmentEntity";
-import { CreateAssessment } from "./CreateAssessment";
+import { CreateAssessment, makeCreateAssessment } from "./CreateAssessment";
 
 const conventionId = "conventionId";
 
@@ -64,18 +64,19 @@ describe("CreateAssessment", () => {
       .withId(conventionId)
       .build();
     conventionRepository.setConventions([convention]);
-    createAssessment = new CreateAssessment(
+    const createNewEvent = makeCreateNewEvent({
+      timeGateway: new CustomTimeGateway(),
+      uuidGenerator: new TestUuidGenerator(),
+    });
+    createAssessment = makeCreateAssessment({
       uowPerformer,
-      makeCreateNewEvent({
-        timeGateway: new CustomTimeGateway(),
-        uuidGenerator: new TestUuidGenerator(),
-      }),
-    );
+      deps: { createNewEvent },
+    });
   });
 
   it("throws forbidden if no magicLink payload is provided", async () => {
     await expectPromiseToFailWithError(
-      createAssessment.execute(assessment),
+      createAssessment.execute(assessment, undefined),
       new ForbiddenError("No magic link provided"),
     );
   });

--- a/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.ts
+++ b/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.ts
@@ -1,27 +1,22 @@
 import { keys } from "ramda";
 import { ApiConsumer, WebhookSubscription } from "shared";
 import { z } from "zod";
-import { ForbiddenError } from "../../../../config/helpers/httpErrors";
-import { TransactionalUseCase } from "../../UseCase";
-import { UnitOfWork } from "../../unit-of-work/ports/UnitOfWork";
+import { createTransactionalUseCase } from "../../UseCase";
 
-export class ListActiveSubscriptions extends TransactionalUseCase<
+export type ListActiveSubscriptions = ReturnType<
+  typeof makeListActiveSubscriptions
+>;
+
+export const makeListActiveSubscriptions = createTransactionalUseCase<
   void,
   WebhookSubscription[],
   ApiConsumer
-> {
-  protected inputSchema = z.void();
-
-  protected async _execute(
-    _: void,
-    _uow: UnitOfWork,
-    apiConsumer?: ApiConsumer,
-  ): Promise<WebhookSubscription[]> {
-    if (!apiConsumer) throw new ForbiddenError();
-
+>(
+  { useCaseName: "ListActiveSubscriptions", inputSchema: z.void() },
+  (_, _uow, apiConsumer) => {
     const subscriptions = keys(apiConsumer.rights).flatMap(
       (rightName) => apiConsumer.rights[rightName].subscriptions,
     );
     return Promise.resolve(subscriptions);
-  }
-}
+  },
+);

--- a/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.ts
+++ b/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.ts
@@ -12,7 +12,7 @@ export const makeListActiveSubscriptions = createTransactionalUseCase<
   WebhookSubscription[],
   ApiConsumer
 >(
-  { useCaseName: "ListActiveSubscriptions", inputSchema: z.void() },
+  { name: "ListActiveSubscriptions", inputSchema: z.void() },
   (_, _uow, apiConsumer) => {
     const subscriptions = keys(apiConsumer.rights).flatMap(
       (rightName) => apiConsumer.rights[rightName].subscriptions,

--- a/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/ListActiveSubscriptions.unit.test.ts
@@ -1,12 +1,14 @@
-import { WebhookSubscription, expectPromiseToFailWithError } from "shared";
-import { ForbiddenError } from "../../../../config/helpers/httpErrors";
+import { WebhookSubscription } from "shared";
 import { InMemoryUowPerformer } from "../../unit-of-work/adapters/InMemoryUowPerformer";
 import {
   InMemoryUnitOfWork,
   createInMemoryUow,
 } from "../../unit-of-work/adapters/createInMemoryUow";
 import { ApiConsumerBuilder } from "../adapters/InMemoryApiConsumerRepository";
-import { ListActiveSubscriptions } from "./ListActiveSubscriptions";
+import {
+  ListActiveSubscriptions,
+  makeListActiveSubscriptions,
+} from "./ListActiveSubscriptions";
 
 describe("ListActiveSubscriptions", () => {
   let uow: InMemoryUnitOfWork;
@@ -14,16 +16,8 @@ describe("ListActiveSubscriptions", () => {
 
   beforeEach(() => {
     uow = createInMemoryUow();
-    listActiveSubscriptions = new ListActiveSubscriptions(
-      new InMemoryUowPerformer(uow),
-    );
-  });
-
-  it("throws a forbidden error when jwtPayload is not provided", async () => {
-    await expectPromiseToFailWithError(
-      listActiveSubscriptions.execute(),
-      new ForbiddenError("Accès refusé"),
-    );
+    const uowPerformer = new InMemoryUowPerformer(uow);
+    listActiveSubscriptions = makeListActiveSubscriptions({ uowPerformer });
   });
 
   it("returns empty list if no subscriptions", async () => {


### PR DESCRIPTION
Voilà un POC de proposition d'une fonction `createTransactionalUseCase`, qui pourrait remplacer (mais aussi cohabiter) la classe `TransactionnalUseCase`. Elle présente les aventantages suivant :

- pas besoin de retyper les paramêtres de la methode `execute` , qui dans le cas de la classe sont fournis 2 fois (une fois en générique de la classe, et une fois dans la methode execute).
- pas besoin d'explicitement écrire une methode execute :  on écrit un call back directement.
- le type du JwtPayload (nommé UserIdentity dans ce cas), est strict au niveau typage : on ne peut pas oublier de le fournir s'il est défini dans la fonction.

Je suis preneur de vos avis. J'ai fait 2 use cases d'exemple pour qu'on se rende compte de l'intérêt