### PR TITLE
#2187 - Fix ne pas utiliser les informations d'un utilisateur précédemment peConnecté

### DIFF
--- a/front/src/app/pages/convention/ConventionImmersionPage.tsx
+++ b/front/src/app/pages/convention/ConventionImmersionPage.tsx
@@ -150,6 +150,11 @@ const useFederatedIdentityFromUrl = (route: ConventionImmersionPageRoute) => {
 
   useEffect(() => {
     if (fedId && fedIdProvider) {
+      const {
+        fedId: _,
+        fedIdProvider: __,
+        ...paramsWithoutFederatedIdentity
+      } = route.params;
       dispatch(
         authSlice.actions.federatedIdentityProvided({
           provider: fedIdProvider as FederatedIdentityProvider,
@@ -159,6 +164,12 @@ const useFederatedIdentityFromUrl = (route: ConventionImmersionPageRoute) => {
           lastName,
         }),
       );
+      routes
+        .conventionImmersion({
+          ...paramsWithoutFederatedIdentity,
+          fromPeConnectedUser: true,
+        })
+        .replace();
     }
   }, [fedId, fedIdProvider, email, firstName, lastName, dispatch]);
 };

--- a/front/src/app/routes/routeParams/convention.ts
+++ b/front/src/app/routes/routeParams/convention.ts
@@ -266,6 +266,7 @@ type ConventionQueryParams = typeof conventionValuesFromUrl;
 export const conventionValuesFromUrl = {
   fedId: param.query.optional.string,
   fedIdProvider: param.query.optional.string,
+  fromPeConnectedUser: param.query.optional.boolean,
   email: param.query.optional.string,
   firstName: param.query.optional.string,
   lastName: param.query.optional.string,


### PR DESCRIPTION
## 🐛 Le problème

Lorsque je clique sur un lien de partage de convention depuis un mail, je n'ai pas le bon nom et prénom affiché.

Un utilisateur au support a rencontré ce problème lorsqu'il clique sur le lien magique depuis le mail reçu (on reproduit aussi sur Brevo), mais ni l'utilisateur ni nous ne reproduisons lorsque l'on accède au lien magique depuis un navigateur.