### PR TITLE
#1811 - ETQ admin, suppression d'un rattachement d'utilisateur sur une agence

### DIFF
--- a/back/src/adapters/primary/routers/admin/createAdminRouter.ts
+++ b/back/src/adapters/primary/routers/admin/createAdminRouter.ts
@@ -1,5 +1,11 @@
 import { Router } from "express";
-import { GetDashboardParams, adminRoutes, agencyRoutes, errors } from "shared";
+import {
+  GetDashboardParams,
+  RemoveAgencyUserParams,
+  adminRoutes,
+  agencyRoutes,
+  errors,
+} from "shared";
 import { BadRequestError } from "shared";
 import { createExpressSharedRouter } from "shared-routes/express";
 import type { AppDependencies } from "../../../../config/bootstrap/createAppDependencies";
@@ -90,6 +96,23 @@ export const createAdminRouter = (deps: AppDependencies): Router => {
         if (!currentUser) throw errors.user.unauthorized();
         return await deps.useCases.createUserForAgency.execute(
           req.body,
+          currentUser,
+        );
+      }),
+  );
+
+  sharedAdminRouter.removeUserFromAgency(
+    deps.inclusionConnectAuthMiddleware,
+    (req, res) =>
+      sendHttpResponse(req, res, async () => {
+        const currentUser = req.payloads?.currentUser;
+        if (!currentUser) throw errors.user.unauthorized();
+        const userWithAgency: RemoveAgencyUserParams = {
+          agencyId: req.params.agencyId,
+          userId: req.params.userId,
+        };
+        return await deps.useCases.removeUserFromAgency.execute(
+          userWithAgency,
           currentUser,
         );
       }),

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -122,6 +122,7 @@ import { GetInclusionConnectedUser } from "../../domains/inclusion-connected-use
 import { GetInclusionConnectedUsers } from "../../domains/inclusion-connected-users/use-cases/GetInclusionConnectedUsers";
 import { LinkFranceTravailUsersToTheirAgencies } from "../../domains/inclusion-connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies";
 import { RejectIcUserForAgency } from "../../domains/inclusion-connected-users/use-cases/RejectIcUserForAgency";
+import { makeRemoveUserFromAgency } from "../../domains/inclusion-connected-users/use-cases/RemoveUserFromAgency";
 import { UpdateUserForAgency } from "../../domains/inclusion-connected-users/use-cases/UpdateUserForAgency";
 import { makeUpdateMarketingEstablishmentContactList } from "../../domains/marketing/use-cases/UpdateMarketingEstablishmentContactsList";
 import { AppConfig } from "./appConfig";
@@ -638,6 +639,10 @@ export const createUseCases = (
         timeGateway: gateways.timeGateway,
         createNewEvent,
       },
+    }),
+    removeUserFromAgency: makeRemoveUserFromAgency({
+      uowPerformer,
+      deps: { createNewEvent },
     }),
     broadcastConventionAgain: makeBroadcastConventionAgain({
       uowPerformer,

--- a/back/src/domains/inclusion-connected-users/helpers/throwIfAgencyWontHaveEnoughCounsellorsOrValidators.ts
+++ b/back/src/domains/inclusion-connected-users/helpers/throwIfAgencyWontHaveEnoughCounsellorsOrValidators.ts
@@ -1,0 +1,44 @@
+import { AgencyDto, UserId, errors } from "shared";
+import { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
+
+export const throwIfAgencyDontHaveOtherValidatorsReceivingNotifications =
+  async (uow: UnitOfWork, agency: AgencyDto, userId: UserId) => {
+    if (agency.refersToAgencyId !== null) return;
+
+    const agencyUsers = await uow.userRepository.getWithFilter({
+      agencyId: agency.id,
+    });
+
+    const agencyHasOtherValidator = agencyUsers.some(
+      (agencyUser) =>
+        agencyUser.id !== userId &&
+        agencyUser.agencyRights.some(
+          (right) =>
+            right.isNotifiedByEmail && right.roles.includes("validator"),
+        ),
+    );
+
+    if (!agencyHasOtherValidator)
+      throw errors.agency.notEnoughValidators({ agencyId: agency.id });
+  };
+
+export const throwIfAgencyDontHaveOtherCounsellorsReceivingNotifications =
+  async (uow: UnitOfWork, agency: AgencyDto, userId: UserId) => {
+    if (!agency.refersToAgencyId) return;
+
+    const agencyUsers = await uow.userRepository.getWithFilter({
+      agencyId: agency.id,
+    });
+
+    const agencyHasOtherCounsellor = agencyUsers.some(
+      (agencyUser) =>
+        agencyUser.id !== userId &&
+        agencyUser.agencyRights.some(
+          (right) =>
+            right.isNotifiedByEmail && right.roles.includes("counsellor"),
+        ),
+    );
+
+    if (!agencyHasOtherCounsellor)
+      throw errors.agency.notEnoughCounsellors({ agencyId: agency.id });
+  };

--- a/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.ts
@@ -27,7 +27,7 @@ const getUserAndThrowIfNotFound = async (
   return requestedUser;
 };
 
-const getAgencyAndThrowIfUserHasNoAgencyRight = (
+const getUserAgencyRightsAndThrowIfUserHasNoAgencyRight = (
   user: InclusionConnectedUser,
   agencyId: AgencyId,
 ): AgencyDto => {
@@ -57,7 +57,7 @@ export const makeRemoveUserFromAgency = createTransactionalUseCase<
       uow.userRepository,
       inputParams.userId,
     );
-    const agency = getAgencyAndThrowIfUserHasNoAgencyRight(
+    const agency = getUserAgencyRightsAndThrowIfUserHasNoAgencyRight(
       requestedUser,
       inputParams.agencyId,
     );

--- a/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.ts
@@ -1,0 +1,84 @@
+import {
+  AgencyDto,
+  AgencyId,
+  InclusionConnectedUser,
+  RemoveAgencyUserParams,
+  UserId,
+  errors,
+  removeAgencyUserParamsSchema,
+} from "shared";
+import { createTransactionalUseCase } from "../../core/UseCase";
+import { UserRepository } from "../../core/authentication/inclusion-connect/port/UserRepository";
+import { CreateNewEvent } from "../../core/events/ports/EventBus";
+import {
+  throwIfAgencyDontHaveOtherCounsellorsReceivingNotifications,
+  throwIfAgencyDontHaveOtherValidatorsReceivingNotifications,
+} from "../helpers/throwIfAgencyWontHaveEnoughCounsellorsOrValidators";
+import { throwIfNotAdmin } from "../helpers/throwIfIcUserNotBackofficeAdmin";
+
+export type RemoveUserFromAgency = ReturnType<typeof makeRemoveUserFromAgency>;
+
+const getUserAndThrowIfNotFound = async (
+  userRepository: UserRepository,
+  userId: UserId,
+): Promise<InclusionConnectedUser> => {
+  const requestedUser = await userRepository.getById(userId);
+  if (!requestedUser) throw errors.user.notFound({ userId });
+  return requestedUser;
+};
+
+const getAgencyAndThrowIfUserHasNoAgencyRight = (
+  user: InclusionConnectedUser,
+  agencyId: AgencyId,
+): AgencyDto => {
+  const userRight = user.agencyRights.find(
+    (agencyRight) => agencyRight.agency.id === agencyId,
+  );
+
+  if (!userRight)
+    throw errors.user.expectedRightsOnAgency({
+      agencyId,
+      userId: user.id,
+    });
+
+  return userRight.agency;
+};
+
+export const makeRemoveUserFromAgency = createTransactionalUseCase<
+  RemoveAgencyUserParams,
+  void,
+  InclusionConnectedUser,
+  { createNewEvent: CreateNewEvent }
+>(
+  { name: "RemoveUserFromAgency", inputSchema: removeAgencyUserParamsSchema },
+  async ({ currentUser, uow, inputParams }) => {
+    throwIfNotAdmin(currentUser);
+    const requestedUser = await getUserAndThrowIfNotFound(
+      uow.userRepository,
+      inputParams.userId,
+    );
+    const agency = getAgencyAndThrowIfUserHasNoAgencyRight(
+      requestedUser,
+      inputParams.agencyId,
+    );
+    await throwIfAgencyDontHaveOtherValidatorsReceivingNotifications(
+      uow,
+      agency,
+      inputParams.userId,
+    );
+    await throwIfAgencyDontHaveOtherCounsellorsReceivingNotifications(
+      uow,
+      agency,
+      inputParams.userId,
+    );
+
+    const filteredAgencyRights = requestedUser.agencyRights.filter(
+      (agencyRight) => agencyRight.agency.id !== inputParams.agencyId,
+    );
+
+    await uow.userRepository.updateAgencyRights({
+      userId: inputParams.userId,
+      agencyRights: filteredAgencyRights,
+    });
+  },
+);

--- a/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.unit.test.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/RemoveUserFromAgency.unit.test.ts
@@ -1,0 +1,257 @@
+import {
+  AgencyDto,
+  AgencyDtoBuilder,
+  AgencyRight,
+  InclusionConnectedUser,
+  InclusionConnectedUserBuilder,
+  RemoveAgencyUserParams,
+  errors,
+  expectPromiseToFailWithError,
+} from "shared";
+import { InMemoryAgencyRepository } from "../../agency/adapters/InMemoryAgencyRepository";
+import { InMemoryUserRepository } from "../../core/authentication/inclusion-connect/adapters/InMemoryUserRepository";
+import {
+  CreateNewEvent,
+  makeCreateNewEvent,
+} from "../../core/events/ports/EventBus";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
+import { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
+import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import { createInMemoryUow } from "../../core/unit-of-work/adapters/createInMemoryUow";
+import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
+import { UuidGenerator } from "../../core/uuid-generator/ports/UuidGenerator";
+import {
+  RemoveUserFromAgency,
+  makeRemoveUserFromAgency,
+} from "./RemoveUserFromAgency";
+
+const agency = new AgencyDtoBuilder()
+  .withCounsellorEmails(["fake-email@gmail.com"])
+  .build();
+
+const backofficeAdminUser = new InclusionConnectedUserBuilder()
+  .withId("backoffice-admin-id")
+  .withIsAdmin(true)
+  .build();
+
+const notAdminUser = new InclusionConnectedUserBuilder()
+  .withId("not-admin-id")
+  .withIsAdmin(false)
+  .build();
+
+describe("RemoveUserFromAgency", () => {
+  let timeGateway: TimeGateway;
+  let uuidGenerator: UuidGenerator;
+  let createNewEvent: CreateNewEvent;
+  let removeUserFromAgency: RemoveUserFromAgency;
+  let userRepository: InMemoryUserRepository;
+  let agencyRepository: InMemoryAgencyRepository;
+
+  beforeEach(() => {
+    const uow = createInMemoryUow();
+    const uowPerformer = new InMemoryUowPerformer(uow);
+    timeGateway = new CustomTimeGateway();
+    uuidGenerator = new TestUuidGenerator();
+    createNewEvent = makeCreateNewEvent({
+      uuidGenerator,
+      timeGateway,
+    });
+    userRepository = uow.userRepository;
+    agencyRepository = uow.agencyRepository;
+    userRepository.setInclusionConnectedUsers([
+      backofficeAdminUser,
+      notAdminUser,
+    ]);
+    agencyRepository.setAgencies([agency]);
+    removeUserFromAgency = makeRemoveUserFromAgency({
+      uowPerformer,
+      deps: { createNewEvent },
+    });
+  });
+
+  it("throws forbidden when token payload is not backoffice token", () => {
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(
+        {
+          agencyId: "agency-id",
+          userId: "user-id",
+        },
+        notAdminUser,
+      ),
+      errors.user.forbidden({ userId: notAdminUser.id }),
+    );
+  });
+
+  it("throws notFound if user to delete not found", async () => {
+    const inputParams: RemoveAgencyUserParams = {
+      agencyId: agency.id,
+      userId: "unexisting-user",
+    };
+
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(inputParams, backofficeAdminUser),
+      errors.user.notFound({ userId: inputParams.userId }),
+    );
+  });
+
+  it("throws forbidden if user to delete has not rights on agency", async () => {
+    const inputParams: RemoveAgencyUserParams = {
+      agencyId: agency.id,
+      userId: notAdminUser.id,
+    };
+
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(inputParams, backofficeAdminUser),
+      errors.user.expectedRightsOnAgency(inputParams),
+    );
+  });
+
+  it("throws forbidden if user to delete is the last validator receiving notifications", async () => {
+    const initialAgencyRights: AgencyRight[] = [
+      {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: true,
+      },
+    ];
+    const user: InclusionConnectedUser = {
+      ...notAdminUser,
+      agencyRights: initialAgencyRights,
+      dashboards: {
+        agencies: {},
+        establishments: {},
+      },
+    };
+    userRepository.setInclusionConnectedUsers([user]);
+    const inputParams: RemoveAgencyUserParams = {
+      agencyId: agency.id,
+      userId: notAdminUser.id,
+    };
+
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(inputParams, backofficeAdminUser),
+      errors.agency.notEnoughValidators(inputParams),
+    );
+  });
+
+  it("throws forbidden if user to delete is the last validator receiving notifications", async () => {
+    const initialAgencyRights: AgencyRight[] = [
+      {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: true,
+      },
+    ];
+    const user: InclusionConnectedUser = {
+      ...notAdminUser,
+      agencyRights: initialAgencyRights,
+      dashboards: {
+        agencies: {},
+        establishments: {},
+      },
+    };
+    userRepository.setInclusionConnectedUsers([user]);
+    const inputParams: RemoveAgencyUserParams = {
+      agencyId: agency.id,
+      userId: notAdminUser.id,
+    };
+
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(inputParams, backofficeAdminUser),
+      errors.agency.notEnoughValidators(inputParams),
+    );
+  });
+
+  it("throws forbidden if user to delete is the last counsellor receiving notifications", async () => {
+    const agencyWithRefersTo: AgencyDto = {
+      ...agency,
+      id: "agency-with-refers-to-id",
+      counsellorEmails: [],
+      validatorEmails: [],
+      refersToAgencyId: agency.id,
+    };
+    const initialAgencyRights: AgencyRight[] = [
+      {
+        agency: agencyWithRefersTo,
+        roles: ["validator"],
+        isNotifiedByEmail: true,
+      },
+    ];
+    const user: InclusionConnectedUser = {
+      ...notAdminUser,
+      agencyRights: initialAgencyRights,
+      dashboards: {
+        agencies: {},
+        establishments: {},
+      },
+    };
+    userRepository.setInclusionConnectedUsers([user]);
+    const inputParams: RemoveAgencyUserParams = {
+      agencyId: agencyWithRefersTo.id,
+      userId: notAdminUser.id,
+    };
+
+    expectPromiseToFailWithError(
+      removeUserFromAgency.execute(inputParams, backofficeAdminUser),
+      errors.agency.notEnoughCounsellors(inputParams),
+    );
+  });
+
+  describe("user to delete has right on agency", () => {
+    it("remove user from agency", async () => {
+      const agency2 = new AgencyDtoBuilder().withId("agency-2-id").build();
+      const initialAgencyRights: AgencyRight[] = [
+        {
+          agency,
+          roles: ["validator"],
+          isNotifiedByEmail: true,
+        },
+        {
+          agency: agency2,
+          roles: ["validator"],
+          isNotifiedByEmail: true,
+        },
+      ];
+      const user: InclusionConnectedUser = {
+        ...notAdminUser,
+        agencyRights: initialAgencyRights,
+        dashboards: {
+          agencies: {},
+          establishments: {},
+        },
+      };
+      const otherUserWithRightOnAgencies: InclusionConnectedUser = {
+        ...notAdminUser,
+        id: "other-user-id",
+        agencyRights: initialAgencyRights,
+        dashboards: {
+          agencies: {},
+          establishments: {},
+        },
+      };
+      userRepository.setInclusionConnectedUsers([
+        user,
+        otherUserWithRightOnAgencies,
+      ]);
+      expect(
+        (await userRepository.getById(notAdminUser.id))?.agencyRights,
+      ).toEqual(initialAgencyRights);
+
+      const inputParams: RemoveAgencyUserParams = {
+        agencyId: agency.id,
+        userId: notAdminUser.id,
+      };
+      await removeUserFromAgency.execute(inputParams, backofficeAdminUser);
+
+      expect(
+        (await userRepository.getById(inputParams.userId))?.agencyRights,
+      ).toEqual([
+        {
+          agency: agency2,
+          roles: ["validator"],
+          isNotifiedByEmail: true,
+        },
+      ]);
+    });
+  });
+});

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -1,6 +1,7 @@
 import { FrClassName, fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
+import { ButtonsGroup } from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { Table } from "@codegouvfr/react-dsfr/Table";
 import { values } from "ramda";
@@ -72,6 +73,11 @@ const manageUserModal = createModal({
   id: domElementIds.admin.agencyTab.editAgencyManageUserModal,
 });
 
+const removeUserModal = createModal({
+  isOpenedByDefault: false,
+  id: domElementIds.admin.agencyTab.editAgencyRemoveUserModal,
+});
+
 export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
   const agencyUsers = useAppSelector(icUsersAdminSelectors.agencyUsers);
   const dispatch = useDispatch();
@@ -118,6 +124,7 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
       </Button>
 
       <Table
+        fixed
         id={domElementIds.admin.agencyTab.agencyUsersTable}
         headers={[
           "Utilisateurs",
@@ -151,30 +158,52 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
                 </Badge>
               );
             }),
-            <Button
-              priority="secondary"
-              className={fr.cx("fr-m-1w")}
-              id={`${domElementIds.admin.agencyTab.editAgencyUserRoleButton}-${agency.id}-${index}`}
-              onClick={() => {
-                dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
-                setMode("update");
-                setSelectedUserData({
-                  agencyId: agency.id,
-                  userId: agencyUser.id,
-                  roles: agencyUser.agencyRights[agency.id].roles,
-                  email: agencyUser.email,
-                  isNotifiedByEmail:
-                    agencyUser.agencyRights[agency.id].isNotifiedByEmail,
-                  isIcUser: !!agencyUser.externalId,
-                });
-                manageUserModal.open();
-              }}
-            >
-              Modifier
-            </Button>,
+            <ButtonsGroup
+              buttons={[
+                {
+                  title: "Modifier",
+                  iconId: "fr-icon-edit-fill",
+                  priority: "secondary",
+                  className: "fr-m-1w",
+                  id: `${domElementIds.admin.agencyTab.editAgencyUserRoleButton}-${agency.id}-${index}`,
+                  onClick: () => {
+                    dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
+                    setMode("update");
+                    setSelectedUserData({
+                      agencyId: agency.id,
+                      userId: agencyUser.id,
+                      roles: agencyUser.agencyRights[agency.id].roles,
+                      email: agencyUser.email,
+                      isNotifiedByEmail:
+                        agencyUser.agencyRights[agency.id].isNotifiedByEmail,
+                      isIcUser: !!agencyUser.externalId,
+                    });
+                    manageUserModal.open();
+                  },
+                },
+                {
+                  title: "Supprimer",
+                  iconId: "fr-icon-delete-fill",
+                  priority: "secondary",
+                  id: `${domElementIds.admin.agencyTab.editAgencyRemoveUserButton}-${agency.id}-${index}`,
+                  onClick: () => {
+                    dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
+                    setSelectedUserData({
+                      agencyId: agency.id,
+                      userId: agencyUser.id,
+                      roles: agencyUser.agencyRights[agency.id].roles,
+                      email: agencyUser.email,
+                      isNotifiedByEmail:
+                        agencyUser.agencyRights[agency.id].isNotifiedByEmail,
+                      isIcUser: !!agencyUser.externalId,
+                    });
+                    removeUserModal.open();
+                  },
+                },
+              ]}
+            />,
           ];
         })}
