### PR TITLE
TECH - seed: ajout d'utilisateurs inclusion connectés à des agences

### DIFF
--- a/back/src/scripts/seed.helpers.ts
+++ b/back/src/scripts/seed.helpers.ts
@@ -1,7 +1,18 @@
-import { AddressDto, AgencyDtoBuilder, AgencyId, AgencyKind } from "shared";
+import {
+  AddressDto,
+  AgencyDtoBuilder,
+  AgencyId,
+  AgencyKind,
+  defaultValidatorEmail,
+} from "shared";
 import { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
 import { UuidV4Generator } from "../domains/core/uuid-generator/adapters/UuidGeneratorImplementations";
 import { seedAddresses } from "./seedAddresses";
+
+type SeedUser = {
+  id: string;
+  email: string;
+};
 
 let agencyIds: Record<AgencyKind, AgencyId[]> = {
   "pole-emploi": [],
@@ -24,6 +35,39 @@ export const getRandomAgencyId = ({ kind }: { kind: AgencyKind }) => {
   return ids[Math.floor(Math.random() * ids.length)];
 };
 
+export const seedUsers: Record<
+  "admins" | "icUsers" | "notIcUsers",
+  SeedUser[]
+> = {
+  admins: [
+    {
+      id: new UuidV4Generator().new(),
+      email: "admin+playwright@immersion-facile.beta.gouv.fr",
+    },
+  ],
+  icUsers: [
+    {
+      id: new UuidV4Generator().new(),
+      email: "recette+playwright@immersion-facile.beta.gouv.fr",
+    },
+  ],
+  notIcUsers: [
+    {
+      id: new UuidV4Generator().new(),
+      email: defaultValidatorEmail,
+    },
+    {
+      id: new UuidV4Generator().new(),
+      email: "notic@user.com",
+    },
+  ],
+};
+
+const getRandomNotIcUserEmail = (): string => {
+  const emails = seedUsers.notIcUsers.map(({ email }) => email);
+  return emails[Math.floor(Math.random() * emails.length)];
+};
+
 export const insertAgencySeed = async ({
   uow,
   kind,
@@ -39,6 +83,7 @@ export const insertAgencySeed = async ({
     .withKind(kind)
     .withStatus("active")
     .withAddress(address)
+    .withValidatorEmails([getRandomNotIcUserEmail()])
     .build();
 
   await uow.agencyRepository.insert(agency);

--- a/back/src/scripts/seed.helpers.ts
+++ b/back/src/scripts/seed.helpers.ts
@@ -27,18 +27,15 @@ let agencyIds: Record<AgencyKind, AgencyId[]> = {
   "operateur-cep": [],
 };
 
-export const getRandomAddress = (): AddressDto =>
+const getRandomAddress = (): AddressDto =>
   seedAddresses[Math.floor(Math.random() * seedAddresses.length)];
 
-export const getRandomAgencyId = ({ kind }: { kind: AgencyKind }) => {
+const getRandomAgencyId = ({ kind }: { kind: AgencyKind }) => {
   const ids = agencyIds[kind];
   return ids[Math.floor(Math.random() * ids.length)];
 };
 
-export const seedUsers: Record<
-  "admins" | "icUsers" | "notIcUsers",
-  SeedUser[]
-> = {
+const seedUsers: Record<"admins" | "icUsers" | "notIcUsers", SeedUser[]> = {
   admins: [
     {
       id: new UuidV4Generator().new(),
@@ -68,7 +65,7 @@ const getRandomNotIcUserEmail = (): string => {
   return emails[Math.floor(Math.random() * emails.length)];
 };
 
-export const insertAgencySeed = async ({
+const insertAgencySeed = async ({
   uow,
   kind,
 }: { uow: UnitOfWork; kind: AgencyKind }): Promise<void> => {
@@ -92,4 +89,10 @@ export const insertAgencySeed = async ({
     ...agencyIds,
     [kind]: [...agencyIds[kind], agencyId],
   };
+};
+
+export const seedHelpers = {
+  seedUsers,
+  getRandomAgencyId,
+  insertAgencySeed,
 };

--- a/back/src/scripts/seed.ts
+++ b/back/src/scripts/seed.ts
@@ -133,7 +133,7 @@ const featureFlagsSeed = async (uow: UnitOfWork) => {
 const agencySeed = async (uow: UnitOfWork) => {
   // biome-ignore lint/suspicious/noConsoleLog: <explanation>
   console.log("seeding agencies...");
-  const agenciesCountByKind = 50;
+  const agenciesCountByKind = 5;
 
   const insertQueries = [...Array(agenciesCountByKind).keys()].flatMap(() => {
     return [

--- a/back/src/scripts/seed.ts
+++ b/back/src/scripts/seed.ts
@@ -20,7 +20,7 @@ import {
   OfferEntityBuilder,
 } from "../domains/establishment/helpers/EstablishmentBuilders";
 import { establishmentAggregateToFormEstablishement } from "../domains/establishment/use-cases/RetrieveFormEstablishmentFromAggregates";
-import { getRandomAgencyId, insertAgencySeed } from "./seed.helpers";
+import { getRandomAgencyId, insertAgencySeed, seedUsers } from "./seed.helpers";
 
 /* eslint-disable no-console */
 const seed = async () => {
@@ -36,6 +36,7 @@ const seed = async () => {
   await client.query("DELETE FROM feature_flags");
 
   await db.deleteFrom("users_ongoing_oauths").execute();
+  await db.deleteFrom("users__agencies").execute();
   await db.deleteFrom("users").execute();
   await db.deleteFrom("conventions").execute();
   await db.deleteFrom("agency_groups__agencies").execute();
@@ -71,7 +72,7 @@ const inclusionConnectUserSeed = async (db: KyselyDb) => {
     .withEmail("recette+playwright@immersion-facile.beta.gouv.fr")
     .withFirstName("Prénom IcUser")
     .withLastName("Nom IcUser")
-    .withId(new UuidV4Generator().new())
+    .withId(seedUsers.icUsers[0].id)
     .withExternalId("e9dce090-f45e-46ce-9c58-4fbbb3e494ba")
     .build();
 
@@ -81,7 +82,7 @@ const inclusionConnectUserSeed = async (db: KyselyDb) => {
     .withEmail("admin+playwright@immersion-facile.beta.gouv.fr")
     .withFirstName("Prénom Admin")
     .withLastName("Nom Admin")
-    .withId(new UuidV4Generator().new())
+    .withId(seedUsers.admins[0].id)
     .withExternalId("7f5cfde7-80b3-4ea1-bf3e-1711d0876161")
     .build();
 

--- a/back/src/scripts/seed.ts
+++ b/back/src/scripts/seed.ts
@@ -45,6 +45,7 @@ const seed = async () => {
   await deps.uowPerformer.perform(async (uow) => {
     await featureFlagsSeed(uow);
     await agencySeed(uow);
+    await icAgencyUsers(uow);
     await establishmentSeed(uow);
     await conventionSeed(uow);
   });
@@ -161,6 +162,30 @@ const agencySeed = async (uow: UnitOfWork) => {
   });
 
   await Promise.all(insertQueries);
+
+  // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+  console.log("done");
+};
+
+const icAgencyUsers = async (uow: UnitOfWork) => {
+  // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+  console.log("seeding ic agency users...");
+
+  const agencies = new Set([
+    seedHelpers.getRandomAgencyId({ kind: "pole-emploi" }),
+    seedHelpers.getRandomAgencyId({ kind: "mission-locale" }),
+  ]);
+
+  await seedHelpers.linkAgenciesWithIcUser({
+    uow,
+    agencyIds: [...agencies, seedHelpers.getRandomAgencyId({ kind: "cci" })],
+    userId: seedHelpers.seedUsers.admins[0].id,
+  });
+  await seedHelpers.linkAgenciesWithIcUser({
+    uow,
+    agencyIds: [...agencies],
+    userId: seedHelpers.seedUsers.icUsers[0].id,
+  });
 
   // biome-ignore lint/suspicious/noConsoleLog: <explanation>
   console.log("done");

--- a/back/src/scripts/seed.ts
+++ b/back/src/scripts/seed.ts
@@ -20,7 +20,7 @@ import {
   OfferEntityBuilder,
 } from "../domains/establishment/helpers/EstablishmentBuilders";
 import { establishmentAggregateToFormEstablishement } from "../domains/establishment/use-cases/RetrieveFormEstablishmentFromAggregates";
-import { getRandomAgencyId, insertAgencySeed, seedUsers } from "./seed.helpers";
+import { seedHelpers } from "./seed.helpers";
 
 /* eslint-disable no-console */
 const seed = async () => {
@@ -72,7 +72,7 @@ const inclusionConnectUserSeed = async (db: KyselyDb) => {
     .withEmail("recette+playwright@immersion-facile.beta.gouv.fr")
     .withFirstName("Prénom IcUser")
     .withLastName("Nom IcUser")
-    .withId(seedUsers.icUsers[0].id)
+    .withId(seedHelpers.seedUsers.icUsers[0].id)
     .withExternalId("e9dce090-f45e-46ce-9c58-4fbbb3e494ba")
     .build();
 
@@ -82,7 +82,7 @@ const inclusionConnectUserSeed = async (db: KyselyDb) => {
     .withEmail("admin+playwright@immersion-facile.beta.gouv.fr")
     .withFirstName("Prénom Admin")
     .withLastName("Nom Admin")
-    .withId(seedUsers.admins[0].id)
+    .withId(seedHelpers.seedUsers.admins[0].id)
     .withExternalId("7f5cfde7-80b3-4ea1-bf3e-1711d0876161")
     .build();
 
@@ -138,15 +138,15 @@ const agencySeed = async (uow: UnitOfWork) => {
 
   const insertQueries = [...Array(agenciesCountByKind).keys()].flatMap(() => {
     return [
-      insertAgencySeed({ uow, kind: "pole-emploi" }),
-      insertAgencySeed({ uow, kind: "cci" }),
-      insertAgencySeed({ uow, kind: "mission-locale" }),
-      insertAgencySeed({ uow, kind: "cap-emploi" }),
-      insertAgencySeed({ uow, kind: "conseil-departemental" }),
-      insertAgencySeed({ uow, kind: "prepa-apprentissage" }),
-      insertAgencySeed({ uow, kind: "structure-IAE" }),
-      insertAgencySeed({ uow, kind: "autre" }),
-      insertAgencySeed({ uow, kind: "operateur-cep" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "pole-emploi" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "cci" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "mission-locale" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "cap-emploi" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "conseil-departemental" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "prepa-apprentissage" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "structure-IAE" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "autre" }),
+      seedHelpers.insertAgencySeed({ uow, kind: "operateur-cep" }),
     ];
   });
 
@@ -304,7 +304,7 @@ const conventionSeed = async (uow: UnitOfWork) => {
     .withDateStart(new Date("2023-03-27").toISOString())
     .withDateEnd(new Date("2023-03-28").toISOString())
     .withStatus("READY_TO_SIGN")
-    .withAgencyId(getRandomAgencyId({ kind: "pole-emploi" }))
+    .withAgencyId(seedHelpers.getRandomAgencyId({ kind: "pole-emploi" }))
     .withSchedule(reasonableSchedule)
     .build();
 
@@ -316,7 +316,7 @@ const conventionSeed = async (uow: UnitOfWork) => {
     .withDateStart(new Date("2023-05-01").toISOString())
     .withDateEnd(new Date("2023-05-03").toISOString())
     .withStatus("READY_TO_SIGN")
-    .withAgencyId(getRandomAgencyId({ kind: "cci" }))
+    .withAgencyId(seedHelpers.getRandomAgencyId({ kind: "cci" }))
     .withSchedule(reasonableSchedule)
     .build();
 


### PR DESCRIPTION
## Description

Côté seeds, cette PR permet :
- d'avoir plusieurs types d'utilisateurs: 
  - 1 admin inclusion-conecté
  - 1 inclusion-connecté non admin
  - 2 non inclusion-connecté
- d'avoir des utilisateurs liés inclusion-connecté à des agences (table users__agencies)