### PR TITLE
TECH - fix format des emails dans les tables notifications_email_recipients et discussions

### DIFF
--- a/back/src/config/pg/migrations/1722954848190_fix-notifications-and-discussions-emails.ts
+++ b/back/src/config/pg/migrations/1722954848190_fix-notifications-and-discussions-emails.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // remove " and \ from emails in discussions table
+  pgm.sql(`
+      UPDATE discussions
+      SET establishment_contact_copy_emails = (
+            SELECT jsonb_agg(REPLACE(value::text, '\\"', '')::jsonb)
+             FROM jsonb_array_elements(establishment_contact_copy_emails) AS elems(value))
+      WHERE EXISTS (
+            SELECT 1
+            FROM
+                jsonb_array_elements(establishment_contact_copy_emails) AS elems(value)
+            WHERE
+                value::text LIKE '%\\"%');
+  `);
+
+  // get notifications id with troubles
+  const result = await pgm.db.query(`
+      select notifications_email_id
+    from notifications_email_recipients
+    where recipient_type = 'cc' and email ilike '"%'
+  `);
+
+  const formattedNotificationIds = result.rows
+    .map(({ notifications_email_id }) => `'${notifications_email_id}'`)
+    .join(",");
+
+  // update notifications and free outbox event in quarantine
+  if (formattedNotificationIds.length > 0) {
+    await pgm.db.query(
+      `
+      UPDATE notifications_email_recipients
+      SET email = REPLACE(email, '"', '')
+      WHERE notifications_email_id in (${formattedNotificationIds})
+      `,
+    );
+
+    await pgm.db.query(`
+      update outbox
+      set was_quarantined = false
+      where was_quarantined = true 
+        and occurred_at > '2024-08-06 12:00:00'
+        and topic = 'NotificationAdded'
+      `);
+  }
+}
+
+export async function down(): Promise<void> {
+  // nothing to do
+}


### PR DESCRIPTION
## 🤖 Problème

La PR https://github.com/gip-inclusion/immersion-facile/pull/2027/files a introduit des backslash et des double quotes dans les mails à cause du cast `::value` dans le script de migration.

## 💯 Solution

Corriger ces emails + mettre was_quarantined=false dans l'outbox