-        fixed
       />
 
       {createPortal(
@@ -194,6 +223,36 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
             />
           )}
         </manageUserModal.Component>,
+        document.body,
+      )}
+
+      {createPortal(
+        <removeUserModal.Component title="Confirmer la suppression">
+          <p>
+            Vous êtes sur le point de supprimer le rattachement de{" "}
+            {selectedUserData?.email}.
+          </p>
+          <p>Souhaitez-vous continuer ?</p>
+          <ButtonsGroup
+            inlineLayoutWhen="always"
+            buttons={[
+              {
+                priority: "secondary",
+                children: "Annuler",
+                onClick: () => {
+                  removeUserModal.close();
+                },
+              },
+              {
+                priority: "primary",
+                children: "Supprimer le rattachement",
+                onClick: () => {
+                  //TODO
+                },
+              },
+            ]}
+          />
+        </removeUserModal.Component>,
         document.body,
       )}
     </>

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -18,6 +18,7 @@ import {
 import { AgencyUserModificationForm } from "src/app/components/agency/AgencyUserModificationForm";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { icUsersAdminSelectors } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.selectors";
+import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 import { feedbackSlice } from "src/core-logic/domain/feedback/feedback.slice";
 import { v4 as uuidV4 } from "uuid";
 import { Feedback } from "../feedback/Feedback";
@@ -159,12 +160,11 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
               );
             }),
             <ButtonsGroup
