### PR TITLE
#1780 - Fix l'update du siret (convention form)

### DIFF
--- a/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
+++ b/front/src/app/components/forms/convention/sections/establishment/EstablishmentBusinessFields.tsx
@@ -54,11 +54,9 @@ export const EstablishmentBusinessFields = (): JSX.Element => {
         nativeInputProps={{
           ...formContents.siret,
           ...register("siret"),
-          // NOT WORKING SINCE PREVIOUS UPDATE
-          // PROBABLY MISSING SET FROM VALUE ON CHANGE
-          // onChange: (event) => {
-          //   updateSiret(event.target.value);
-          // },
+          onBlur: (event) => {
+            updateSiret(event.target.value);
+          },
           value: currentSiret || values.siret,
         }}
         disabled={isFetchingSiret}


### PR DESCRIPTION
C'est vraiment en mode hotfix : on réalimente le siret dans redux (vu que le form peut utiliser cette donnée dans certains cas). En faisant ça, je ne reproduis plus le souci rencontré (et ça fonctionne bien pour le partage).