### PR TITLE
#1797 - afficher le tableau des utilisateurs rattachés à une agence depuis la page admin

### DIFF
--- a/back/src/domains/core/dashboard/port/InclusionConnectedUserRepository.ts
+++ b/back/src/domains/core/dashboard/port/InclusionConnectedUserRepository.ts
@@ -12,7 +12,7 @@ export type InclusionConnectedFilters = Partial<WithAgencyRole> & {
 
 export interface InclusionConnectedUserRepository {
   getWithFilter(
-    filter: InclusionConnectedFilters,
+    filters: InclusionConnectedFilters,
   ): Promise<InclusionConnectedUser[]>;
   getById(userId: string): Promise<InclusionConnectedUser | undefined>;
   updateAgencyRights(params: {

--- a/back/src/domains/inclusion-connected-users/use-cases/GetInclusionConnectedUsers.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/GetInclusionConnectedUsers.ts
@@ -1,25 +1,25 @@
 import {
   InclusionConnectedUser,
-  WithAgencyRole,
-  withAgencyRoleSchema,
+  WithUserFilters,
+  withUserFiltersSchema,
 } from "shared";
 import { TransactionalUseCase } from "../../core/UseCase";
 import { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
 import { throwIfNotAdmin } from "../helpers/throwIfIcUserNotBackofficeAdmin";
 
 export class GetInclusionConnectedUsers extends TransactionalUseCase<
-  WithAgencyRole,
+  WithUserFilters,
   InclusionConnectedUser[],
   InclusionConnectedUser
 > {
-  protected inputSchema = withAgencyRoleSchema;
+  protected inputSchema = withUserFiltersSchema;
 
   protected async _execute(
-    { agencyRole }: WithAgencyRole,
+    filters: WithUserFilters,
     uow: UnitOfWork,
     currentUser?: InclusionConnectedUser,
   ): Promise<InclusionConnectedUser[]> {
     throwIfNotAdmin(currentUser);
-    return uow.inclusionConnectedUserRepository.getWithFilter({ agencyRole });
+    return uow.inclusionConnectedUserRepository.getWithFilter(filters);
   }
 }

--- a/back/src/domains/inclusion-connected-users/use-cases/GetInclusionConnectedUsers.unit.test.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/GetInclusionConnectedUsers.unit.test.ts
@@ -105,7 +105,7 @@ describe("GetInclusionConnectedUsers", () => {
     );
   });
 
-  it("gets the users which have at least one agency with the given role", async () => {
+  it("gets the users by agencyRole which have at least one agency with the given role", async () => {
     inclusionConnectedUserRepository.setInclusionConnectedUsers([
       johnWithAgenciesToReview,
       paulWithAllAgenciesReviewed,
@@ -117,5 +117,22 @@ describe("GetInclusionConnectedUsers", () => {
     );
 
     expectToEqual(users, [johnWithAgenciesToReview]);
+  });
+
+  it("gets the users by agencyId which have at least one agency with the given role", async () => {
+    inclusionConnectedUserRepository.setInclusionConnectedUsers([
+      johnWithAgenciesToReview,
+      paulWithAllAgenciesReviewed,
+      backofficeAdminUser,
+    ]);
+    const users = await getInclusionConnectedUsers.execute(
+      { agencyId: agency1.id },
+      backofficeAdminUser,
+    );
+
+    expectToEqual(users, [
+      johnWithAgenciesToReview,
+      paulWithAllAgenciesReviewed,
+    ]);
   });
 });

--- a/front/src/app/components/agency/AgencyAdminAutocomplete.tsx
+++ b/front/src/app/components/agency/AgencyAdminAutocomplete.tsx
@@ -9,6 +9,7 @@ import { AgencyId, AgencyOption, propEq } from "shared";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
 import { agencyAdminSlice } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
+import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 import { useStyles } from "tss-react/dsfr";
 
 export const useAgencyAdminAutocomplete = () => {
@@ -17,8 +18,16 @@ export const useAgencyAdminAutocomplete = () => {
   return {
     updateSearchTerm: (searchTerm: string) =>
       dispatch(agencyAdminSlice.actions.setAgencySearchQuery(searchTerm)),
-    selectOption: (agencyId: AgencyId) =>
-      dispatch(agencyAdminSlice.actions.setSelectedAgencyId(agencyId)),
+    selectOption: (agencyId: AgencyId) => {
+      dispatch(agencyAdminSlice.actions.setSelectedAgencyId(agencyId));
+      dispatch(
+        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
+          {
+            agencyId,
+          },
+        ),
+      );
+    },
   };
 };
 

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -1,8 +1,69 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
+import { Table } from "@codegouvfr/react-dsfr/Table";
+import { values } from "ramda";
 import { Tooltip } from "react-design-system";
-import { domElementIds } from "shared";
+import { AgencyId, AgencyRole, domElementIds } from "shared";
+import { NormalizedIcUserById } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 
-export const AgencyUsers = () => {
+type AgencyUsersProperties = {
+  agencyId: AgencyId;
+  agencyUsers: NormalizedIcUserById;
+};
+
+const agencyRoleToDisplay: Record<AgencyRole, string> = {
+  toReview: "A valider",
+  validator: "Validateur",
+  agencyOwner: "Responsable d'agence",
+  counsellor: "Pré-validateur",
+  "agency-viewer": "Lecteur",
+};
+
+export const AgencyUsers = ({
+  agencyId,
+  agencyUsers,
+}: AgencyUsersProperties) => {
+  const tableData = values(agencyUsers).map((agencyUser) => {
+    const hasFirstNameOrLastName = agencyUser.firstName || agencyUsers.lastName;
+    const formattedUserInfo = (
+      <>
+        {hasFirstNameOrLastName ? (
+          <>
+            <strong>
+              {agencyUser.firstName} {agencyUser.lastName}
+            </strong>
+            <br />
+          </>
+        ) : (
+          <></>
+        )}
+        {agencyUser.email}
+      </>
+    );
+    const formattedUserRights = agencyUser.agencyRights[agencyId].roles.map(
+      (role) => {
+        if (role === "toReview") {
+          return (
+            <Badge severity="new" small>
+              {agencyRoleToDisplay[role]}
+            </Badge>
+          );
+        }
+        return (
+          <Badge small className={"fr-badge--purple-glycine"}>
+            {agencyRoleToDisplay[role]}
+          </Badge>
+        );
+      },
+    );
+    const formattedContactMode = agencyUser.agencyRights[agencyId]
+      .isNotifiedByEmail
+      ? "Reçoit les notifications"
+      : "Ne reçoit pas les notifications";
+
+    return [formattedUserInfo, formattedContactMode, formattedUserRights];
+  });
+
   return (
     <>
       <h5 className={fr.cx("fr-h5", "fr-mb-1v", "fr-mt-4w")}>Utilisateurs</h5>
@@ -16,6 +77,12 @@ export const AgencyUsers = () => {
           id={domElementIds.admin.agencyTab.editAgencyUserTooltip}
         />
       </div>
+      <Table
+        id={domElementIds.admin.agencyTab.agencyUsersTable}
+        headers={["Utilisateurs", "Préférence de communication", "Rôles"]}
+        data={tableData}
+        fixed
+      />
     </>
   );
 };

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -1,0 +1,21 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Tooltip } from "react-design-system";
+import { domElementIds } from "shared";
+
+export const AgencyUsers = () => {
+  return (
+    <>
+      <h5 className={fr.cx("fr-h5", "fr-mb-1v", "fr-mt-4w")}>Utilisateurs</h5>
+      <div className={fr.cx("fr-mb-2w", "fr-mt-1v")}>
+        Pourquoi certains utilisateurs n'ont pas de nom ?
+        <Tooltip
+          type="click"
+          description="Certains utilisateurs n'ont pas de compte Inclusion Connect. Ils
+            peuvent se créer un compte avec la même adresse email pour ajouter
+            leurs infos et accéder à leur espace personnel."
+          id={domElementIds.admin.agencyTab.editAgencyUserTooltip}
+        />
+      </div>
+    </>
+  );
+};

--- a/front/src/app/components/agency/EditAgency.tsx
+++ b/front/src/app/components/agency/EditAgency.tsx
@@ -1,5 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import React from "react";
+import { AgencyUsers } from "src/app/components/agency/AgencyUsers";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import "src/assets/admin.css";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
@@ -21,6 +22,7 @@ export const EditAgency = () => {
         />
       </div>
       {agency && <EditAgencyForm agency={agency} />}
+      {agency && <AgencyUsers />}
     </>
   );
 };

--- a/front/src/app/components/agency/EditAgency.tsx
+++ b/front/src/app/components/agency/EditAgency.tsx
@@ -4,11 +4,15 @@ import { AgencyUsers } from "src/app/components/agency/AgencyUsers";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import "src/assets/admin.css";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
+import { icUsersAdminSelectors } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors";
 import { EditAgencyForm } from "../forms/agency/EditAgencyForm";
 import { AgencyAdminAutocomplete } from "./AgencyAdminAutocomplete";
 
 export const EditAgency = () => {
   const agency = useAppSelector(agencyAdminSelectors.agency);
+  const agencyUsers = useAppSelector(
+    icUsersAdminSelectors.icUsersNeedingReviewSelector,
+  );
 
   return (
     <>
@@ -22,7 +26,7 @@ export const EditAgency = () => {
         />
       </div>
       {agency && <EditAgencyForm agency={agency} />}
-      {agency && <AgencyUsers />}
+      {agency && <AgencyUsers agencyId={agency.id} agencyUsers={agencyUsers} />}
     </>
   );
 };

--- a/front/src/app/components/agency/RegisterUsersToAgencies.tsx
+++ b/front/src/app/components/agency/RegisterUsersToAgencies.tsx
@@ -23,7 +23,9 @@ export const RegisterUsersToAgencies = () => {
 
   useEffect(() => {
     dispatch(
-      icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(),
+      icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested({
+        agencyRole: "toReview",
+      }),
     );
   }, [dispatch]);
 

--- a/front/src/app/components/forms/agency/EditAgencyForm.tsx
+++ b/front/src/app/components/forms/agency/EditAgencyForm.tsx
@@ -29,6 +29,7 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import "src/assets/admin.css";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
 import { agencyAdminSlice } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
+import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 
 type EditAgencyFormProperties = {
   agency: AgencyDto;
@@ -67,9 +68,16 @@ export const EditAgencyForm = ({
     <FormProvider {...methods}>
       <form
         className={fr.cx("fr-my-4w")}
-        onSubmit={handleSubmit((values) =>
-          dispatch(agencyAdminSlice.actions.updateAgencyRequested(values)),
-        )}
+        onSubmit={handleSubmit((values) => {
+          dispatch(agencyAdminSlice.actions.updateAgencyRequested(values));
+          dispatch(
+            icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
+              {
+                agencyId: agency.id,
+              },
+            ),
+          );
+        })}
         id={domElementIds.admin.agencyTab.editAgencyForm}
         data-matomo-name={domElementIds.admin.agencyTab.editAgencyForm}
       >

--- a/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
@@ -12,6 +12,7 @@ import {
   InclusionConnectedUser,
   RejectIcUserRoleForAgencyParams,
   SetFeatureFlagParam,
+  WithUserFilters,
   createApiConsumerParamsFromApiConsumer,
 } from "shared";
 import { HttpClient } from "shared-routes";
@@ -92,11 +93,12 @@ export class HttpAdminGateway implements AdminGateway {
 
   public getInclusionConnectedUsersToReview$(
     token: InclusionConnectJwt,
+    filters: WithUserFilters,
   ): Observable<InclusionConnectedUser[]> {
     return from(
       this.httpClient
         .getInclusionConnectedUsers({
-          queryParams: { agencyRole: "toReview" },
+          queryParams: filters,
           headers: { authorization: token },
         })
         .then((response) =>

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
@@ -7,6 +7,7 @@ import {
   IcUserRoleForAgencyParams,
   InclusionConnectedUser,
   RejectIcUserRoleForAgencyParams,
+  WithUserFilters,
 } from "shared";
 import { getAdminToken } from "src/core-logic/domain/admin/admin.helpers";
 import {
@@ -28,9 +29,10 @@ const fetchInclusionConnectedUsersWithAgencyNeedingReviewEpic: AppEpic<
       icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested
         .match,
     ),
-    switchMap((_action) =>
+    switchMap((action: PayloadAction<WithUserFilters>) =>
       adminGateway.getInclusionConnectedUsersToReview$(
         getAdminToken(state$.value),
+        action.payload,
       ),
     ),
     map(normalizeUsers),

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
@@ -52,4 +52,5 @@ export const icUsersAdminSelectors = {
   selectedUserId,
   agenciesNeedingReviewForSelectedUser,
   feedback: createSelector(icUsersAdminState, ({ feedback }) => feedback),
+  icUsersNeedingReviewSelector,
 };

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -7,6 +7,7 @@ import {
   OmitFromExistingKeys,
   RejectIcUserRoleForAgencyParams,
   UserId,
+  WithUserFilters,
 } from "shared";
 import { SubmitFeedBack } from "src/core-logic/domain/SubmitFeedback";
 
@@ -57,7 +58,10 @@ export const icUsersAdminSlice = createSlice({
       if (state.feedback.kind === "errored")
         state.feedback = { kind: "usersToReviewFetchSuccess" };
     },
-    fetchInclusionConnectedUsersToReviewRequested: (state) => {
+    fetchInclusionConnectedUsersToReviewRequested: (
+      state,
+      _action: PayloadAction<WithUserFilters>,
+    ) => {
       state.isFetchingAgenciesNeedingReviewForIcUser = true;
     },
     fetchInclusionConnectedUsersToReviewFailed: (

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.test.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.test.ts
@@ -148,9 +148,38 @@ describe("Agency registration for authenticated users", () => {
   });
 
   describe("fetches inclusion connected users that have agencies to review", () => {
-    it("gets the users successfully", () => {
+    it("gets the users by agencyId successfully", () => {
       store.dispatch(
-        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(),
+        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
+          {
+            agencyId: agency2.id,
+          },
+        ),
+      );
+      expectIsFetchingIcUsersNeedingReviewToBe(true);
+
+      dependencies.adminGateway.getAgencyUsersToReviewResponse$.next([
+        {
+          ...authUser1,
+          agencyRights: [agency1Right, agency2Right],
+          dashboards: { agencies: {}, establishments: {} },
+        },
+      ]);
+      expectIsFetchingIcUsersNeedingReviewToBe(false);
+      expectToEqual(
+        icUsersAdminSelectors.icUsersNeedingReview(store.getState()),
+        [authUser1],
+      );
+      expectFeedbackToEqual({ kind: "usersToReviewFetchSuccess" });
+    });
+
+    it("gets the users by agencyRole successfully", () => {
+      store.dispatch(
+        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
+          {
+            agencyRole: "toReview",
+          },
+        ),
       );
       expectIsFetchingIcUsersNeedingReviewToBe(true);
 
@@ -176,7 +205,11 @@ describe("Agency registration for authenticated users", () => {
 
     it("stores error message when something goes wrong in fetching", () => {
       store.dispatch(
-        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(),
+        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
+          {
+            agencyRole: "toReview",
+          },
+        ),
       );
       const errorMessage = "Error fetching users to review";
       expectIsFetchingIcUsersNeedingReviewToBe(true);

--- a/front/src/core-logic/ports/AdminGateway.ts
+++ b/front/src/core-logic/ports/AdminGateway.ts
@@ -12,6 +12,7 @@ import {
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
   SetFeatureFlagParam,
+  WithUserFilters,
 } from "shared";
 
 export interface AdminGateway {
@@ -26,6 +27,7 @@ export interface AdminGateway {
   ) => Observable<DashboardUrlAndName>;
   getInclusionConnectedUsersToReview$: (
     token: InclusionConnectJwt,
+    filters: WithUserFilters,
   ) => Observable<InclusionConnectedUser[]>;
   updateFeatureFlags$: (
     params: SetFeatureFlagParam,

--- a/shared/src/admin/admin.dto.ts
+++ b/shared/src/admin/admin.dto.ts
@@ -1,4 +1,8 @@
-import { ActiveOrRejectedStatus, AgencyId } from "../agency/agency.dto";
+import {
+  ActiveOrRejectedStatus,
+  AgencyId,
+  WithAgencyId,
+} from "../agency/agency.dto";
 import { ConventionId } from "../convention/convention.dto";
 import {
   AgencyRole,
@@ -23,6 +27,8 @@ export type RejectIcUserRoleForAgencyParams = OmitFromExistingKeys<
 export type WithAgencyRole = {
   agencyRole: AgencyRole;
 };
+
+export type WithUserFilters = WithAgencyId | WithAgencyRole;
 
 export type ManageConventionAdminForm = {
   conventionId: ConventionId;

--- a/shared/src/admin/admin.routes.ts
+++ b/shared/src/admin/admin.routes.ts
@@ -24,7 +24,7 @@ import { expressEmptyResponseBody } from "../zodUtils";
 import {
   icUserRoleForAgencyParamsSchema,
   rejectIcUserRoleForAgencyParamsSchema,
-  withAgencyRoleSchema,
+  withUserFiltersSchema,
 } from "./admin.schema";
 
 export type AdminRoutes = typeof adminRoutes;
@@ -76,7 +76,7 @@ export const adminRoutes = defineRoutes({
   getInclusionConnectedUsers: defineRoute({
     method: "get",
     url: "/admin/inclusion-connected/users",
-    queryParamsSchema: withAgencyRoleSchema,
+    queryParamsSchema: withUserFiltersSchema,
     ...withAuthorizationHeaders,
     responses: {
       200: z.array(inclusionConnectedUserSchema),

--- a/shared/src/admin/admin.schema.ts
+++ b/shared/src/admin/admin.schema.ts
@@ -12,7 +12,7 @@ import {
   ManageConventionAdminForm,
   ManageEstablishmentAdminForm,
   RejectIcUserRoleForAgencyParams,
-  WithAgencyRole,
+  WithUserFilters,
 } from "./admin.dto";
 
 export const icUserRoleForAgencyParamsSchema: z.Schema<IcUserRoleForAgencyParams> =
@@ -29,9 +29,15 @@ export const rejectIcUserRoleForAgencyParamsSchema: z.Schema<RejectIcUserRoleFor
     justification: zTrimmedString,
   });
 
-export const withAgencyRoleSchema: z.Schema<WithAgencyRole> = z.object({
-  agencyRole: agencyRoleSchema,
-});
+export const withUserFiltersSchema: z.Schema<WithUserFilters> = z
+  .object({
+    agencyRole: agencyRoleSchema,
+  })
+  .or(
+    z.object({
+      agencyId: agencyIdSchema,
+    }),
+  );
 
 export const manageConventionAdminFormSchema: z.Schema<ManageConventionAdminForm> =
   z.object({

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -552,6 +552,7 @@ export const domElementIds = {
       editAgencyFormStatusSelector: "im-form-edit-agency__status-select",
       editAgencyFormSafirCodeInput: "im-form-edit-agency__safir-code-input",
       editAgencyFormEditSubmitButton: "im-form-edit-agency__submit-button",
+      editAgencyUserTooltip: "im-edit-agency-tooltip",
       rejectAgencyModal: "im-reject-agency-modal",
       agencyToReviewInput: "im-agency-to-review__input",
       agencyToReviewButton: "im-agency-to-review__review-button",

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -547,6 +547,7 @@ export const domElementIds = {
       inclusionConnectButton: "im-login-form__inclusion-connect-button--admin",
     },
     agencyTab: {
+      agencyUsersTable: "im-agency-users-table",
       editAgencyForm: "im-form-edit-agency",
       activateAgencySelector: "agency-selector",
       editAgencyFormStatusSelector: "im-form-edit-agency__status-select",

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.dto.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.dto.ts
@@ -77,8 +77,9 @@ export type WithDashboards = {
   dashboards: WithAgencyDashboards & WithEstablishmentDashboards;
 };
 
-export type InclusionConnectedUser = User &
-  WithAgencyRights &
+export type UserWithAgencyRights = User & WithAgencyRights;
+
+export type InclusionConnectedUser = UserWithAgencyRights &
   WithEstablishments &
   WithDashboards & { isBackofficeAdmin?: boolean };
 

--- a/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.schema.ts
+++ b/shared/src/inclusionConnectedAllowed/inclusionConnectedAllowed.schema.ts
@@ -6,7 +6,11 @@ import { emailSchema } from "../email/email.schema";
 import { establishmentsRoles } from "../role/role.dto";
 import { dateTimeIsoStringSchema } from "../schedule/Schedule.schema";
 import { siretSchema } from "../siret/siret.schema";
-import { zStringMinLength1, zTrimmedString } from "../zodUtils";
+import {
+  zStringMinLength1,
+  zStringPossiblyEmpty,
+  zTrimmedString,
+} from "../zodUtils";
 import {
   AgencyRight,
   InclusionConnectedUser,
@@ -61,14 +65,12 @@ export const inclusionConnectedUserSchema: z.Schema<InclusionConnectedUser> =
   z.object({
     id: userIdSchema,
     email: emailSchema,
-    firstName: zStringMinLength1,
-    lastName: zStringMinLength1,
     createdAt: dateTimeIsoStringSchema,
     agencyRights: z.array(agencyRightSchema),
-
-    externalId: zStringMinLength1,
+    firstName: zStringPossiblyEmpty,
+    lastName: zStringPossiblyEmpty,
+    externalId: zStringPossiblyEmpty,
     dashboards: dashboardsSchema,
     establishments: z.array(withEstablishmentSiretAndName).optional(),
-
     isBackofficeAdmin: z.boolean().optional(),
   });

--- a/shared/src/zodUtils.ts
+++ b/shared/src/zodUtils.ts
@@ -75,6 +75,7 @@ export const zStringCanBeEmpty = z.string(requiredText);
 
 export const zStringPossiblyEmpty = zStringMinLength1
   .optional()
+  .or(z.null())
   .or(z.literal("")) as z.Schema<string>;
 
 export const zStringPossiblyEmptyWithMax = (max: number) =>


### PR DESCRIPTION
## Description

Ajout de la liste des utilisateurs liés à une agence:

![Screenshot 2024-07-12 at 16 11 54](https://github.com/user-attachments/assets/1458d8a0-1675-42f4-9b2b-399ce60ba0ec)


## TODO / suggestions
A faire dans d'autres PR:
- ~~renommer la route /admin/inclusion-connected/users car elle peut retourner des utilisateurs non inclusion connecté~~
- quand l'utilisateur n'a pas de compte inclusion connect, il n'a pas de firstname lastname: mais actuellement on sauvegarde une string vide --> changer pour un null ?
- utiliser le nouveau tableau du DSFR