### PR TITLE
#2129 - Supprimer les demande de référencement entreprises invalides

### DIFF
--- a/back/src/config/pg/migrations/1724854197570_delete-invalid-form-establishments.ts
+++ b/back/src/config/pg/migrations/1724854197570_delete-invalid-form-establishments.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  await pgm.sql(`
+    WITH FormEstablishmentWithoutBusinessAddress AS (
+      SELECT siret
+      FROM form_establishments
+      WHERE business_addresses::TEXT LIKE '%11111111-2222-4444-1111-111111111111%'
+      ), FormEstablishmentFailedToEstablishment AS (
+        SELECT payload -> 'formEstablishment' ->> 'siret' AS siret
+        FROM outbox
+        WHERE was_quarantined IS TRUE
+          AND status = 'failed-to-many-times'
+          AND topic = 'FormEstablishmentAdded'
+          AND payload -> 'formEstablishment' ->> 'siret' IN (
+           SELECT siret FROM FormEstablishmentWithoutBusinessAddress
+          )
+          AND occurred_at < '2024-03-01'
+      )
+      DELETE FROM form_establishments fe
+      WHERE EXISTS (
+          SELECT 1
+          FROM FormEstablishmentFailedToEstablishment fft
+                   LEFT JOIN establishments e ON e.siret = fft.siret
+          WHERE fft.siret = fe.siret
+            AND e.siret IS NULL
+      )
+  `);
+}
+
+export async function down(_pgm: MigrationBuilder): Promise<void> {}


### PR DESCRIPTION
## 🐛 Description du problème

L'entreprise au siret 13000548125405 a fait une demande de référencement chez nous en février mais n'est toujours pas devenue entreprise accueillante.

Une fois la demande de référencement effectuée, l'entreprise est enregistrée dans la table form_establishments.
Puis si les informations sont correctes, elle est ensuite ajoutée à la table establishments --> c'est cette étape là qui manque.

## 📖 Investigation

En février 2024, on a ajouté la possibilité aux enterprises de se référencer avec plusieurs adresses.
Nous avons alors fait une modification des demandes de référencement existantes (table DB form_establishments) en les liant à des adresses (dans la table establishments_locations) avec un id fictif car pas encore existant.
L'id étant fictif, on ne la trouve pas (dans la table establishments_locations), d'où l'erreur provoquant la non conversion d'un form_establishment en establishment.

Ces demandes de référencement étant anciennes (avant mars 2024), nous les supprimons afin de ne pas bloquer les entreprises qui re-tentent de se référencer.

--> Cela concerne 46 suppressions de demandes de référencement.

