### PR TITLE
Feature - Lien direct vers une discussion depuis le mail de MER

### DIFF
--- a/back/src/domains/establishment/use-cases/ContactEstablishment.ts
+++ b/back/src/domains/establishment/use-cases/ContactEstablishment.ts
@@ -187,6 +187,8 @@ export class ContactEstablishment extends TransactionalUseCase<ContactEstablishm
         appellationCode: contactRequest.appellationCode,
       });
 
+    const discussionId = this.#uuidGenerator.new();
+
     const emailContent =
       contactRequest.contactMode === "EMAIL"
         ? configureGenerateHtmlFromTemplate(emailTemplatesByName, {
@@ -218,12 +220,13 @@ export class ContactEstablishment extends TransactionalUseCase<ContactEstablishm
               potentialBeneficiaryHasWorkingExperience:
                 contactRequest.hasWorkingExperience,
               domain,
+              discussionId: discussionId,
             },
             { showContentParts: true },
           )
         : null;
     return {
-      id: this.#uuidGenerator.new(),
+      id: discussionId,
       appellationCode: contactRequest.appellationCode,
       siret: contactRequest.siret,
       businessName: establishment.customizedName ?? establishment.name,

--- a/back/src/domains/establishment/use-cases/notifications/NotifyContactRequest.ts
+++ b/back/src/domains/establishment/use-cases/notifications/NotifyContactRequest.ts
@@ -102,6 +102,7 @@ export class NotifyContactRequest extends TransactionalUseCase<ContactEstablishm
             potentialBeneficiaryHasWorkingExperience:
               discussion.potentialBeneficiary.hasWorkingExperience,
             domain: this.#domain,
+            discussionId: discussion.id,
           },
         };
         if (payload.isLegacy) {

--- a/back/src/domains/establishment/use-cases/notifications/NotifyContactRequest.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/notifications/NotifyContactRequest.unit.test.ts
@@ -133,6 +133,7 @@ describe("NotifyContactRequest", () => {
                 discussion.potentialBeneficiary.resumeLink,
               businessAddress: addressDtoToString(discussion.address),
               domain,
+              discussionId: discussion.id,
             },
             cc: establishmentContact.copyEmails,
           },

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -316,6 +316,7 @@ export const defaultEmailValueByEmailKind: {
       "POTENTIAL_BENEFICIARY_EXPERIENCE_ADDITIONAL_INFORMATION",
     potentialBeneficiaryHasWorkingExperience: true,
     domain: "immersion-facile.beta.gouv.fr",
+    discussionId: "fake-discussion-id",
   },
   CONTACT_BY_PHONE_INSTRUCTIONS: {
     businessName: "BUSINESS_NAME",

--- a/front/src/app/pages/establishment-dashboard/EstablishmentDashboardPage.tsx
+++ b/front/src/app/pages/establishment-dashboard/EstablishmentDashboardPage.tsx
@@ -10,6 +10,7 @@ import { MetabaseView } from "src/app/components/MetabaseView";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { ManageConventionFormSection } from "src/app/pages/admin/ManageConventionFormSection";
 
+import { DiscussionManageContent } from "src/app/components/admin/establishments/DiscussionManageContent";
 import { ManageEstablishmentsTab } from "src/app/pages/establishment-dashboard/ManageEstablishmentTab";
 import { isEstablishmentDashboardTab } from "src/app/routes/routeParams/establishmentDashboardTabs";
 import { routes } from "src/app/routes/routes";
@@ -31,7 +32,7 @@ export const EstablishmentDashboardPage = ({
 }): ReactJSXElement => {
   const currentUser = useAppSelector(inclusionConnectedSelectors.currentUser);
   const isLoading = useAppSelector(inclusionConnectedSelectors.isLoading);
-
+  const { params } = route;
   const rawEstablishmentDashboardTabs = ({
     dashboards: {
       establishments: { conventions, discussions },
@@ -71,7 +72,9 @@ export const EstablishmentDashboardPage = ({
     {
       label: "Mises en relation",
       tabId: "discussions",
-      content: (
+      content: params.discussionId ? (
+        <DiscussionManageContent discussionId={params.discussionId} />
+      ) : (
         <>
           <ManageDiscussionFormSection />
           {discussions ? (

--- a/front/src/app/pages/establishment-dashboard/ManageDiscussionFormSection.tsx
+++ b/front/src/app/pages/establishment-dashboard/ManageDiscussionFormSection.tsx
@@ -26,7 +26,9 @@ export const ManageDiscussionFormSection = (): JSX.Element => {
       <div className={fr.cx("fr-card", "fr-px-4w", "fr-py-2w", "fr-mb-4w")}>
         <form
           onSubmit={handleSubmit(({ discussionId }) => {
-            routes.manageDiscussion({ discussionId }).push();
+            routes
+              .establishmentDashboard({ discussionId, tab: "discussions" })
+              .push();
           })}
         >
           <div className={fr.cx("fr-grid-row")}>

--- a/front/src/app/routes/routes.ts
+++ b/front/src/app/routes/routes.ts
@@ -163,6 +163,7 @@ export const { RouteProvider, useRoute, routes } = createRouter({
         .ofType(icUserEstablishmentDashboardTabSerializer)
         .default("conventions"),
       siret: param.query.optional.string,
+      discussionId: param.query.optional.string,
     },
     ({ tab }) => `/${frontRoutes.establishmentDashboard}/${tab}`,
   ),

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -111,6 +111,7 @@ export type EmailParamsByEmailType = {
     potentialBeneficiaryHasWorkingExperience?: boolean;
     potentialBeneficiaryExperienceAdditionalInformation?: string;
     domain: string;
+    discussionId: string;
   };
   CONTACT_BY_EMAIL_REQUEST_LEGACY: {
     businessName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1486,6 +1486,7 @@ Pour toute question concernant ce rejet, il est possible de nous contacter : con
         potentialBeneficiaryExperienceAdditionalInformation,
         potentialBeneficiaryHasWorkingExperience,
         domain,
+        discussionId,
       }) => ({
         subject: `${potentialBeneficiaryFirstName} ${potentialBeneficiaryLastName} vous contacte pour une demande d'immersion sur le métier de ${appellationLabel}`,
         greetings: `Bonjour ${contactFirstName} ${contactLastName},`,
@@ -1522,7 +1523,7 @@ Profil du candidat :
           {
             label: "Répondre au candidat via mon espace",
             target: "_blank",
-            url: `https://${domain}/${frontRoutes.establishmentDashboard}/discussions?mtm_campaign=inbound-parsing-reponse-via-espace-entreprise&mtm_kwd=inbound-parsing-reponse-via-espace-entreprise`,
+            url: `https://${domain}/${frontRoutes.establishmentDashboard}/discussions?discussionId=${discussionId}&mtm_campaign=inbound-parsing-reponse-via-espace-entreprise&mtm_kwd=inbound-parsing-reponse-via-espace-entreprise`,
           },
         ],
         highlight: {


### PR DESCRIPTION
On pourra accéder directement à une discussion avec sur /tableau-de-bord-etablissement/discussions?discussionId=347a7608-eb13-424b-a06e-b99e725bd926. Si la personne n'est pas connectée, il tombera sur la solution d'authentification. 

Par contre, après connexion, on ne redirige pas vers l'url que l'utilisateur a cherché à atteindre, on redirige quoiqu'il arrive sur l'onglet conventions