### PR TITLE
TECH: amélioration des perfs de la requête de récupération des conventions sur lesquels envoyer les bilans

### DIFF
--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1,4 +1,5 @@
 import { addDays, addHours } from "date-fns";
+import subDays from "date-fns/subDays";
 import { sql } from "kysely";
 import { Pool } from "pg";
 import {
@@ -643,7 +644,7 @@ describe("Pg implementation of ConventionQueries", () => {
       );
 
       const notification: Notification = {
-        createdAt: new Date().toISOString(),
+        createdAt: subDays(new Date(dateEnd15), 1).toISOString(),
         followedIds: {
           conventionId:
             validatedImmersionEndingThe15thThatAlreadyReceivedAnEmail.id,

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -95,7 +95,17 @@ export class PgConventionQueries implements ConventionQueries {
         qb
           .selectFrom("notifications_email")
           .select("convention_id")
-          .where("email_kind", "=", assessmentEmailKind),
+          .where("email_kind", "=", assessmentEmailKind)
+          .where(
+            sql`DATE(created_at)`,
+            ">=",
+            subDays(dateEnd.from, 1).toISOString().split("T")[0],
+          )
+          .where(
+            sql`DATE(created_at)`,
+            "<=",
+            addDays(dateEnd.from, 1).toISOString().split("T")[0],
+          ),
       )
       .orderBy("conventions.date_start", "desc")
       .execute();


### PR DESCRIPTION
## 🤖 Problème

conventionQueries.getAllConventionsForThoseEndingThatDidntGoThrough met beaucoup de temps à récupérer les conventions sur lesquels envoyer les bilans de **tout le mois de juillet** (période où on a eu des loupé d'envoi de bilans).

## 🦄 Solution

Utiliser l'index sur notifications_email.created_at pour filtrer dessus car on sait que les mails de bilans sont envoyés à plus et moins 1 jour de la date de fin de la convention.

## 💯 Tests sur la réplica

La nouvelle requête met ~11s à s'exécuter sur la réplica alors qu'elle mettait plus de 10 minutes quand je l'ai joué hier.