### PR TITLE
Fix - erreur lors de la modification du rôle d'un utilisateur dans une agence

### DIFF
--- a/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
+++ b/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
@@ -449,9 +449,15 @@ describe("Admin router", () => {
         externalId: "john-external-id",
         createdAt: new Date().toISOString(),
       };
+      const validatorInAgency = new InclusionConnectedUserBuilder()
+        .withAgencyRights([
+          { roles: ["validator"], agency, isNotifiedByEmail: true },
+        ])
+        .build();
 
       inMemoryUow.inclusionConnectedUserRepository.setInclusionConnectedUsers([
         inclusionConnectedUser,
+        validatorInAgency,
         backofficeAdminUser,
       ]);
 

--- a/back/src/domains/inclusion-connected-users/use-cases/UpdateIcUserRoleForAgency.unit.test.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/UpdateIcUserRoleForAgency.unit.test.ts
@@ -1,5 +1,6 @@
 import {
   AgencyDtoBuilder,
+  AgencyRight,
   AgencyRole,
   IcUserRoleForAgencyParams,
   InclusionConnectedUser,
@@ -255,6 +256,36 @@ describe("GetInclusionConnectedUsers", () => {
           },
         },
       }),
+    );
+  });
+  it("cannot remove the last validator of an agency", async () => {
+    const agency = new AgencyDtoBuilder().build();
+    const agencyRight: AgencyRight = {
+      agency,
+      roles: ["validator"],
+      isNotifiedByEmail: false,
+    };
+
+    const icUser: InclusionConnectedUser = {
+      ...notAdminUser,
+      agencyRights: [agencyRight],
+      dashboards: {
+        agencies: {},
+        establishments: {},
+      },
+    };
+
+    inclusionConnectedUserRepository.setInclusionConnectedUsers([
+      backofficeAdminUser,
+      icUser,
+    ]);
+
+    await expectPromiseToFailWithError(
+      updateIcUserRoleForAgency.execute(
+        { agencyId: agency.id, roles: ["counsellor"], userId: icUser.id },
+        backofficeAdminUser,
+      ),
+      errors.agency.notEnoughValidators({ agencyId: agency.id }),
     );
   });
 });

--- a/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
@@ -193,6 +193,9 @@ export class HttpAdminGateway implements AdminGateway {
         .then((response) =>
           match(response)
             .with({ status: 201 }, () => undefined)
+            .with({ status: 400 }, (error) => {
+              throw new Error(error.body.errors);
+            })
             .with({ status: P.union(401, 404) }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),

--- a/shared/src/admin/admin.routes.ts
+++ b/shared/src/admin/admin.routes.ts
@@ -58,6 +58,7 @@ export const adminRoutes = defineRoutes({
     ...withAuthorizationHeaders,
     responses: {
       201: expressEmptyResponseBody,
+      400: legacyHttpErrorSchema,
       401: legacyUnauthenticatedErrorSchema,
       404: legacyHttpErrorSchema,
     },

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -270,6 +270,10 @@ export const errors = {
       new NotFoundError(
         `Mail not found for agency with id: ${agencyId} on agency repository.aaaaaaaaa`,
       ),
+    notEnoughValidators: ({ agencyId }: { agencyId: AgencyId }) =>
+      new BadRequestError(
+        `L'agence ${agencyId} doit avoir au moins un validateur.`,
+      ),
   },
   user: {
     unauthorized: () => new UnauthorizedError(),


### PR DESCRIPTION
Le back throw une erreur si on essaie de modifier le rôle d'un utilisateur et qu'il n'y a plus de validateur dans l'agence : 
<img width="981" alt="image" src="https://github.com/user-attachments/assets/965a6409-ae16-4e26-8114-b9e883f4cc6b">