+              inlineLayoutWhen={"always"}
               buttons={[
                 {
-                  title: "Modifier",
-                  iconId: "fr-icon-edit-fill",
+                  children: "Modifier",
                   priority: "secondary",
-                  className: "fr-m-1w",
                   id: `${domElementIds.admin.agencyTab.editAgencyUserRoleButton}-${agency.id}-${index}`,
                   onClick: () => {
                     dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
@@ -182,8 +182,7 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
                   },
                 },
                 {
-                  title: "Supprimer",
-                  iconId: "fr-icon-delete-fill",
+                  children: "Supprimer",
                   priority: "secondary",
                   id: `${domElementIds.admin.agencyTab.editAgencyRemoveUserButton}-${agency.id}-${index}`,
                   onClick: () => {
@@ -230,7 +229,7 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
         <removeUserModal.Component title="Confirmer la suppression">
           <p>
             Vous êtes sur le point de supprimer le rattachement de{" "}
-            {selectedUserData?.email}.
+            {selectedUserData?.email} à l'agence "{agency.name}".
           </p>
           <p>Souhaitez-vous continuer ?</p>
           <ButtonsGroup
@@ -247,7 +246,15 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
                 priority: "primary",
                 children: "Supprimer le rattachement",
                 onClick: () => {
-                  //TODO
+                  if (!selectedUserData) return;
+                  dispatch(
+                    icUsersAdminSlice.actions.removeUserFromAgencyRequested({
+                      userId: selectedUserData.userId,
+                      agencyId: agency.id,
+                      feedbackTopic: "agency-user",
+                    }),
+                  );
+                  removeUserModal.close();
                 },
               },
             ]}

--- a/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
@@ -10,6 +10,7 @@ import {
   InclusionConnectJwt,
   InclusionConnectedUser,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserParamsForAgency,
   WithUserFilters,
@@ -215,6 +216,26 @@ export class HttpAdminGateway implements AdminGateway {
         .then((response) =>
           match(response)
             .with({ status: 201 }, () => undefined)
+            .with({ status: 400 }, throwBadRequestWithExplicitMessage)
+            .with({ status: P.union(401, 404) }, logBodyAndThrow)
+            .otherwise(otherwiseThrow),
+        ),
+    );
+  }
+
+  public removeUserFromAgency$(
+    params: RemoveAgencyUserParams,
+    token: string,
+  ): Observable<void> {
+    return from(
+      this.httpClient
+        .removeUserFromAgency({
+          headers: { authorization: token },
+          urlParams: params,
+        })
+        .then((response) =>
+          match(response)
+            .with({ status: 200 }, () => undefined)
             .with({ status: 400 }, throwBadRequestWithExplicitMessage)
             .with({ status: P.union(401, 404) }, logBodyAndThrow)
             .otherwise(otherwiseThrow),

--- a/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
@@ -12,6 +12,7 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   UserParamsForAgency,
 } from "shared";
 import { AdminGateway } from "src/core-logic/ports/AdminGateway";
@@ -181,6 +182,13 @@ export class SimulatedAdminGateway implements AdminGateway {
     return agencyId === "non-existing-agency-id"
       ? throwError(() => new Error(`Agency Id ${agencyId} not found`))
       : of(undefined);
+  }
+
+  public removeUserFromAgency$(
+    _params: RemoveAgencyUserParams,
+    _token: string,
+  ): Observable<void> {
+    return of(undefined);
   }
 }
 

--- a/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
@@ -9,6 +9,7 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserParamsForAgency,
 } from "shared";
@@ -42,6 +43,8 @@ export class TestAdminGateway implements AdminGateway {
   public token$ = new Subject<string>();
 
   public updateAgencyRoleForUserResponse$ = new Subject<undefined>();
+
+  public removeUserFromAgencyResponse$ = new Subject<undefined>();
 
   public createUserForAgencyResponse$ = new Subject<InclusionConnectedUser>();
 
@@ -102,5 +105,12 @@ export class TestAdminGateway implements AdminGateway {
     _token: string,
   ): Observable<void> {
     return this.updateAgencyRoleForUserResponse$;
+  }
+
+  public removeUserFromAgency$(
+    _params: RemoveAgencyUserParams,
+    _token: string,
+  ): Observable<void> {
+    return this.removeUserFromAgencyResponse$;
   }
 }

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics.ts
@@ -183,6 +183,32 @@ const updateUserOnAgencyEpic: IcUsersAdminActionEpic = (
     ),
   );
 
