### PR TITLE
doc: added security.txt

### DIFF
--- a/front/public/.well-known/security.txt
+++ b/front/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:service.securite@gip-inclusion.org
+Policy: https://inclusion.beta.gouv.fr/.well-known/security-policy.txt
+Preferred-Languages: fr, en
+Expires: 2027-01-01T00:00:00.000Z
+Encryption: https://inclusion.beta.gouv.fr/.well-known/pdi-pgp.asc


### PR DESCRIPTION
I added `security.txt` file according to RFC9116 and linked directly to the PDI security policy.

It should server the file at `/.well-known/security.txt`