### PR TITLE
#2060 - pouvoir saisir une adresse sur Saint Barthélemy

### DIFF
--- a/shared/src/address/address.dto.ts
+++ b/shared/src/address/address.dto.ts
@@ -144,9 +144,10 @@ export const departmentNameToDepartmentCode: Record<
   Martinique: "972",
   Guyane: "973",
   "La Réunion": "974",
-  Mayotte: "976",
-  "Saint-Martin": "971",
   "Saint-Pierre-et-Miquelon": "975",
+  Mayotte: "976",
+  "Saint-Barthélemy": "977",
+  "Saint-Martin": "978",
 };
 
 export const getDepartmentCodeFromDepartmentNameOrCity: Record<


### PR DESCRIPTION
## 📓 Problème 

Il n'est pas possible de référencer une entreprise sur Saint-Barthélemy:
![image](https://github.com/user-attachments/assets/8e8d94d5-ede6-464d-b883-fef818e4f96d)

## 💯 Solution

Ajouter Saint-Barthélemy à la liste des départements gérés dans address.dto.

## 🤖 Remarque

J'ai changé le code département de Saint-Martin 971 -> 978