### PR TITLE
FIX - accéder à au formulaire d'édition d'agence

### DIFF
--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors.ts
@@ -18,7 +18,7 @@ const icUsersNeedingReviewSelector = createSelector(
 
 const agencyUsers = createSelector(
   icUsersAdminState,
-  ({ icAgencyUsers }) => icAgencyUsers,
+  ({ agencyUsers }) => agencyUsers,
 );
 
 const agenciesNeedingReviewForSelectedUser = createSelector(

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -33,7 +33,7 @@ export type IcUsersAdminFeedback = SubmitFeedBack<IcUsersAdminFeedbackKind>;
 
 export type IcUsersAdminState = {
   icUsersNeedingReview: NormalizedIcUserById;
-  icAgencyUsers: NormalizedIcUserById;
+  agencyUsers: NormalizedIcUserById;
   selectedUserId: UserId | null;
   isUpdatingIcUserAgency: boolean;
   isFetchingAgenciesNeedingReviewForIcUser: boolean;
@@ -43,7 +43,7 @@ export type IcUsersAdminState = {
 
 export const icUsersAdminInitialState: IcUsersAdminState = {
   icUsersNeedingReview: {},
-  icAgencyUsers: {},
+  agencyUsers: {},
   selectedUserId: null,
   isUpdatingIcUserAgency: false,
   isFetchingAgenciesNeedingReviewForIcUser: false,
@@ -88,7 +88,7 @@ export const icUsersAdminSlice = createSlice({
       state,
       _action: PayloadAction<WithUserFilters>,
     ) => {
-      state.icAgencyUsers = icUsersAdminInitialState.icAgencyUsers;
+      state.agencyUsers = icUsersAdminInitialState.agencyUsers;
       state.isFetchingAgencyUsers = true;
     },
     fetchAgencyUsersFailed: (state, action: PayloadAction<string>) => {
@@ -100,7 +100,7 @@ export const icUsersAdminSlice = createSlice({
       action: PayloadAction<NormalizedIcUserById>,
     ) => {
       state.isFetchingAgencyUsers = false;
-      state.icAgencyUsers = action.payload;
+      state.agencyUsers = action.payload;
       state.feedback.kind = "agencyUsersFetchSuccess";
     },
     registerAgencyWithRoleToUserRequested: (

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -88,6 +88,7 @@ export const icUsersAdminSlice = createSlice({
       state,
       _action: PayloadAction<WithUserFilters>,
     ) => {
+      state.icAgencyUsers = icUsersAdminInitialState.icAgencyUsers;
       state.isFetchingAgencyUsers = true;
     },
     fetchAgencyUsersFailed: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
## Pour reproduire le problème en staging/prod

1. Sur la page admin > onglet agences > accéder au formulaire d'édition d'une agence
2. Accéder ensuite au formulaire d'édition d'une autre agence qui n'est pas rattaché aux mêmes utilisateurs inclusion-connecté
3. Constater cette erreur en screenshot:

![image](https://github.com/user-attachments/assets/fe439a24-5737-4acf-878a-41dc24cc2206)
