### PR TITLE
TECH - fix accéder au formulaire d'édition d'une agence

### DIFF
--- a/front/src/app/components/agency/AgencyAdminAutocomplete.tsx
+++ b/front/src/app/components/agency/AgencyAdminAutocomplete.tsx
@@ -21,11 +21,9 @@ export const useAgencyAdminAutocomplete = () => {
     selectOption: (agencyId: AgencyId) => {
       dispatch(agencyAdminSlice.actions.setSelectedAgencyId(agencyId));
       dispatch(
-        icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
-          {
-            agencyId,
-          },
-        ),
+        icUsersAdminSlice.actions.fetchAgencyUsersRequested({
+          agencyId,
+        }),
       );
     },
   };

--- a/front/src/app/components/agency/EditAgency.tsx
+++ b/front/src/app/components/agency/EditAgency.tsx
@@ -10,9 +10,7 @@ import { AgencyAdminAutocomplete } from "./AgencyAdminAutocomplete";
 
 export const EditAgency = () => {
   const agency = useAppSelector(agencyAdminSelectors.agency);
-  const agencyUsers = useAppSelector(
-    icUsersAdminSelectors.icUsersNeedingReviewSelector,
-  );
+  const agencyUsers = useAppSelector(icUsersAdminSelectors.agencyUsers);
 
   return (
     <>

--- a/front/src/app/components/forms/agency/EditAgencyForm.tsx
+++ b/front/src/app/components/forms/agency/EditAgencyForm.tsx
@@ -71,11 +71,9 @@ export const EditAgencyForm = ({
         onSubmit={handleSubmit((values) => {
           dispatch(agencyAdminSlice.actions.updateAgencyRequested(values));
           dispatch(
-            icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested(
-              {
-                agencyId: agency.id,
-              },
-            ),
+            icUsersAdminSlice.actions.fetchAgencyUsersRequested({
+              agencyId: agency.id,
+            }),
           );
         })}
         id={domElementIds.admin.agencyTab.editAgencyForm}
@@ -88,7 +86,7 @@ export const EditAgencyForm = ({
           />
 
           <Select
-            label="⚠️Statut de l'agence ⚠️"
+            label="!Statut de l'agence !"
             options={statusListOfOptions}
             placeholder="Sélectionner un statut"
             nativeSelectProps={{
@@ -98,7 +96,7 @@ export const EditAgencyForm = ({
           />
 
           <Input
-            label="⚠️Code Safir de l'agence ⚠️"
+            label="!Code Safir de l'agence !"
             nativeInputProps={{
               ...register("codeSafir"),
               placeholder: "Code Safir ",

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
@@ -46,6 +46,24 @@ const fetchInclusionConnectedUsersWithAgencyNeedingReviewEpic: AppEpic<
     ),
   );
 
+const fetchInclusionConnectedUsersWithAgencyIdEpic: AppEpic<
+  IcUsersAdminAction
+> = (action$, state$, { adminGateway }) =>
+  action$.pipe(
+    filter(icUsersAdminSlice.actions.fetchAgencyUsersRequested.match),
+    switchMap((action: PayloadAction<WithUserFilters>) =>
+      adminGateway.getInclusionConnectedUsersToReview$(
+        getAdminToken(state$.value),
+        action.payload,
+      ),
+    ),
+    map(normalizeUsers),
+    map(icUsersAdminSlice.actions.fetchAgencyUsersSucceeded),
+    catchEpicError((error) =>
+      icUsersAdminSlice.actions.fetchAgencyUsersFailed(error?.message),
+    ),
+  );
+
 const registerAgencyToUserEpic: AppEpic<IcUsersAdminAction> = (
   action$,
   state$,
@@ -122,4 +140,5 @@ export const icUsersAdminEpics = [
   fetchInclusionConnectedUsersWithAgencyNeedingReviewEpic,
   registerAgencyToUserEpic,
   rejectAgencyToUserEpic,
+  fetchInclusionConnectedUsersWithAgencyIdEpic,
 ];

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
@@ -16,6 +16,11 @@ const icUsersNeedingReviewSelector = createSelector(
   ({ icUsersNeedingReview }) => icUsersNeedingReview,
 );
 
+const agencyUsers = createSelector(
+  icUsersAdminState,
+  ({ icAgencyUsers }) => icAgencyUsers,
+);
+
 const agenciesNeedingReviewForSelectedUser = createSelector(
   icUsersNeedingReviewSelector,
   selectedUserId,
@@ -52,5 +57,5 @@ export const icUsersAdminSelectors = {
   selectedUserId,
   agenciesNeedingReviewForSelectedUser,
   feedback: createSelector(icUsersAdminState, ({ feedback }) => feedback),
-  icUsersNeedingReviewSelector,
+  agencyUsers,
 };

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -26,23 +26,28 @@ export type NormalizedIcUserById = Record<
 type IcUsersAdminFeedbackKind =
   | "usersToReviewFetchSuccess"
   | "agencyRegisterToUserSuccess"
-  | "agencyRejectionForUserSuccess";
+  | "agencyRejectionForUserSuccess"
+  | "agencyUsersFetchSuccess";
 
 export type IcUsersAdminFeedback = SubmitFeedBack<IcUsersAdminFeedbackKind>;
 
 export type IcUsersAdminState = {
   icUsersNeedingReview: NormalizedIcUserById;
+  icAgencyUsers: NormalizedIcUserById;
   selectedUserId: UserId | null;
   isUpdatingIcUserAgency: boolean;
   isFetchingAgenciesNeedingReviewForIcUser: boolean;
+  isFetchingAgencyUsers: boolean;
   feedback: IcUsersAdminFeedback;
 };
 
 export const icUsersAdminInitialState: IcUsersAdminState = {
   icUsersNeedingReview: {},
+  icAgencyUsers: {},
   selectedUserId: null,
   isUpdatingIcUserAgency: false,
   isFetchingAgenciesNeedingReviewForIcUser: false,
+  isFetchingAgencyUsers: false,
   feedback: { kind: "idle" },
 };
 
@@ -78,6 +83,24 @@ export const icUsersAdminSlice = createSlice({
       state.isFetchingAgenciesNeedingReviewForIcUser = false;
       state.icUsersNeedingReview = action.payload;
       state.feedback.kind = "usersToReviewFetchSuccess";
+    },
+    fetchAgencyUsersRequested: (
+      state,
+      _action: PayloadAction<WithUserFilters>,
+    ) => {
+      state.isFetchingAgencyUsers = true;
+    },
+    fetchAgencyUsersFailed: (state, action: PayloadAction<string>) => {
+      state.isFetchingAgencyUsers = false;
+      state.feedback = { kind: "errored", errorMessage: action.payload };
+    },
+    fetchAgencyUsersSucceeded: (
+      state,
+      action: PayloadAction<NormalizedIcUserById>,
+    ) => {
+      state.isFetchingAgencyUsers = false;
+      state.icAgencyUsers = action.payload;
+      state.feedback.kind = "agencyUsersFetchSuccess";
     },
     registerAgencyWithRoleToUserRequested: (
       state,


### PR DESCRIPTION
## Description du problème

On ne peut pas accéder au formulaire d'édition d'une agence depuis la vue admin. Ce problème est aléatoire.

Ceci est dû au fait que nous utilisons le même state pour récupérer:
- les utilisateurs "toReview"
- et les utilisateurs d'une agence

Du coup, lorsque l'on veut accéder à ceux d'une agence, il se peut que l'on ne pas trouve de droits sur les utilisateurs  car on se base sur les utilisateurs "toReview" au lieu les utilisateurs d'une agence. L'accès aux "roles" d'un agencyRight null fait planter l'affichage du formulaire utilisateur. 