### PR TITLE
#2176 - Modification de l'affichage de la visibilité de l'entreprise

### DIFF
--- a/front/src/app/components/forms/establishment/EstablishmentForm.tsx
+++ b/front/src/app/components/forms/establishment/EstablishmentForm.tsx
@@ -412,11 +412,9 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                   currentStep={currentStep}
                   setAvailableForImmersion={setAvailableForImmersion}
                   availableForImmersion={availableForImmersion}
-                  shouldUpdateAvailability={
-                    Boolean(
-                      initialUrlParams.current.shouldUpdateAvailability,
-                    ) ?? undefined
-                  }
+                  shouldUpdateAvailability={Boolean(
+                    initialUrlParams.current.shouldUpdateAvailability,
+                  )}
                 />
                 <h2>{steps[2].title}</h2>
                 <SearchableBySection

--- a/front/src/app/components/forms/establishment/EstablishmentForm.tsx
+++ b/front/src/app/components/forms/establishment/EstablishmentForm.tsx
@@ -412,6 +412,11 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                   currentStep={currentStep}
                   setAvailableForImmersion={setAvailableForImmersion}
                   availableForImmersion={availableForImmersion}
+                  shouldUpdateAvailability={
+                    Boolean(
+                      initialUrlParams.current.shouldUpdateAvailability,
+                    ) ?? undefined
+                  }
                 />
                 <h2>{steps[2].title}</h2>
                 <SearchableBySection
@@ -455,6 +460,7 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
                       currentStep={currentStep}
                       availableForImmersion={availableForImmersion}
                       setAvailableForImmersion={setAvailableForImmersion}
