### PR TITLE
#2184 - Afficher les retours de synchronisation de convention dans une modale

### DIFF
--- a/front/src/core-logic/domain/convention/convention.epics.ts
+++ b/front/src/core-logic/domain/convention/convention.epics.ts
@@ -191,12 +191,15 @@ const broadcastConventionAgainEpic: ConventionEpic = (
               feedbackTopic: payload.feedbackTopic,
             }),
           ),
-          catchEpicError((error: Error) =>
-            conventionSlice.actions.broadcastConventionToPartnerFailed({
-              errorMessage: error.message,
+          catchEpicError((error: Error) => {
+            const isJsonError = error.message.at(0) === "{";
+            return conventionSlice.actions.broadcastConventionToPartnerFailed({
+              errorMessage: isJsonError
+                ? JSON.parse(error.message).message
+                : error.message,
               feedbackTopic: payload.feedbackTopic,
-            }),
-          ),
+            });
+          }),
         ),
     ),
   );

--- a/front/src/core-logic/domain/convention/convention.selectors.ts
+++ b/front/src/core-logic/domain/convention/convention.selectors.ts
@@ -24,6 +24,11 @@ const fetchError = createSelector(
 
 const isLoading = createSelector(conventionState, ({ isLoading }) => isLoading);
 
+const isBroadcasting = createSelector(
+  conventionState,
+  ({ isBroadcasting }) => isBroadcasting,
+);
+
 const similarConventionIds = createSelector(
   conventionState,
   ({ similarConventionIds }) => similarConventionIds,
@@ -94,6 +99,7 @@ export const conventionSelectors = {
   showSummary,
   agencyDepartment,
   similarConventionIds,
+  isBroadcasting,
 };
 
 export const signatoryDataFromConvention = (

--- a/front/src/core-logic/domain/convention/convention.slice.ts
+++ b/front/src/core-logic/domain/convention/convention.slice.ts
@@ -63,6 +63,7 @@ export interface ConventionState {
   feedback: ConventionSubmitFeedback;
   currentSignatoryRole: SignatoryRole | null;
   similarConventionIds: ConventionId[];
+  isBroadcasting: boolean;
 }
 
 export const initialConventionState: ConventionState = {
@@ -83,6 +84,7 @@ export const initialConventionState: ConventionState = {
   feedback: { kind: "idle" },
   currentSignatoryRole: null,
   similarConventionIds: [],
+  isBroadcasting: false,
 };
 
 export type FetchConventionRequestedPayload = {
@@ -296,19 +298,19 @@ export const conventionSlice = createSlice({
       state,
       _action: PayloadActionWithFeedbackTopic<WithConventionId>,
     ) => {
-      state.isLoading = true;
+      state.isBroadcasting = true;
     },
     broadcastConventionToPartnerSucceeded: (
       state,
       _action: PayloadActionWithFeedbackTopic,
     ) => {
-      state.isLoading = false;
+      state.isBroadcasting = false;
     },
     broadcastConventionToPartnerFailed: (
       state,
       _action: PayloadActionWithFeedbackTopic<{ errorMessage: string }>,
     ) => {
-      state.isLoading = false;
+      state.isBroadcasting = false;
     },
   },
 });

--- a/front/src/core-logic/domain/convention/convention.test.ts
+++ b/front/src/core-logic/domain/convention/convention.test.ts
@@ -100,6 +100,7 @@ describe("Convention slice", () => {
           feedback: { kind: "idle" },
           currentSignatoryRole: null,
           similarConventionIds: [],
+          isBroadcasting: false,
         },
       }));
       const convention = new ConventionDtoBuilder().build();
@@ -329,6 +330,7 @@ describe("Convention slice", () => {
           jwt: null,
           currentSignatoryRole: null,
           similarConventionIds: [],
+          isBroadcasting: false,
         },
       }));
       store.dispatch(
@@ -694,6 +696,7 @@ describe("Convention slice", () => {
           conventionStatusDashboardUrl: null,
           currentSignatoryRole: null,
           similarConventionIds: [],
+          isBroadcasting: false,
         },
       }));
       const signatoryData = conventionSelectors.signatoryData(store.getState());
@@ -742,6 +745,7 @@ describe("Convention slice", () => {
           conventionStatusDashboardUrl: null,
           currentSignatoryRole: "beneficiary",
           similarConventionIds: [],
+          isBroadcasting: false,
         },
       }));
 
@@ -891,7 +895,7 @@ describe("Convention slice", () => {
         }),
       );
       expectConventionState({
-        isLoading: true,
+        isBroadcasting: true,
       });
 
       dependencies.conventionGateway.broadcastConventionAgainResult$.next(
@@ -899,7 +903,7 @@ describe("Convention slice", () => {
       );
 
       expectConventionState({
-        isLoading: false,
+        isBroadcasting: false,
       });
       expectToEqual(feedbacksSelectors.feedbacks(store.getState()), {
         "broadcast-convention-again": {
@@ -921,7 +925,7 @@ describe("Convention slice", () => {
         }),
       );
       expectConventionState({
-        isLoading: true,
+        isBroadcasting: true,
       });
 
       dependencies.conventionGateway.broadcastConventionAgainResult$.error(
@@ -929,7 +933,7 @@ describe("Convention slice", () => {
       );
 
       expectConventionState({
-        isLoading: false,
+        isBroadcasting: false,
       });
       expectToEqual(feedbacksSelectors.feedbacks(store.getState()), {
         "broadcast-convention-again": {
@@ -1000,6 +1004,7 @@ describe("Convention slice", () => {
         fetchError: null,
         currentSignatoryRole: null,
         similarConventionIds: [],
+        isBroadcasting: false,
       },
     }));
     store.dispatch(conventionSlice.actions.clearFeedbackTriggered());
@@ -1026,6 +1031,7 @@ describe("Convention slice", () => {
         fetchError: null,
         currentSignatoryRole: null,
         similarConventionIds: [],
+        isBroadcasting: false,
       },
     }));
     expectConventionState({
@@ -1057,6 +1063,7 @@ describe("Convention slice", () => {
         fetchError: null,
         currentSignatoryRole: null,
         similarConventionIds: [],
+        isBroadcasting: false,
       },
     }));
     expectConventionState({
@@ -1092,6 +1099,7 @@ describe("Convention slice", () => {
         fetchError: null,
         currentSignatoryRole: null,
         similarConventionIds: [],
+        isBroadcasting: false,
       },
     }));
     expectConventionState({
@@ -1168,6 +1176,7 @@ describe("Convention slice", () => {
         fetchError: null,
         currentSignatoryRole: null,
         similarConventionIds: [],
+        isBroadcasting: false,
       },
     }));
     expectConventionState({ convention });


### PR DESCRIPTION
## Description

Eviter les messages d'alertes dans la barre d'action.

Avant:
![Screenshot 2024-10-02 at 12 52 42](https://github.com/user-attachments/assets/b96936b3-799e-4a37-a66f-bf49f5d9c08a)

Avec cette PR:

![Screenshot 2024-10-04 at 12 39 22](https://github.com/user-attachments/assets/1c9f61a2-7dc4-40b7-875c-c2cc62738c29)
