### PR TITLE
#1822 - fix demande de renouvellement de modification de convention

### DIFF
--- a/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
+++ b/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
@@ -115,6 +115,7 @@ export const ConventionFormWrapper = ({
         .with(
           {
             formSuccessfullySubmitted: false,
+            shouldRedirectToError: false,
           },
           ({ showSummary }) =>
             showSummary ? (
@@ -124,7 +125,10 @@ export const ConventionFormWrapper = ({
             ),
         )
         .with(
-          { formSuccessfullySubmitted: true },
+          {
+            formSuccessfullySubmitted: true,
+            shouldRedirectToError: false,
+          },
           () =>
             fetchedConvention && (
               <SubmitConfirmationSection


### PR DESCRIPTION
## Description

Problème: Lorsque le lien magique est périmé, la page de formulaire de convention s'affiche quand même alors que l'on doit demander à l'utilisateur de renouveler son lien magique.