### PR TITLE
FIX - Eliminer les doublons d'agences quand on fetch les utilisateurs dans l'onglet agences page admin

### DIFF
--- a/front/src/app/components/forms/agency/EditAgencyForm.tsx
+++ b/front/src/app/components/forms/agency/EditAgencyForm.tsx
@@ -29,7 +29,6 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import "src/assets/admin.css";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
 import { agencyAdminSlice } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
-import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 
 type EditAgencyFormProperties = {
   agency: AgencyDto;
@@ -70,11 +69,6 @@ export const EditAgencyForm = ({
         className={fr.cx("fr-my-4w")}
         onSubmit={handleSubmit((values) => {
           dispatch(agencyAdminSlice.actions.updateAgencyRequested(values));
-          dispatch(
-            icUsersAdminSlice.actions.fetchAgencyUsersRequested({
-              agencyId: agency.id,
-            }),
-          );
         })}
         id={domElementIds.admin.agencyTab.editAgencyForm}
         data-matomo-name={domElementIds.admin.agencyTab.editAgencyForm}

--- a/front/src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics.ts
@@ -8,6 +8,8 @@ import {
   ActionOfSlice,
   AppEpic,
 } from "src/core-logic/storeConfig/redux.helpers";
+import { type IcUsersAdminAction } from "../icUsersAdmin/icUsersAdmin.epics";
+import { icUsersAdminSlice } from "../icUsersAdmin/icUsersAdmin.slice";
 import { agencyAdminSlice } from "./agencyAdmin.slice";
 
 export type AgencyAction = ActionOfSlice<typeof agencyAdminSlice>;
@@ -152,6 +154,16 @@ const agencyDoesNotNeedReviewAnymoreEpic: AgencyEpic = (action$, state$) =>
     }),
   );
 
+const fetchAgencyOnIcUserUpdatedEpic: AppEpic<
+  IcUsersAdminAction | AgencyAction
+> = (action$) =>
+  action$.pipe(
+    filter(icUsersAdminSlice.actions.updateUserOnAgencySucceeded.match),
+    map((action) =>
+      agencyAdminSlice.actions.setSelectedAgencyId(action.payload.agencyId),
+    ),
+  );
+
 export const agenciesAdminEpics = [
   agencyAdminGetByNameEpic,
   agencyAdminGetNeedingReviewEpic,
@@ -160,4 +172,5 @@ export const agenciesAdminEpics = [
   updateAgencyEpic,
   updateAgencyNeedingReviewStatusEpic,
   agencyDoesNotNeedReviewAnymoreEpic,
+  fetchAgencyOnIcUserUpdatedEpic,
 ];

--- a/front/src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics.ts
@@ -10,7 +10,7 @@ import {
 } from "src/core-logic/storeConfig/redux.helpers";
 import { agencyAdminSlice } from "./agencyAdmin.slice";
 
-type AgencyAction = ActionOfSlice<typeof agencyAdminSlice>;
+export type AgencyAction = ActionOfSlice<typeof agencyAdminSlice>;
 
 type AgencyEpic = AppEpic<AgencyAction | { type: "do-nothing" }>;
 

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
@@ -1,6 +1,6 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { filter } from "rxjs";
-import { map, switchMap } from "rxjs/operators";
+import { map, switchMap, tap } from "rxjs/operators";
 import {
   AgencyId,
   AgencyRight,
@@ -10,7 +10,7 @@ import {
   WithUserFilters,
 } from "shared";
 import { getAdminToken } from "src/core-logic/domain/admin/admin.helpers";
-import { AgencyAction } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics";
+import { type AgencyAction } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.epics";
 import { agencyAdminSlice } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
 import {
   NormalizedIcUserById,
@@ -22,12 +22,13 @@ import {
   AppEpic,
 } from "src/core-logic/storeConfig/redux.helpers";
 
-type IcUsersAdminAction = ActionOfSlice<typeof icUsersAdminSlice>;
+export type IcUsersAdminAction = ActionOfSlice<typeof icUsersAdminSlice>;
 type IcUsersAdminActionEpic = AppEpic<IcUsersAdminAction>;
 
 const fetchInclusionConnectedUsersWithAgencyNeedingReviewEpic: IcUsersAdminActionEpic =
   (action$, state$, { adminGateway }) =>
     action$.pipe(
+      tap(console.log),
       filter(
         icUsersAdminSlice.actions.fetchInclusionConnectedUsersToReviewRequested
           .match,

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -148,7 +148,6 @@ export const icUsersAdminSlice = createSlice({
 
       const { [agencyId]: _agency, ...agenciesFiltered } =
         state.icUsersNeedingReview[userId].agencyRights;
-
       state.isUpdatingIcUserAgency = false;
       state.feedback.kind = "agencyRejectionForUserSuccess";
       state.icUsersNeedingReview[userId].agencyRights = agenciesFiltered;


### PR DESCRIPTION
- **quick fix to eliminate duplicates in agencyRight and establishment when fetching users**
- **refetch users on success on update agency in admin**