+                      shouldUpdateAvailability={undefined}
                     />
                   ))
                   .with(2, () => (

--- a/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
+++ b/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
@@ -73,6 +73,7 @@ export const AvailabilitySection = ({
   return (
     <section className={fr.cx("fr-mb-4w")}>
       <RadioButtons
+        id={domElementIds.establishment[mode].availabilityButton}
         legend="Êtes-vous disponible actuellement pour recevoir des personnes en immersion ?"
         name="availableForImmersion"
         options={richBooleanSelectOptions.map((option) => ({

--- a/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
+++ b/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
@@ -28,13 +28,15 @@ export const AvailabilitySection = ({
   onStepChange,
   currentStep,
   setAvailableForImmersion,
-  availableForImmersion,
+  availableForImmersion: availableForImmersionClicked,
+  shouldUpdateAvailability,
 }: {
   mode: Mode;
   onStepChange: OnStepChange;
   currentStep: Step;
   setAvailableForImmersion: (value: boolean) => void;
   availableForImmersion: boolean | undefined;
+  shouldUpdateAvailability: boolean | undefined;
 }) => {
   const { register, setValue, getValues, formState, clearErrors } =
     useFormContext<FormEstablishmentDto>();
@@ -44,7 +46,7 @@ export const AvailabilitySection = ({
   const getFieldError = makeFieldError(formState);
 
   const shouldShowErrorOnAvailableForImmersion =
-    availableForImmersion === undefined &&
+    availableForImmersionClicked === undefined &&
     (getFieldError("maxContactsPerMonth") ||
       getFieldError("nextAvailabilityDate"));
 
@@ -55,6 +57,18 @@ export const AvailabilitySection = ({
     toDateString(new Date(currentNextAvailabilityDate));
 
   const isStepMode = currentStep !== null;
+
+  const isAvailableForImmersion = () => {
+    if (availableForImmersionClicked !== undefined)
+      return availableForImmersionClicked;
+    if (mode === "create" || shouldUpdateAvailability) return undefined;
+    if (currentNextAvailabilityDate === undefined) return true;
+    if (currentNextAvailabilityDate < new Date().toISOString())
+      return undefined;
+    return false;
+  };
+
+  const availableForImmersion = isAvailableForImmersion();
 
   return (
     <section className={fr.cx("fr-mb-4w")}>
@@ -128,7 +142,7 @@ export const AvailabilitySection = ({
             {...getFieldError("maxContactsPerMonth")}
           />
         )}
-      {mode === "admin" && availableForImmersion === undefined && (
+      {mode === "admin" && availableForImmersion === true && (
         <div>
           <Alert
             severity="info"

--- a/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
+++ b/front/src/app/components/forms/establishment/sections/AvailabilitySection.tsx
@@ -28,7 +28,7 @@ export const AvailabilitySection = ({
   onStepChange,
   currentStep,
   setAvailableForImmersion,
-  availableForImmersion: availableForImmersionClicked,
+  availableForImmersion: availableForImmersionInProps,
   shouldUpdateAvailability,
 }: {
   mode: Mode;
@@ -46,7 +46,7 @@ export const AvailabilitySection = ({
   const getFieldError = makeFieldError(formState);
 
   const shouldShowErrorOnAvailableForImmersion =
-    availableForImmersionClicked === undefined &&
+    availableForImmersionInProps === undefined &&
     (getFieldError("maxContactsPerMonth") ||
       getFieldError("nextAvailabilityDate"));
 
@@ -59,8 +59,8 @@ export const AvailabilitySection = ({
   const isStepMode = currentStep !== null;
 
   const isAvailableForImmersion = () => {
-    if (availableForImmersionClicked !== undefined)
-      return availableForImmersionClicked;
+    if (availableForImmersionInProps !== undefined)
+      return availableForImmersionInProps;
     if (mode === "create" || shouldUpdateAvailability) return undefined;
     if (currentNextAvailabilityDate === undefined) return true;
     if (currentNextAvailabilityDate < new Date().toISOString())
@@ -142,7 +142,7 @@ export const AvailabilitySection = ({
             {...getFieldError("maxContactsPerMonth")}
           />
         )}
-      {mode === "admin" && availableForImmersion === true && (
+      {mode === "admin" && (
         <div>
           <Alert
             severity="info"

--- a/front/src/app/pages/establishment-dashboard/ManageEstablishmentTab.tsx
+++ b/front/src/app/pages/establishment-dashboard/ManageEstablishmentTab.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { WithEstablismentsSiretAndName } from "shared";
 import { EstablishmentForm } from "src/app/components/forms/establishment/EstablishmentForm";
 import { routes } from "src/app/routes/routes";
+import { getUrlParameters } from "src/app/utils/url.utils";
 import { Route } from "type-route";
 type ManageEstablishmentTabProps = {
   establishments: WithEstablismentsSiretAndName[];
@@ -13,11 +14,13 @@ export const ManageEstablishmentsTab = ({
   establishments,
   route,
 }: ManageEstablishmentTabProps) => {
+  const initialUrlParams = getUrlParameters(window.location);
   if (establishments.length === 1) {
     routes
       .establishmentDashboard({
         tab: "fiche-entreprise",
         siret: establishments[0].siret,
+        shouldUpdateAvailability: initialUrlParams.shouldUpdateAvailability,
       })
       .push();
   }

--- a/front/src/app/routes/routes.ts
+++ b/front/src/app/routes/routes.ts
@@ -166,6 +166,7 @@ export const { RouteProvider, useRoute, routes } = createRouter({
         .default("conventions"),
       siret: param.query.optional.string,
       discussionId: param.query.optional.string,
+      shouldUpdateAvailability: param.query.optional.string,
     },
     ({ tab }) => `/${frontRoutes.establishmentDashboard}/${tab}`,
   ),

--- a/playwright/tests/establishment/establishmentWorkflow.spec.ts
+++ b/playwright/tests/establishment/establishmentWorkflow.spec.ts
@@ -51,9 +51,12 @@ test.describe("Establishment creation and modification workflow", () => {
     isEngagedEnterprise: true,
   } satisfies Partial<FormEstablishmentDto>;
   test("creates a new establishment", async ({ page }) => {
-    firstStepsEstablishmentFormCreation(page, providedSiret);
+    await fillEstablishmentFormFirstStep(page, providedSiret);
 
-    await page.locator(".fr-radio-rich").getByText("Oui").click();
+    await page
+      .locator(`#${domElementIds.establishment.create.availabilityButton}`)
+      .getByText("Oui")
+      .click();
 
     await goToNextStep(page, 1, "create");
     await page
@@ -180,7 +183,10 @@ test.describe("Establishment creation and modification workflow", () => {
       await expectLocatorToBeVisibleAndEnabled(startFormButtonLocator);
 
       await startFormButtonLocator.click();
-      await page.locator(".fr-radio-rich").getByText("Non").click();
+      await page
+        .locator(`#${domElementIds.establishment.edit.availabilityButton}`)
+        .getByText("Non")
+        .click();
       await page
         .locator(
           `#${domElementIds.establishment.edit.nextAvailabilityDateInput}`,
@@ -459,7 +465,10 @@ test.describe("Establishment creation and modification workflow", () => {
       await page.click(
         `#${domElementIds.admin.manageEstablishment.searchButton}`,
       );
-      await page.locator(".fr-radio-rich").getByText("Oui").click();
+      await page
+        .locator(`#${domElementIds.establishment.admin.availabilityButton}`)
+        .getByText("Oui")
+        .click();
       await page.click(
         `#${domElementIds.establishment.admin.submitFormButton}`,
       );
@@ -497,16 +506,15 @@ test.describe("Establishment creation and modification workflow", () => {
       await page
         .locator(`#${domElementIds.admin.manageEstablishment.searchButton}`)
         .click();
-      await checkAvailibilityButtons(page);
+      await checkAvailibilityButtons(page, "admin");
     });
 
-    test("at immersion offer creation", async ({ page }) => {
+    test("in establishment form", async ({ page }) => {
       const siretForAvailabilityCheck = "88462068300018";
-      await firstStepsEstablishmentFormCreation(
-        page,
-        siretForAvailabilityCheck,
+      await fillEstablishmentFormFirstStep(page, siretForAvailabilityCheck);
+      const initialRadioButton = page.locator(
+        `#${domElementIds.establishment.create.availabilityButton}`,
       );
-      const initialRadioButton = page.locator(".fr-radio-rich");
       await expect(initialRadioButton.getByText("Oui")).not.toBeChecked();
       await expect(initialRadioButton.getByText("Non")).not.toBeChecked();
     });
@@ -518,7 +526,7 @@ test.describe("Establishment creation and modification workflow", () => {
         .locator(`#${domElementIds.header.navLinks.establishment.dashboard}`)
         .click();
       await page.locator(".fr-tabs").getByText("Fiche établissement").click();
-      await checkAvailibilityButtons(page);
+      await checkAvailibilityButtons(page, "edit");
     });
   });
 
@@ -548,10 +556,7 @@ test.describe("Establishment creation and modification workflow", () => {
   });
 });
 
-const firstStepsEstablishmentFormCreation = async (
-  page: Page,
-  siret: string,
-) => {
+const fillEstablishmentFormFirstStep = async (page: Page, siret: string) => {
   await page.goto("/");
   await page.click(`#${domElementIds.home.heroHeader.establishment}`);
   await page.click(
@@ -561,19 +566,19 @@ const firstStepsEstablishmentFormCreation = async (
     `#${domElementIds.homeEstablishments.siretModal.siretFetcherInput}`,
     siret,
   );
-  const addEstablishmentButton = await page.locator(
+  const addEstablishmentButton = page.locator(
     `#${domElementIds.establishment.create.startFormButton}`,
   );
   await expectLocatorToBeVisibleAndEnabled(addEstablishmentButton);
   await addEstablishmentButton.click();
 };
 
-const checkAvailibilityButtons = async (page: Page) => {
-  const availibilityRadioButton = page.locator(".fr-radio-rich");
+const checkAvailibilityButtons = async (page: Page, mode: "edit" | "admin") => {
+  const availibilityRadioButton = page.locator(
+    `#${domElementIds.establishment[mode].availabilityButton}`,
+  );
   await expect(availibilityRadioButton.getByText("Oui")).toBeChecked();
-  await expect(
-    availibilityRadioButton.getByText("Non").first(),
-  ).not.toBeChecked();
+  await expect(availibilityRadioButton.getByText("Non")).not.toBeChecked();
 };
 
 const goToNextStep = async (

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -381,6 +381,7 @@ export const domElementIds = {
         "im-form-create-establishment__edit-establishment-button",
       startFormButton: "im-form-create-establishment__start-button",
       submitFormButton: "im-form-create-establishment__submit-button",
+      availabilityButton: "im-form-create-establishment__availability-button",
       nextAvailabilityDateInput:
         "im-form-create-establishment__next-availability-date",
       previousButtonFromStepAndMode: ({ currentStep }) =>
@@ -425,6 +426,7 @@ export const domElementIds = {
         "im-form-edit-establishment__edit-establishment-button",
       startFormButton: "im-form-edit-establishment__start-button",
       submitFormButton: "im-form-edit-establishment__submit-button",
+      availabilityButton: "im-form-edit-establishment__availability-button",
       nextAvailabilityDateInput:
         "im-form-edit-establishment__next-availability-date",
       previousButtonFromStepAndMode: ({ currentStep }) =>
@@ -482,6 +484,8 @@ export const domElementIds = {
         "im-form-manage-establishment-admin__add-address-button",
       errorSiretAlreadyExistButton:
         "im-form-manage-establishment-admin__edit-establishment-button",
+      availabilityButton:
+        "im-form-manage-establishment-admin__availability-button",
       nextAvailabilityDateInput:
         "im-form-manage-establishment-admin__next-availability-date",
       maxContactsPerMonthValue:

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1414,7 +1414,7 @@ Pour toute question concernant ce rejet, il est possible de nous contacter : con
         buttons: [
           {
             label: "Mettre à jour ma fiche établissement",
-            url: `${editFrontUrl}&mtm_campaign=transactionnel-etablissement-suggestion-mise-a-jour`,
+            url: `${editFrontUrl}&shouldUpdateAvailability=true&mtm_campaign=transactionnel-etablissement-suggestion-mise-a-jour`,
           },
         ],
         highlight: {


### PR DESCRIPTION
La visibilité de l'entreprise est affichée différemment selon les cas suivants : 
- création d'offre d'immersion ou fiche établissement via lien dans le mail de suggestion de maj bi-annuel ou date d'indisponibilité dépassée : 
![image](https://github.com/user-attachments/assets/5228b072-a291-4184-9d8e-62dabcc12fd0)

- fiche établissement (entreprise visible) : 
![image](https://github.com/user-attachments/assets/3dd10693-2fcd-4d5f-90ee-cf20217f4e78)

- page admin (entreprise visible): 
![image](https://github.com/user-attachments/assets/bcfd626c-44e9-4833-a8d7-5694074a907b)

Les cas dans lesquels l'entreprise n'est pas visible ont été testés en local.