### PR TITLE
#2023 - Ajout d'un champ adresse du candidat dans le formulaire de mini stage

### DIFF
--- a/back/src/domains/convention/adapters/PgConventionRepository.ts
+++ b/back/src/domains/convention/adapters/PgConventionRepository.ts
@@ -333,7 +333,7 @@ export class PgConventionRepository implements ConventionRepository {
           'levelOfEducation', ${studentFields.levelOfEducation}::text,
           'schoolName', ${studentFields.schoolName}::text,
           'schoolPostcode', ${studentFields.schoolPostcode}::text,
-          'address', ${studentFields.address}::text
+          'address', ${studentFields.address}::jsonb
           ))`,
       })
       .returning("actors.id")
@@ -464,7 +464,7 @@ export class PgConventionRepository implements ConventionRepository {
           'isRqth',  ${beneficiary.isRqth}::boolean,
           'schoolName',  ${studentFields.schoolName}::text,
           'schoolPostcode',  ${studentFields.schoolPostcode}::text,
-          'address', ${studentFields.address}::text
+          'address', ${studentFields.address}::jsonb
       ))`,
       })
       .from("conventions")

--- a/back/src/domains/convention/adapters/PgConventionRepository.ts
+++ b/back/src/domains/convention/adapters/PgConventionRepository.ts
@@ -332,7 +332,8 @@ export class PgConventionRepository implements ConventionRepository {
           'isRqth', ${beneficiary.isRqth}::boolean,
           'levelOfEducation', ${studentFields.levelOfEducation}::text,
           'schoolName', ${studentFields.schoolName}::text,
-          'schoolPostcode', ${studentFields.schoolPostcode}::text
+          'schoolPostcode', ${studentFields.schoolPostcode}::text,
+          'address', ${studentFields.address}::text
           ))`,
       })
       .returning("actors.id")
@@ -462,7 +463,8 @@ export class PgConventionRepository implements ConventionRepository {
           'financiaryHelp',  ${beneficiary.financiaryHelp}::text,
           'isRqth',  ${beneficiary.isRqth}::boolean,
           'schoolName',  ${studentFields.schoolName}::text,
-          'schoolPostcode',  ${studentFields.schoolPostcode}::text
+          'schoolPostcode',  ${studentFields.schoolPostcode}::text,
+          'address', ${studentFields.address}::text
       ))`,
       })
       .from("conventions")
@@ -637,7 +639,7 @@ const getStudentFields = (
 ):
   | Pick<
       Beneficiary<"mini-stage-cci">,
-      "levelOfEducation" | "schoolName" | "schoolPostcode"
+      "levelOfEducation" | "schoolName" | "schoolPostcode" | "address"
     >
   | Record<string, never> =>
   isBeneficiaryStudent(beneficiary)