+const removeAgencyUserRequestedEpic: IcUsersAdminActionEpic = (
+  action$,
+  state$,
+  { adminGateway },
+) =>
+  action$.pipe(
+    filter(icUsersAdminSlice.actions.removeUserFromAgencyRequested.match),
+    switchMap((action) =>
+      adminGateway
+        .removeUserFromAgency$(action.payload, getAdminToken(state$.value))
+        .pipe(
+          map(() =>
+            icUsersAdminSlice.actions.removeUserFromAgencySucceeded(
+              action.payload,
+            ),
+          ),
+          catchEpicError((error) =>
+            icUsersAdminSlice.actions.removeUserFromAgencyFailed({
+              errorMessage: error.message,
+              feedbackTopic: action.payload.feedbackTopic,
+            }),
+          ),
+        ),
+    ),
+  );
+
 const fetchInclusionConnectedUserOnAgencyUpdateEpic: AppEpic<
   IcUsersAdminAction | AgencyAction
 > = (action$) =>
@@ -223,4 +249,5 @@ export const icUsersAdminEpics = [
   updateUserOnAgencyEpic,
   fetchInclusionConnectedUserOnAgencyUpdateEpic,
   createUserOnAgencyEpic,
+  removeAgencyUserRequestedEpic,
 ];

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -220,5 +220,12 @@ export const icUsersAdminSlice = createSlice({
     ) => {
       state.isUpdatingIcUserAgency = false;
     },
+
+    removeAgencyUserRequested: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<UserParamsForAgency>,
+    ) => {
+      state.isUpdatingIcUserAgency = true;
+    },
   },
 });

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -1,10 +1,12 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { filter } from "ramda";
 import {
   AgencyId,
   AgencyRight,
   InclusionConnectedUser,
   OmitFromExistingKeys,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   User,
   UserId,
   UserParamsForAgency,
@@ -221,11 +223,29 @@ export const icUsersAdminSlice = createSlice({
       state.isUpdatingIcUserAgency = false;
     },
 
-    removeAgencyUserRequested: (
+    removeUserFromAgencyRequested: (
       state,
-      _action: PayloadActionWithFeedbackTopic<UserParamsForAgency>,
+      _action: PayloadActionWithFeedbackTopic<RemoveAgencyUserParams>,
     ) => {
       state.isUpdatingIcUserAgency = true;
+    },
+
+    removeUserFromAgencySucceeded: (
+      state,
+      action: PayloadActionWithFeedbackTopic<RemoveAgencyUserParams>,
+    ) => {
+      state.isUpdatingIcUserAgency = false;
+      state.agencyUsers = filter(
+        (agencyUser) => agencyUser.id !== action.payload.userId,
+        state.agencyUsers,
+      );
+    },
+
+    removeUserFromAgencyFailed: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<{ errorMessage: string }>,
+    ) => {
+      state.isUpdatingIcUserAgency = false;
     },
   },
 });

