### PR TITLE
#2213 - FIX ETQ admin, modifier une agence en deux étapes en une seule étape et garder le conseiller en valideur

### DIFF
--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -324,7 +324,18 @@ export class PgAgencyRepository implements AgencyRepository {
         .where("is_notified_by_email", "=", true)
         .where("agency_id", "=", agency.id)
         .execute();
+    }
 
+    if (agency.counsellorEmails) {
+      await this.transaction
+        .deleteFrom("users__agencies")
+        .where(usersAgenciesRolesIncludeCounsellor)
+        .where("is_notified_by_email", "=", true)
+        .where("agency_id", "=", agency.id)
+        .execute();
+    }
+
+    if (agency.validatorEmails) {
       await Promise.all(
         agency.validatorEmails.map(async (email) =>
           this.#addUserAndAgencyRights(
@@ -339,13 +350,6 @@ export class PgAgencyRepository implements AgencyRepository {
     }
 
     if (agency.counsellorEmails) {
-      await this.transaction
-        .deleteFrom("users__agencies")
-        .where(usersAgenciesRolesIncludeCounsellor)
-        .where("is_notified_by_email", "=", true)
-        .where("agency_id", "=", agency.id)
-        .execute();
-
       await Promise.all(
         agency.counsellorEmails.map(async (email) =>
           this.#addUserAndAgencyRights(email, agency.id, ["counsellor"]),


### PR DESCRIPTION
## Etapes pour reproduire le problème

1. ETQ admin, lorsque j'accède au formulaire d'édition d'une agence à deux étapes de validation qui a un conseiller et un valideur
2. Je vide le champ de mails valideurs
3. Je mets le mail du conseiller en tant que valideur
4. Je vide le champ de mails conseillers
5. Je sauvegarde

Alors je constate qu'en DB je n'ai ni valideur ni conseiller pour cette agence. 
Cela engendre des problèmes de recherche d'agence depuis le formulaire de convention car on se retrouve avec une agence sans valideurs ni conseillers.