### PR TITLE
TECH - fix autocompletion de la raison sociale sur le formualire de création d'une convention

### DIFF
--- a/back/src/domains/core/sirene/adapters/AnnuaireDesEntreprisesSiretGateway.ts
+++ b/back/src/domains/core/sirene/adapters/AnnuaireDesEntreprisesSiretGateway.ts
@@ -72,8 +72,11 @@ export const convertAdeEstablishmentToSirenEstablishmentDto = (
 ): SiretEstablishmentDto => ({
   siret: adeEstablishment.matching_etablissements[0].siret,
   businessName:
-    adeEstablishment.matching_etablissements[0].nom_commercial ??
-    adeEstablishment.nom_complet,
+    adeEstablishment.matching_etablissements[0].nom_commercial &&
+    adeEstablishment.matching_etablissements[0].nom_commercial?.trim().length >
+      0
+      ? adeEstablishment.matching_etablissements[0].nom_commercial
+      : adeEstablishment.nom_complet,
   businessAddress: adeEstablishment.matching_etablissements[0].adresse,
   nafDto: {
     code: (

--- a/back/src/domains/core/sirene/adapters/AnnuaireDesEntreprisesSiretGateway.unit.test.ts
+++ b/back/src/domains/core/sirene/adapters/AnnuaireDesEntreprisesSiretGateway.unit.test.ts
@@ -76,4 +76,25 @@ describe("convertAdeEstablishmentToSirenEstablishmentDto", () => {
       numberEmployeesRange: "1-2",
     });
   });
+
+  it("falls back to nom_complet if response contains an empty nom_commercial", async () => {
+    const response = await convertAdeEstablishmentToSirenEstablishmentDto({
+      ...validEstablishment,
+      matching_etablissements: [
+        {
+          ...validEstablishment.matching_etablissements[0],
+          nom_commercial: " ",
+        },
+      ],
+    });
+
+    expectToEqual(response, {
+      siret: "12345678901234",
+      businessName: validEstablishment.nom_complet,
+      businessAddress: "20 AVENUE DE SEGUR 75007 PARIS 7",
+      nafDto: { code: "783Z", nomenclature: "NAFRev2" },
+      isOpen: true,
+      numberEmployeesRange: "1-2",
+    });
+  });
 });


### PR DESCRIPTION
## 🌈 Description

Sur le formulaire de création de convention, la dénomination sociale ne se rempli pas pour ce siret 57578002800016.
Cela est dû au fait que l'annuaire retourne une string " " pour le nom_commercial.

## 👣 Étapes pour reproduire

1. Aller sur "remplir une demande de convention"
2. Dans la partie "3. Coordonnées de l'entreprise", saisir le siret: 57578002800016
3. Constater que la raison sociale de l'établissement ne se pré rempli pas.