--- a/front/src/core-logic/domain/feedback/feedback.slice.ts
+++ b/front/src/core-logic/domain/feedback/feedback.slice.ts
@@ -161,6 +161,18 @@ export const feedbackMapping: Record<
       title: "Problème lors de la création de l'utilisateur",
       message: "Une erreur est survenue lors de la création de l'utilisateur",
     },
+    "delete.success": {
+      action: icUsersAdminSlice.actions.removeUserFromAgencySucceeded,
+      title: "L'utilisateur n'est plus rattaché à cette agence",
+      message: "Les données de l'utilisateur (rôles) ont été mises à jour.",
+    },
+    "delete.error": {
+      action: icUsersAdminSlice.actions.removeUserFromAgencyFailed,
+      title:
+        "Problème lors de la suppression du rattachement l'utilisateur à cette agence",
+      message:
+        "Une erreur est survenue lors de la suppression du rattachement de l'utilisateur.",
+    },
   },
 };
 

--- a/front/src/core-logic/ports/AdminGateway.ts
+++ b/front/src/core-logic/ports/AdminGateway.ts
@@ -10,6 +10,7 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserParamsForAgency,
   WithUserFilters,
@@ -48,6 +49,11 @@ export interface AdminGateway {
 
   updateUserRoleForAgency$(
     params: UserParamsForAgency,
+    token: InclusionConnectJwt,
+  ): Observable<void>;
+
+  removeUserFromAgency$(
+    params: RemoveAgencyUserParams,
     token: InclusionConnectJwt,
   ): Observable<void>;
 

--- a/shared/src/admin/admin.dto.ts
+++ b/shared/src/admin/admin.dto.ts
@@ -12,6 +12,11 @@ import {
 import { SiretDto } from "../siret/siret";
 import { OmitFromExistingKeys } from "../utils";
 
+export type RemoveAgencyUserParams = {
+  agencyId: AgencyId;
+  userId: UserId;
+};
+
 export type UserParamsForAgency = {
   agencyId: AgencyId;
   roles: AgencyRole[];

--- a/shared/src/admin/admin.routes.ts
+++ b/shared/src/admin/admin.routes.ts
@@ -59,6 +59,17 @@ export const adminRoutes = defineRoutes({
       404: httpErrorSchema,
     },
   }),
+  removeUserFromAgency: defineRoute({
+    method: "delete",
+    url: "/admin/inclusion-connected/users/:userId/agency/:agencyId",
+    ...withAuthorizationHeaders,
+    responses: {
+      200: expressEmptyResponseBody,
+      400: httpErrorSchema,
+      401: httpErrorSchema,
+      404: httpErrorSchema,
+    },
+  }),
 
   createUserForAgency: defineRoute({
     method: "post",

--- a/shared/src/admin/admin.schema.ts
+++ b/shared/src/admin/admin.schema.ts
@@ -12,9 +12,16 @@ import {
   ManageConventionAdminForm,
   ManageEstablishmentAdminForm,
   RejectIcUserRoleForAgencyParams,
+  RemoveAgencyUserParams,
   UserParamsForAgency,
   WithUserFilters,
 } from "./admin.dto";
+
+export const removeAgencyUserParamsSchema: z.Schema<RemoveAgencyUserParams> =
+  z.object({
+    agencyId: agencyIdSchema,
+    userId: userIdSchema,
+  });
 
 export const userParamsForAgencySchema: z.Schema<UserParamsForAgency> =
   z.object({

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -559,7 +559,9 @@ export const domElementIds = {
       agencyUsersTable: "im-form-edit-agency__users-table",
       editAgencyAutocompleteInput: "im-form-edit-agency__agency-autocomplete",
       editAgencyManageUserModal: "im-form-edit-agency__manage-user-modal",
+      editAgencyRemoveUserModal: "im-form-edit-agency__remove-user-modal",
       editAgencyUserRoleButton: "im-form-edit-agency__users-table-edit-button",
+      editAgencyRemoveUserButton: "im-form-edit-agency__remove-user-button",
       editAgencyUserRoleSubmitButton:
         "im-form-edit-agency__users-submit-button",
       editAgencyManageUserCheckbox: "im-form-edit-agency__manage-user-checkbox",

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -313,6 +313,13 @@ export const errors = {
       new BadRequestError(
         `L'utilisateur qui a l'identifiant "${userId}" a déjà les droits pour cette agence.`,
       ),
+    expectedRightsOnAgency: ({
+      agencyId,
+      userId,
+    }: { userId: UserId; agencyId: AgencyId }) =>
+      new BadRequestError(
+        `L'utilisateur qui a l'identifiant "${userId}" n'a pas de droits sur l'agence "${agencyId}".`,
+      ),
     noRightsOnAgency: ({
       agencyId,
       userId,


### PR DESCRIPTION
## Description

En tant qu'admin, pouvoir supprimer un utilisateur d'une agence.

![Screenshot 2024-09-25 at 10 40 39](https://github.com/user-attachments/assets/69208a96-a8cf-4f8f-b2fb-b9f64d948378)