@@ -645,5 +647,6 @@ const getStudentFields = (
         levelOfEducation: beneficiary.levelOfEducation,
         schoolPostcode: beneficiary.schoolPostcode,
         schoolName: beneficiary.schoolName,
+        address: beneficiary.address,
       }
     : {};

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -108,6 +108,12 @@ export const createConventionQueryBuilder = (transaction: KyselyDb) => {
               .then(sql`b.extra_fields ->> 'financiaryHelp'`)
               .else(null)
               .end(),
+            address: eb
+              .case()
+              .when(sql`b.extra_fields ->> 'address'`, "is not", null)
+              .then(sql`b.extra_fields ->> 'address'`)
+              .else(null)
+              .end(),
             birthdate: eb
               .case()
               .when(sql`b.extra_fields ->> 'birthdate'`, "is not", null)

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -111,7 +111,14 @@ export const createConventionQueryBuilder = (transaction: KyselyDb) => {
             address: eb
               .case()
               .when(sql`b.extra_fields ->> 'address'`, "is not", null)
-              .then(sql`b.extra_fields ->> 'address'`)
+              .then(
+                jsonBuildObject({
+                  city: sql`b.extra_fields -> 'address' ->> 'city'`,
+                  departmentCode: sql`b.extra_fields -> 'address' ->> 'departmentCode'`,
+                  postcode: sql`b.extra_fields -> 'address' ->> 'postcode'`,
+                  streetNumberAndAddress: sql`b.extra_fields -> 'address' ->> 'streetNumberAndAddress'`,
+                }),
+              )
               .else(null)
               .end(),
             birthdate: eb

--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -548,13 +548,12 @@ export const ConventionForm = ({
                   )}
                 </>
               </>
-              <div className={fr.cx("fr-mt-4w")}>
+              <div className={fr.cx("fr-mt-4w", "fr-hidden", "fr-unhidden-lg")}>
                 <Button
                   disabled={shouldSubmitButtonBeDisabled}
                   iconId="fr-icon-checkbox-circle-line"
                   iconPosition="left"
                   type="button"
-                  className={fr.cx("fr-hidden", "fr-unhidden-lg")}
                   nativeButtonProps={{
                     id: domElementIds.conventionImmersionRoute.submitFormButton,
                   }}

--- a/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
+++ b/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
@@ -214,7 +214,7 @@ const ConventionSummarySection = () => {
         <Alert
           severity={"info"}
           title="Validation"
-          description="Attention ! Vérifiez que tous les éléments sont bien intégrés et exacts.En cas de demande de modification après validation, tous les signataires devront signer à nouveau la convention."
+          description="Attention ! Vérifiez que tous les éléments sont bien intégrés et exacts. En cas de demande de modification après validation, tous les signataires devront signer à nouveau la convention."
           small
         />
       )}

--- a/front/src/app/components/forms/convention/ConventionSummarySection.tsx
+++ b/front/src/app/components/forms/convention/ConventionSummarySection.tsx
@@ -240,6 +240,10 @@ const beneficiarySummary = (
       ...(convention.internshipKind === "mini-stage-cci"
         ? ([
             [
+              fields["signatories.beneficiary.address"].label,
+              convention.signatories.beneficiary.address,
+            ],
+            [
               fields["signatories.beneficiary.levelOfEducation"].label,
               convention.signatories.beneficiary.levelOfEducation,
             ],

--- a/front/src/app/components/forms/convention/ConventionSummarySection.tsx
+++ b/front/src/app/components/forms/convention/ConventionSummarySection.tsx
@@ -6,6 +6,7 @@ import {
   DateIntervalDto,
   DotNestedKeys,
   ScheduleDto,
+  addressDtoToString,
   convertLocaleDateToUtcTimezoneDate,
   prettyPrintSchedule,
   toDisplayedDate,
@@ -237,12 +238,17 @@ const beneficiarySummary = (
         fields["signatories.beneficiary.birthdate"].label,
         displayDate(convention.signatories.beneficiary.birthdate),
       ],
-      ...(convention.internshipKind === "mini-stage-cci"
+      ...(convention.internshipKind === "mini-stage-cci" &&
+      convention.signatories.beneficiary.address
         ? ([
             [
               fields["signatories.beneficiary.address"].label,
-              convention.signatories.beneficiary.address,
+              addressDtoToString(convention.signatories.beneficiary.address),
             ],
+          ] satisfies ConventionSummaryRow[])
+        : []),
+      ...(convention.internshipKind === "mini-stage-cci"
+        ? ([
             [
               fields["signatories.beneficiary.levelOfEducation"].label,
               convention.signatories.beneficiary.levelOfEducation,

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
@@ -10,10 +10,12 @@ import {
   BeneficiaryRepresentative,
   ConventionReadDto,
   InternshipKind,
+  domElementIds,
   emailSchema,
   isBeneficiaryStudent,
   levelsOfEducation,
 } from "shared";
+import { AddressAutocomplete } from "src/app/components/forms/autocomplete/AddressAutocomplete";
 import { ConventionEmailWarning } from "src/app/components/forms/convention/ConventionEmailWarning";
 import {
   EmailValidationErrorsState,
@@ -204,6 +206,16 @@ export const BeneficiaryFormSection = ({
       />
       {values.internshipKind === "mini-stage-cci" && (
         <>
+          <AddressAutocomplete
+            {...formContents["signatories.beneficiary.address"]}
+            setFormValue={(value) => {
+              setValue(
+                "signatories.beneficiary.address",
+                `${value.address.streetNumberAndAddress}, ${value.address.postcode} ${value.address.city}`,
+              );
+            }}
+            id={domElementIds.addAgency.addressAutocomplete}
+          />
           <Select
             label={
               formContents["signatories.beneficiary.levelOfEducation"].label

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
@@ -10,6 +10,7 @@ import {
   BeneficiaryRepresentative,
   ConventionReadDto,
   InternshipKind,
+  addressDtoToString,
   domElementIds,
   emailSchema,
   isBeneficiaryStudent,
@@ -208,6 +209,10 @@ export const BeneficiaryFormSection = ({
         <>
           <AddressAutocomplete
             {...formContents["signatories.beneficiary.address"]}
+            initialSearchTerm={
+              values.signatories.beneficiary.address &&
+              addressDtoToString(values.signatories.beneficiary.address)
+            }
             setFormValue={({ address }) => {
               setValue("signatories.beneficiary.address.city", address.city);
               setValue(

--- a/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
+++ b/front/src/app/components/forms/convention/sections/beneficiary/BeneficiaryFormSection.tsx
@@ -208,13 +208,24 @@ export const BeneficiaryFormSection = ({
         <>
           <AddressAutocomplete
             {...formContents["signatories.beneficiary.address"]}
-            setFormValue={(value) => {
+            setFormValue={({ address }) => {
+              setValue("signatories.beneficiary.address.city", address.city);
               setValue(
-                "signatories.beneficiary.address",
-                `${value.address.streetNumberAndAddress}, ${value.address.postcode} ${value.address.city}`,
+                "signatories.beneficiary.address.postcode",
+                address.postcode,
+              );
+              setValue(
+                "signatories.beneficiary.address.streetNumberAndAddress",
+                address.streetNumberAndAddress,
+              );
+              setValue(
+                "signatories.beneficiary.address.departmentCode",
+                address.departmentCode,
               );
             }}
-            id={domElementIds.addAgency.addressAutocomplete}
+            id={
+              domElementIds.conventionImmersionRoute.beneficiarySection.address
+            }
           />
           <Select
             label={

--- a/front/src/app/contents/admin/conventionValidation.tsx
+++ b/front/src/app/contents/admin/conventionValidation.tsx
@@ -131,6 +131,8 @@ const beneficiaryFields: ColField[] = [
         </div>
         {convention.internshipKind === "mini-stage-cci" && (
           <div className={fr.cx("fr-text--xs")}>
+            Adresse du candidat : {convention.signatories.beneficiary.address}
+            <br />
             Niveau d'études :{" "}
             {convention.signatories.beneficiary.levelOfEducation}
             <br />

--- a/front/src/app/contents/admin/conventionValidation.tsx
+++ b/front/src/app/contents/admin/conventionValidation.tsx
@@ -2,6 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 import React from "react";
 import {
   ConventionReadDto,
+  addressDtoToString,
   displayEmergencyContactInfos,
   makeSiretDescriptionLink,
   prettyPrintSchedule,
@@ -131,7 +132,9 @@ const beneficiaryFields: ColField[] = [
         </div>
         {convention.internshipKind === "mini-stage-cci" && (
           <div className={fr.cx("fr-text--xs")}>
-            Adresse du candidat : {convention.signatories.beneficiary.address}
+            Adresse du candidat :{" "}
+            {convention.signatories.beneficiary.address &&
+              addressDtoToString(convention.signatories.beneficiary.address)}
             <br />
             Niveau d'études :{" "}
             {convention.signatories.beneficiary.levelOfEducation}

--- a/front/src/app/contents/forms/convention/formConvention.tsx
+++ b/front/src/app/contents/forms/convention/formConvention.tsx
@@ -306,6 +306,11 @@ const beneficiarySection = (internshipKind: InternshipKind) => ({
     id: beneficiarySectionIds.emergencyContactEmail,
     placeholder: "Ex : contact@urgence.com (optionnel)",
   },
+  "signatories.beneficiary.address": {
+    label: "Adresse du candidat",
+    id: beneficiarySectionIds.address,
+    placeholder: "Ex : 10 Rue de la Paix, 75001 Paris",
+  },
   "signatories.beneficiary.schoolName": {
     label: "Nom de l'établissement scolaire du candidat",
     id: beneficiarySectionIds.schoolName,

--- a/front/src/app/contents/forms/convention/formConvention.tsx
+++ b/front/src/app/contents/forms/convention/formConvention.tsx
@@ -310,6 +310,7 @@ const beneficiarySection = (internshipKind: InternshipKind) => ({
     label: "Adresse du candidat",
     id: beneficiarySectionIds.address,
     placeholder: "Ex : 10 Rue de la Paix, 75001 Paris",
+    required: true,
   },
   "signatories.beneficiary.schoolName": {
     label: "Nom de l'établissement scolaire du candidat",

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -12,6 +12,7 @@ import { useDispatch } from "react-redux";
 import {
   ConventionId,
   ConventionReadDto,
+  addressDtoToString,
   domElementIds,
   isConventionRenewed,
   isStringDate,
@@ -230,7 +231,11 @@ export const ConventionDocumentPage = ({
                 <li>email&nbsp;: {beneficiary.email}</li>
                 {convention.internshipKind === "mini-stage-cci" && (
                   <li>
-                    adresse&nbsp;: {convention.signatories.beneficiary.address}
+                    adresse&nbsp;:{" "}
+                    {convention.signatories.beneficiary.address &&
+                      addressDtoToString(
+                        convention.signatories.beneficiary.address,
+                      )}
                   </li>
                 )}
               </ul>

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -226,8 +226,13 @@ export const ConventionDocumentPage = ({
               en qualité de <strong>bénéficiaire</strong> {""}
               {beneficiary.isRqth && "reconnu en situation de handicap"}
               <ul>
-                <li>tel: {beneficiary.phone}</li>
-                <li>email: {beneficiary.email}</li>
+                <li>tel.&nbsp;: {beneficiary.phone}</li>
+                <li>email&nbsp;: {beneficiary.email}</li>
+                {convention.internshipKind === "mini-stage-cci" && (
+                  <li>
+                    adresse&nbsp;: {convention.signatories.beneficiary.address}
+                  </li>
+                )}
               </ul>
             </li>
             {beneficiaryRepresentative && (
@@ -239,8 +244,8 @@ export const ConventionDocumentPage = ({
                 en qualité de{" "}
                 <strong>représentant(e) légal(e) du bénéficiaire</strong>
                 <ul>
-                  <li>tel: {beneficiaryRepresentative.phone}</li>
-                  <li>email: {beneficiaryRepresentative.email}</li>
+                  <li>tel.&nbsp;: {beneficiaryRepresentative.phone}</li>
+                  <li>email&nbsp;: {beneficiaryRepresentative.email}</li>
                 </ul>
               </li>
             )}
@@ -254,9 +259,11 @@ export const ConventionDocumentPage = ({
                 {beneficiaryCurrentEmployer.businessName}{" "}
                 <strong>employant actuellement le bénéficiaire</strong>
                 <ul>
-                  <li>tel: {beneficiaryCurrentEmployer.phone}</li>
-                  <li>email: {beneficiaryCurrentEmployer.email}</li>
-                  <li>adresse: {beneficiaryCurrentEmployer.businessAddress}</li>
+                  <li>tel.&nbsp;: {beneficiaryCurrentEmployer.phone}</li>
+                  <li>email&nbsp;: {beneficiaryCurrentEmployer.email}</li>
+                  <li>
+                    adresse&nbsp;: {beneficiaryCurrentEmployer.businessAddress}
+                  </li>
                 </ul>
               </li>
             )}
@@ -269,8 +276,8 @@ export const ConventionDocumentPage = ({
                 en qualité de <strong>représentant de l'entreprise</strong>{" "}
                 {convention.businessName}
                 <ul>
-                  <li>tel: {establishmentRepresentative.phone}</li>
-                  <li>email: {establishmentRepresentative.email}</li>
+                  <li>tel.&nbsp;: {establishmentRepresentative.phone}</li>
+                  <li>email&nbsp;: {establishmentRepresentative.email}</li>
                 </ul>
               </li>
             )}
@@ -482,7 +489,7 @@ export const ConventionDocumentPage = ({
             {isStartingByVowel(convention.establishmentTutor.job)
               ? `d'${convention.establishmentTutor.job}`
               : `de ${convention.establishmentTutor.job}`}{" "}
-            (tel: {convention.establishmentTutor.phone}
+            (tel.&nbsp;: {convention.establishmentTutor.phone}
             {convention.establishmentTutor.email !==
               establishmentRepresentative.email &&
               `, mail: ${convention.establishmentTutor.email}`}

--- a/front/src/app/routes/routeParams/convention.ts
+++ b/front/src/app/routes/routeParams/convention.ts
@@ -10,6 +10,8 @@ import {
   LevelOfEducation,
   PeConnectIdentity,
   ScheduleDto,
+  addressDtoToString,
+  addressStringToDto,
   appellationCodeSchema,
   errors,
   isBeneficiaryStudent,
@@ -163,6 +165,7 @@ const conventionToConventionInUrl = (
         led: beneficiary.levelOfEducation,
         schoolName: beneficiary.schoolName,
         schoolPostcode: beneficiary.schoolPostcode,
+        address: beneficiary.address && addressDtoToString(beneficiary.address),
       }
     : undefined;
 
@@ -273,6 +276,7 @@ export const conventionValuesFromUrl = {
   phone: param.query.optional.string,
   financiaryHelp: param.query.optional.string,
   led: param.query.optional.string,
+  address: param.query.optional.string,
   schoolName: param.query.optional.string,
   schoolPostcode: param.query.optional.string,
   emergencyContact: param.query.optional.string,
@@ -422,6 +426,7 @@ const conventionPresentationFromParams = (
       emergencyContact: params.emergencyContact ?? "",
       emergencyContactPhone: params.emergencyContactPhone ?? "",
       emergencyContactEmail: params.emergencyContactEmail ?? "",
+      address: params.address ? addressStringToDto(params.address) : undefined,
       levelOfEducation: (params.led as LevelOfEducation) ?? "",
       schoolName: params.schoolName ?? "",
       schoolPostcode: params.schoolPostcode ?? "",

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -571,7 +571,12 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
               levelOfEducation: "3ème",
               schoolName: "École du quartier ouest",
               schoolPostcode: "87000",
-              address: "1 rue de la paix, 75001 Paris",
+              address: {
+                city: "Paris",
+                departmentCode: "75",
+                postcode: "75001",
+                streetNumberAndAddress: "1 rue de la paix",
+              },
             },
           },
         });

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -571,6 +571,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
               levelOfEducation: "3ème",
               schoolName: "École du quartier ouest",
               schoolPostcode: "87000",
+              address: "1 rue de la paix, 75001 Paris",
             },
           },
         });

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -1,6 +1,6 @@
 import { keys } from "ramda";
 import { WithAcquisition } from "../acquisition.dto";
-import { Postcode } from "../address/address.dto";
+import { AddressDto, Postcode } from "../address/address.dto";
 import { AgencyId, AgencyKind } from "../agency/agency.dto";
 import { Email } from "../email/email.dto";
 import { PeConnectIdentity } from "../federatedIdentities/federatedIdentity.dto";
@@ -224,7 +224,7 @@ type StudentProperties = {
   levelOfEducation: LevelOfEducation;
   schoolName: string;
   schoolPostcode: Postcode;
-  address?: string;
+  address?: AddressDto;
 };
 
 export type Beneficiary<T extends InternshipKind> =

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -224,6 +224,7 @@ type StudentProperties = {
   levelOfEducation: LevelOfEducation;
   schoolName: string;
   schoolPostcode: Postcode;
+  address?: string;
 };
 
 export type Beneficiary<T extends InternshipKind> =

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -145,6 +145,7 @@ const studentBeneficiarySchema: z.Schema<Beneficiary<"mini-stage-cci">> =
       ),
       schoolName: zStringMinLength1,
       schoolPostcode: zStringMinLength1,
+      address: zStringMinLength1.optional(),
     }),
   );
 

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -95,6 +95,7 @@ import {
   isTutorEmailDifferentThanBeneficiaryRelatedEmails,
   minorBeneficiaryHasRepresentative,
   mustBeSignedByEveryone,
+  shouldValidateBeneficiaryAddressAndParse,
   startDateIsBeforeEndDate,
   underMaxCalendarDuration,
 } from "./conventionRefinements";
@@ -145,7 +146,14 @@ const studentBeneficiarySchema: z.Schema<Beneficiary<"mini-stage-cci">> =
       ),
       schoolName: zStringMinLength1,
       schoolPostcode: zStringMinLength1,
-      address: zStringMinLength1.optional(),
+      address: z
+        .object({
+          streetNumberAndAddress: zStringCanBeEmpty,
+          postcode: zStringMinLength1,
+          departmentCode: zStringMinLength1,
+          city: zStringMinLength1,
+        })
+        .optional(),
     }),
   );
 
@@ -355,6 +363,10 @@ export const conventionSchema: z.Schema<ConventionDto> = conventionCommonSchema
   .refine(mustBeSignedByEveryone, {
     message: localization.mustBeSignedByEveryone,
     path: [getConventionFieldName("status")],
+  })
+  .refine(shouldValidateBeneficiaryAddressAndParse, {
+    message: localization.invalidBeneficiaryAddress,
+    path: [getConventionFieldName("signatories.beneficiary.address")],
   });
 
 export const conventionReadSchema: z.Schema<ConventionReadDto> =

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -95,9 +95,9 @@ import {
   isTutorEmailDifferentThanBeneficiaryRelatedEmails,
   minorBeneficiaryHasRepresentative,
   mustBeSignedByEveryone,
-  shouldValidateBeneficiaryAddressAndParse,
   startDateIsBeforeEndDate,
   underMaxCalendarDuration,
+  validateBeneficiaryAddressAndParse,
 } from "./conventionRefinements";
 
 const zTrimmedStringMax255 = zTrimmedStringWithMax(255);
@@ -364,7 +364,7 @@ export const conventionSchema: z.Schema<ConventionDto> = conventionCommonSchema
     message: localization.mustBeSignedByEveryone,
     path: [getConventionFieldName("status")],
   })
-  .refine(shouldValidateBeneficiaryAddressAndParse, {
+  .refine(validateBeneficiaryAddressAndParse, {
     message: localization.invalidBeneficiaryAddress,
     path: [getConventionFieldName("signatories.beneficiary.address")],
   });

--- a/shared/src/convention/conventionRefinements.ts
+++ b/shared/src/convention/conventionRefinements.ts
@@ -80,7 +80,7 @@ export const minorBeneficiaryHasRepresentative = ({
 export const shouldValidateBeneficiaryAddressAndParse = (
   convention: ConventionDto,
 ) => {
-  const ruleAppliesFrom = new Date("2024-09-28");
+  const ruleAppliesFrom = new Date("2024-09-30");
   const conventionWasSubmittedBeforeRuleApplies =
     new Date(convention.dateSubmission).getTime() < ruleAppliesFrom.getTime();
   if (

--- a/shared/src/convention/conventionRefinements.ts
+++ b/shared/src/convention/conventionRefinements.ts
@@ -77,10 +77,10 @@ export const minorBeneficiaryHasRepresentative = ({
   );
 };
 
-export const shouldValidateBeneficiaryAddressAndParse = (
+export const validateBeneficiaryAddressAndParse = (
   convention: ConventionDto,
 ) => {
-  const ruleAppliesFrom = new Date("2024-09-30");
+  const ruleAppliesFrom = new Date("2024-10-01");
   const conventionWasSubmittedBeforeRuleApplies =
     new Date(convention.dateSubmission).getTime() < ruleAppliesFrom.getTime();
   if (

--- a/shared/src/convention/conventionRefinements.ts
+++ b/shared/src/convention/conventionRefinements.ts
@@ -1,5 +1,6 @@
 import { differenceInYears } from "date-fns";
 import differenceInDays from "date-fns/differenceInDays";
+import { addressSchema } from "../address/address.schema";
 import { DateString } from "../utils/date";
 import { allSignatoriesSigned, getConventionFieldName } from "./convention";
 import {
@@ -74,6 +75,22 @@ export const minorBeneficiaryHasRepresentative = ({
     beneficiaryAgeAtConventionStart >= 18 ||
     !!signatories.beneficiaryRepresentative
   );
+};
+
+export const shouldValidateBeneficiaryAddressAndParse = (
+  convention: ConventionDto,
+) => {
+  const ruleAppliesFrom = new Date("2024-09-28");
+  const conventionWasSubmittedBeforeRuleApplies =
+    new Date(convention.dateSubmission).getTime() < ruleAppliesFrom.getTime();
+  if (
+    convention.internshipKind === "immersion" ||
+    conventionWasSubmittedBeforeRuleApplies
+  )
+    return true;
+
+  return addressSchema.safeParse(convention.signatories.beneficiary.address)
+    .success;
 };
 
 const statusesAllowedWithoutSign: ConventionStatus[] = [

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -257,6 +257,7 @@ export const domElementIds = {
       emergencyContactEmail:
         "im-convention-form__signatories-beneficiary-emergencyContactEmail",
       isRqth: "im-convention-form__signatories-beneficiary-isRqth",
+      address: "im-convention-form__signatories-beneficiary-address",
     },
     establishmentTutorSection: {
       firstName: "im-convention-form__establishmentTutor-firstName",

--- a/shared/src/zodUtils.ts
+++ b/shared/src/zodUtils.ts
@@ -38,6 +38,8 @@ export const localization = {
   expectedBoolean: "La sélection d'une valeur (oui/non) est obligatoire",
   expectText: "Une chaine de caractères est attendue",
   expectRadioButtonSelected: "Veuillez sélectionner une option.",
+  invalidBeneficiaryAddress:
+    "L'adresse complète du candidat doit être renseignée.",
   invalidDate: "Le format de la date saisie est invalide",
   invalidDateEnd: "Le format de la date de fin est invalide",
   invalidDateStart: "Le format de la date de début est invalide",


### PR DESCRIPTION
Ce champ sera obligatoire à partir de la MEP de cette fonctionnalité (voir la date renseignée dans shouldValidateBeneficiaryAddressAndParse dans conventionRefinements.ts).

Après l'envoi de la convention par le bénéficiaire, l'adresse du candidat est visible dans :
- la page de validation du conseiller : 
![image](https://github.com/user-attachments/assets/eca6d259-28e7-4b1c-88e4-7437f3d2539a)

- le récapitulatif avant signature : 
![image](https://github.com/user-attachments/assets/c22bbd8d-1d29-4ff9-963c-30833a446dc0)

- la convention au format pdf : 
![image](https://github.com/user-attachments/assets/8f14fe6b-c135-4403-831c-9f8cc13e8a9b)
