### PR TITLE
TECH - préciser les dates de fin de conventions pour lesquels envoyer des bilans 

### DIFF
--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -53,7 +53,10 @@ export class InMemoryConventionQueries implements ConventionQueries {
   }
 
   public async getAllConventionsForThoseEndingThatDidntGoThrough(
-    dateEnd: Date,
+    dateEnd: {
+      from: Date;
+      to: Date;
+    },
     assessmentEmailKind: AssessmentEmailKind,
   ): Promise<ConventionReadDto[]> {
     const notifications = this.notificationRepository
@@ -69,7 +72,8 @@ export class InMemoryConventionQueries implements ConventionQueries {
     return this.conventionRepository.conventions
       .filter(
         (convention) =>
-          new Date(convention.dateEnd).getDate() === dateEnd.getDate() &&
+          new Date(convention.dateEnd).getDate() >= dateEnd.from.getDate() &&
+          new Date(convention.dateEnd).getDate() < dateEnd.to.getDate() &&
           validatedConventionStatuses.includes(convention.status) &&
           !immersionIdsThatAlreadyGotAnEmail.includes(convention.id),
       )

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1,4 +1,4 @@
-import { addDays } from "date-fns";
+import { addDays, subHours } from "date-fns";
 import { sql } from "kysely";
 import { Pool } from "pg";
 import {
@@ -672,9 +672,13 @@ describe("Pg implementation of ConventionQueries", () => {
       await notificationRepo.saveBatch([notification]);
 
       // Act
+      const date = new Date("2022-05-15T12:43:11");
       const queryResults =
         await conventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough(
-          new Date("2022-05-15T12:43:11"),
+          {
+            from: subHours(date, 24),
+            to: date,
+          },
           "ESTABLISHMENT_ASSESSMENT_NOTIFICATION",
         );
 

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1,4 +1,4 @@
-import { addDays, subHours } from "date-fns";
+import { addDays, addHours } from "date-fns";
 import { sql } from "kysely";
 import { Pool } from "pg";
 import {
@@ -676,8 +676,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const queryResults =
         await conventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough(
           {
-            from: subHours(date, 24),
-            to: date,
+            from: date,
+            to: addHours(date, 24),
           },
           "ESTABLISHMENT_ASSESSMENT_NOTIFICATION",
         );

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -82,8 +82,16 @@ export class PgConventionQueries implements ConventionQueries {
     assessmentEmailKind: AssessmentEmailKind,
   ): Promise<ConventionDto[]> {
     const pgResults = await createConventionQueryBuilder(this.transaction)
-      .where("conventions.date_end", ">=", dateEnd.from)
-      .where("conventions.date_end", "<", dateEnd.to)
+      .where(
+        sql`DATE(conventions.date_end)`,
+        ">=",
+        dateEnd.from.toISOString().split("T")[0],
+      )
+      .where(
+        sql`DATE(conventions.date_end)`,
+        "<",
+        dateEnd.to.toISOString().split("T")[0],
+      )
       .where("conventions.status", "in", validatedConventionStatuses)
       .where("conventions.id", "not in", (qb) =>
         qb

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -1,4 +1,4 @@
-import { addDays, subDays, subHours } from "date-fns";
+import { addDays, subDays } from "date-fns";
 import { sql } from "kysely";
 import { andThen } from "ramda";
 import {
@@ -75,12 +75,15 @@ export class PgConventionQueries implements ConventionQueries {
   }
 
   public async getAllConventionsForThoseEndingThatDidntGoThrough(
-    dateEnd: Date,
+    dateEnd: {
+      from: Date;
+      to: Date;
+    },
     assessmentEmailKind: AssessmentEmailKind,
   ): Promise<ConventionDto[]> {
     const pgResults = await createConventionQueryBuilder(this.transaction)
-      .where("conventions.date_end", ">=", subHours(dateEnd, 24))
-      .where("conventions.date_end", "<", dateEnd)
+      .where("conventions.date_end", ">=", dateEnd.from)
+      .where("conventions.date_end", "<", dateEnd.to)
       .where("conventions.status", "in", validatedConventionStatuses)
       .where("conventions.id", "not in", (qb) =>
         qb

--- a/back/src/domains/convention/ports/ConventionQueries.ts
+++ b/back/src/domains/convention/ports/ConventionQueries.ts
@@ -46,7 +46,10 @@ export interface ConventionQueries {
   // TODO: a voir si on veut pas à terme unifier en une seule query les 3 queries si dessous
   getConventions(params: GetConventionsParams): Promise<ConventionDto[]>;
   getAllConventionsForThoseEndingThatDidntGoThrough: (
-    dateEnd: Date,
+    dateEnd: {
+      from: Date;
+      to: Date;
+    },
     assessmentEmailKind: AssessmentEmailKind,
   ) => Promise<ConventionDto[]>;
   getConventionsByScope(params: {

--- a/back/src/domains/establishment/use-cases/SendBeneficiariesPdfAssessmentsEmails.ts
+++ b/back/src/domains/establishment/use-cases/SendBeneficiariesPdfAssessmentsEmails.ts
@@ -51,7 +51,10 @@ export class SendBeneficiariesPdfAssessmentsEmails extends TransactionalUseCase<
     const tomorrow = addDays(now, 1);
     const conventions =
       await uow.conventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough(
-        tomorrow,
+        {
+          from: tomorrow,
+          to: addDays(tomorrow, 1),
+        },
         "BENEFICIARY_ASSESSMENT_NOTIFICATION",
       );
     const errors: Record<ConventionId, Error> = {};

--- a/back/src/domains/establishment/use-cases/SendEmailsWithAssessmentCreationLink.ts
+++ b/back/src/domains/establishment/use-cases/SendEmailsWithAssessmentCreationLink.ts
@@ -60,7 +60,10 @@ export class SendEmailsWithAssessmentCreationLink extends TransactionalUseCase<
     const yesterday = subDays(now, 1);
     const conventions =
       await uow.conventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough(
-        yesterday,
+        {
+          from: yesterday,
+          to: now,
+        },
         "ESTABLISHMENT_ASSESSMENT_NOTIFICATION",
       );
 


### PR DESCRIPTION
## Description

1. modification de ConventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough pour filtrer sur les dates de fin de conventions
2. dans la requête qui récupère les conventions pour lesquels envoyer les demandes de bilan: ne plus tenir compte de l'heure dans la comparaison de conventions.date_end (car le script d'envoi des bilans n'est pas exécuté tous les jours à la même heure et en faisant des comparaisons en tenant compte de l'heure, on risquerait de rater des conventions)