### PR TITLE
Fix - Valider une convention en étant admin mais aussi validator

### DIFF
--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
@@ -46,6 +46,7 @@ const allInclusionConnectedTestUsers = [
   "icUserWithRoleAgencyOwner",
   "icUserWithRoleEstablishmentRepresentative",
   "icUserWithRoleBackofficeAdmin",
+  "icUserWithRoleBackofficeAdminAndValidator",
 ] as const;
 
 type InclusionConnectedTestUser =
@@ -138,6 +139,27 @@ const makeUserIdMapInclusionConnectedUser: Record<
     lastName: "Validator",
     dashboards: { agencies: {}, establishments: {} },
     externalId: "icUserWithRoleValidator-external-id",
+    createdAt: new Date().toISOString(),
+  },
+  icUserWithRoleBackofficeAdminAndValidator: {
+    agencyRights: [
+      {
+        agency: agencyWithoutCounsellorEmail,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      },
+      {
+        agency: agencyWithCounsellorEmails,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      },
+    ],
+    email: "icUserWithRoleBackofficeAdminAndValidator@mail.com",
+    firstName: "icUserWithRoleBackofficeAdminAndValidator",
+    id: "icUserWithRoleBackofficeAdminAndValidator",
+    lastName: "Validator",
+    dashboards: { agencies: {}, establishments: {} },
+    externalId: "icUserWithRoleBackofficeAdminAndValidator-external-id",
     createdAt: new Date().toISOString(),
   },
 

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
@@ -55,6 +55,7 @@ describe("UpdateConventionStatus", () => {
         "icUserWithRoleValidator",
         "icUserWithRoleEstablishmentRepresentative",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: [
         "READY_TO_SIGN",
@@ -84,6 +85,7 @@ describe("UpdateConventionStatus", () => {
         "icUserWithRoleValidator",
         "icUserWithRoleEstablishmentRepresentative",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: [
         "READY_TO_SIGN",
@@ -380,7 +382,10 @@ describe("UpdateConventionStatus", () => {
       },
       expectedDomainTopic: "ConventionAcceptedByValidator",
       allowedMagicLinkRoles: ["validator"],
-      allowedInclusionConnectedUsers: ["icUserWithRoleValidator"],
+      allowedInclusionConnectedUsers: [
+        "icUserWithRoleValidator",
+        "icUserWithRoleBackofficeAdminAndValidator",
+      ],
       allowedInitialStatuses: ["IN_REVIEW", "ACCEPTED_BY_COUNSELLOR"],
       updatedFields: {
         dateValidation: validationDate.toISOString(),
@@ -401,7 +406,10 @@ describe("UpdateConventionStatus", () => {
         lastname: "Validator Lastname",
       },
       allowedMagicLinkRoles: ["validator"],
-      allowedInclusionConnectedUsers: ["icUserWithRoleValidator"],
+      allowedInclusionConnectedUsers: [
+        "icUserWithRoleValidator",
+        "icUserWithRoleBackofficeAdminAndValidator",
+      ],
       allowedInitialStatuses: ["IN_REVIEW", "ACCEPTED_BY_COUNSELLOR"],
     });
 
@@ -415,7 +423,10 @@ describe("UpdateConventionStatus", () => {
         },
         expectedDomainTopic: "ConventionAcceptedByValidator",
         allowedMagicLinkRoles: ["validator"],
-        allowedInclusionConnectedUsers: ["icUserWithRoleValidator"],
+        allowedInclusionConnectedUsers: [
+          "icUserWithRoleValidator",
+          "icUserWithRoleBackofficeAdminAndValidator",
+        ],
         allowedInitialStatuses: ["ACCEPTED_BY_COUNSELLOR"],
         updatedFields: {
           dateValidation: validationDate.toISOString(),
@@ -445,6 +456,7 @@ describe("UpdateConventionStatus", () => {
         "icUserWithRoleValidator",
         "icUserWithRoleCounsellor",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: [
         "PARTIALLY_SIGNED",
@@ -464,6 +476,7 @@ describe("UpdateConventionStatus", () => {
         "icUserWithRoleValidator",
         "icUserWithRoleCounsellor",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: [
         "PARTIALLY_SIGNED",
@@ -487,6 +500,7 @@ describe("UpdateConventionStatus", () => {
       allowedInclusionConnectedUsers: [
         "icUserWithRoleValidator",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: ["ACCEPTED_BY_VALIDATOR"],
     });
@@ -500,6 +514,7 @@ describe("UpdateConventionStatus", () => {
       allowedInclusionConnectedUsers: [
         "icUserWithRoleValidator",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: ["ACCEPTED_BY_VALIDATOR"],
     });
@@ -519,6 +534,7 @@ describe("UpdateConventionStatus", () => {
         "icUserWithRoleCounsellor",
         "icUserWithRoleValidator",
         "icUserWithRoleBackofficeAdmin",
+        "icUserWithRoleBackofficeAdminAndValidator",
       ],
       allowedInitialStatuses: [
         "PARTIALLY_SIGNED",


### PR DESCRIPTION
## 🌈 Description

Sur la page de convention, il y a bien un bouton pour valider la convention mais une erreur survient au clic:

![image](https://github.com/gip-inclusion/immersion-facile/assets/11294487/118b9e68-7cd4-4a75-b77d-8ead40cf7808)
