### PR TITLE
TECH - amélioration performance de la requête sql getSiretOfEstablishmentsToSuggestUpdate

### DIFF
--- a/back/src/config/pg/migrations/1724233123941_add-index-on-establishment-update-date.ts
+++ b/back/src/config/pg/migrations/1724233123941_add-index-on-establishment-update-date.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addIndex("establishments", "update_date");
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("establishments", "update_date");
+}

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
@@ -191,7 +191,8 @@ export class PgEstablishmentAggregateRepository
               .select(sql`1`.as("_"))
               .where("o.topic", "=", "FormEstablishmentEditLinkSent")
               .whereRef(sql`o.payload ->> 'siret'`, "=", "establishments.siret")
-              .where("o.occurred_at", ">", before),
+              .where("o.occurred_at", ">", before)
+              .limit(1),
           ),
         ),
       )
@@ -202,7 +203,8 @@ export class PgEstablishmentAggregateRepository
               .select(sql`1`.as("__"))
               .where("n.email_kind", "=", "SUGGEST_EDIT_FORM_ESTABLISHMENT")
               .whereRef("n.establishment_siret", "=", "establishments.siret")
-              .where("n.created_at", ">", before),
+              .where("n.created_at", ">", before)
+              .limit(1),
           ),
         ),
       )


### PR DESCRIPTION
## Description

La requête qui récupère les établissements à qui envoyer un mail de demande de mise à jour de leur infos tombe en timeout.

## Solution

Ajout d'un index + ajout d'un `limit 1`