### PR TITLE
#2269 - La liste des utilisateurs des agences accompagnantes est mise à jour en fonction de l'agence prescriptrice

### DIFF
--- a/back/src/adapters/primary/routers/admin/createAdminRouter.ts
+++ b/back/src/adapters/primary/routers/admin/createAdminRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import {
   GetDashboardParams,
-  RemoveAgencyUserParams,
+  WithAgencyIdAndUserId,
   adminRoutes,
   agencyRoutes,
   errors,
@@ -107,7 +107,7 @@ export const createAdminRouter = (deps: AppDependencies): Router => {
       sendHttpResponse(req, res, async () => {
         const currentUser = req.payloads?.currentUser;
         if (!currentUser) throw errors.user.unauthorized();
-        const userWithAgency: RemoveAgencyUserParams = {
+        const userWithAgency: WithAgencyIdAndUserId = {
           agencyId: req.params.agencyId,
           userId: req.params.userId,
         };

--- a/back/src/domains/agency/use-cases/UpdateAgency.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgency.ts
@@ -44,7 +44,7 @@ export class UpdateAgency extends TransactionalUseCase<
       this.#createNewEvent({
         topic: "AgencyUpdated",
         payload: {
-          agency,
+          agencyId: agency.id,
           triggeredBy: {
             kind: "inclusion-connected",
             userId: currentUser.id,

--- a/back/src/domains/agency/use-cases/UpdateAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgency.unit.test.ts
@@ -131,7 +131,7 @@ describe("Update agency", () => {
     expectObjectsToMatch(outboxRepository.events[0], {
       topic: "AgencyUpdated",
       payload: {
-        agency: updatedAgency,
+        agencyId: updatedAgency.id,
         triggeredBy: {
           kind: "inclusion-connected",
           userId: backofficeAdmin.id,

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
@@ -1,6 +1,8 @@
 import {
   AgencyDtoBuilder,
   InclusionConnectedUserBuilder,
+  errors,
+  expectPromiseToFailWithError,
   expectToEqual,
 } from "shared";
 import {
@@ -55,6 +57,16 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
         new InMemoryUowPerformer(uow),
         createNewEvent,
       );
+  });
+
+  it("throw error when agency not found", () => {
+    expectPromiseToFailWithError(
+      updateAgencyReferringToUpdatedAgency.execute(
+        { agencyId: updatedAgency.id },
+        icUser,
+      ),
+      errors.agency.notFound({ agencyId: updatedAgency.id }),
+    );
   });
 
   describe("right paths", () => {

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
@@ -67,7 +67,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
       ]);
 
       await updateAgencyReferringToUpdatedAgency.execute(
-        { agency: updatedAgency },
+        { agencyId: updatedAgency.id },
         icUser,
       );
 
@@ -88,10 +88,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
           ...createNewEvent({
             topic: "AgencyUpdated",
             payload: {
-              agency: {
-                ...agencyRefersToUpdatedAgency1,
-                validatorEmails: updatedAgency.validatorEmails,
-              },
+              agencyId: agencyRefersToUpdatedAgency1.id,
               triggeredBy: {
                 kind: "crawler",
               },
@@ -103,10 +100,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
           ...createNewEvent({
             topic: "AgencyUpdated",
             payload: {
-              agency: {
-                ...agencyRefersToUpdatedAgency2,
-                validatorEmails: updatedAgency.validatorEmails,
-              },
+              agencyId: agencyRefersToUpdatedAgency2.id,
               triggeredBy: {
                 kind: "crawler",
               },
@@ -124,7 +118,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
       ]);
 
       await updateAgencyReferringToUpdatedAgency.execute({
-        agency: updatedAgency,
+        agencyId: updatedAgency.id,
       });
 
       expectToEqual(uow.agencyRepository.agencies, [

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
@@ -1,14 +1,84 @@
 import {
   AgencyDto,
+  AgencyId,
+  AgencyRight,
   InclusionConnectedUser,
   WithAgencyId,
   errors,
   withAgencyIdSchema,
 } from "shared";
 import { TransactionalUseCase } from "../../core/UseCase";
+import { oAuthProviderByFeatureFlags } from "../../core/authentication/inclusion-connect/port/OAuthGateway";
 import { CreateNewEvent } from "../../core/events/ports/EventBus";
 import { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
 import { UnitOfWorkPerformer } from "../../core/unit-of-work/ports/UnitOfWorkPerformer";
+
+const addValidatorsNotReceivingNotifications = async (
+  uow: UnitOfWork,
+  agencyId: AgencyId,
+  agenciesWithRefersTo: AgencyDto[],
+) => {
+  const provider = oAuthProviderByFeatureFlags(
+    await uow.featureFlagRepository.getAll(),
+  );
+
+  const validatorsNotNotifiedToCopy =
+    await uow.userRepository.getIcUsersWithFilter(
+      {
+        agencyId: agencyId,
+        agencyRole: "validator",
+        isNotifiedByEmail: false,
+      },
+      provider,
+    );
+
+  const updatedUsers: InclusionConnectedUser[] =
+    validatorsNotNotifiedToCopy.map((user) => {
+      const newOrUpdatedAgencyRights: AgencyRight[] = agenciesWithRefersTo.map(
+        (agency) => {
+          const agencyRightToUpdate = user.agencyRights.find(
+            (agencyRight) => agencyRight.agency.id === agency.id,
+          );
+          const updatedAgencyRight: AgencyRight = {
+            agency,
+            isNotifiedByEmail: false,
+            roles:
+              agencyRightToUpdate !== undefined
+                ? [...agencyRightToUpdate.roles, "validator"]
+                : ["validator"],
+          };
+
+          return updatedAgencyRight;
+        },
+      );
+
+      const newOrUpdatedAgencyRightsAgencyIds = newOrUpdatedAgencyRights.map(
+        (agencyRight) => agencyRight.agency.id,
+      );
+
+      return {
+        ...user,
+        agencyRights: [
+          ...user.agencyRights.filter(
+            (agencyRight) =>
+              !newOrUpdatedAgencyRightsAgencyIds.includes(
+                agencyRight.agency.id,
+              ),
+          ),
+          ...newOrUpdatedAgencyRights,
+        ],
+      };
+    });
+
+  await Promise.all(
+    updatedUsers.map((user) =>
+      uow.userRepository.updateAgencyRights({
+        userId: user.id,
+        agencyRights: user.agencyRights,
+      }),
+    ),
+  );
+};
 
 export class UpdateAgencyReferringToUpdatedAgency extends TransactionalUseCase<
   WithAgencyId,
@@ -37,6 +107,12 @@ export class UpdateAgencyReferringToUpdatedAgency extends TransactionalUseCase<
       ...agency,
       validatorEmails: agencyUpdated.validatorEmails,
     }));
+
+    await addValidatorsNotReceivingNotifications(
+      uow,
+      agencyUpdated.id,
+      updatedRelatedAgencies,
+    );
 
     await Promise.all(
       updatedRelatedAgencies.flatMap((agency) => [

--- a/back/src/domains/convention/use-cases/notifications/NotifyIcUserAgencyRightChanged.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyIcUserAgencyRightChanged.unit.test.ts
@@ -99,7 +99,7 @@ describe("SendEmailWhenAgencyIsActivated", () => {
       },
       agencyRights: [
         {
-          roles: ["to-review"],
+          roles: ["counsellor"],
           agency,
           isNotifiedByEmail: false,
         },
@@ -140,7 +140,7 @@ describe("SendEmailWhenAgencyIsActivated", () => {
       },
       agencyRights: [
         {
-          roles: ["validator"],
+          roles: ["to-review"],
           agency,
           isNotifiedByEmail: false,
         },
@@ -151,11 +151,8 @@ describe("SendEmailWhenAgencyIsActivated", () => {
     uow.userRepository.setInclusionConnectedUsers([icUser]);
 
     await notifyIcUserAgencyRightChanged.execute({
-      roles: ["to-review"],
       agencyId: "agency-1",
       userId: icUser.id,
-      isNotifiedByEmail: false,
-      email: icUser.email,
     });
 
     expectSavedNotificationsAndEvents({

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/InMemoryUserRepository.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/InMemoryUserRepository.ts
@@ -86,23 +86,30 @@ export class InMemoryUserRepository implements UserRepository {
     agencyRole,
     agencyId,
     email,
+    isNotifiedByEmail: isNotifiedByEmailFilter,
   }: InclusionConnectedFilters): Promise<InclusionConnectedUser[]> {
     // TODO: gestion des filtres optionnels à améliorer
     return this.users
       .filter((user) => (email ? user.email === email : true))
       .filter((user) => (email ? user.email === email : true))
       .filter((user) =>
-        this.agencyRightsByUserId[user.id].some(({ roles, agency }) => {
-          if (agencyId) {
-            if (agency.id !== agencyId) return false;
-          }
+        this.agencyRightsByUserId[user.id].some(
+          ({ roles, agency, isNotifiedByEmail }) => {
+            if (agencyId) {
+              if (agency.id !== agencyId) return false;
+            }
 
-          if (agencyRole) {
-            if (!roles.includes(agencyRole)) return false;
-          }
+            if (agencyRole) {
+              if (!roles.includes(agencyRole)) return false;
+            }
 
-          return true;
-        }),
+            if (isNotifiedByEmailFilter !== undefined) {
+              return isNotifiedByEmail === isNotifiedByEmailFilter;
+            }
+
+            return true;
+          },
+        ),
       )
       .map((user) => ({
         ...user,

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/PgUserRepository.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/PgUserRepository.ts
@@ -172,11 +172,16 @@ export class PgUserRepository implements UserRepository {
   }
 
   public async getIcUsersWithFilter(
-    { agencyRole, agencyId, email }: InclusionConnectedFilters,
+    {
+      agencyRole,
+      agencyId,
+      email,
+      isNotifiedByEmail,
+    }: InclusionConnectedFilters,
     provider: OAuthGatewayProvider,
   ): Promise<InclusionConnectedUser[]> {
     return this.#getInclusionConnectedUsers(
-      { agencyRole, agencyId, email },
+      { agencyRole, agencyId, email, isNotifiedByEmail },
       provider,
     );
   }
@@ -213,6 +218,7 @@ export class PgUserRepository implements UserRepository {
       agencyRole?: AgencyRole;
       agencyId?: AgencyId;
       email?: Email;
+      isNotifiedByEmail?: boolean;
     },
     provider: OAuthGatewayProvider,
   ): Promise<InclusionConnectedUser[]> {
@@ -397,6 +403,7 @@ type Filters = {
   agencyRole?: AgencyRole;
   agencyId?: AgencyId;
   email?: Email;
+  isNotifiedByEmail?: boolean;
 };
 
 type WhereClause = {
@@ -440,6 +447,13 @@ const getWhereClause = (filters: Filters): WhereClause => {
       searchParams.length > 0 ? "AND" : ""
     } users__agencies.agency_id = $${searchParams.length + 1}`;
     searchParams = [...searchParams, filters.agencyId];
+  }
+
+  if (filters.isNotifiedByEmail !== undefined) {
+    searchClause = `${searchClause} ${
+      searchParams.length > 0 ? "AND" : ""
+    } users__agencies.is_notified_by_email = $${searchParams.length + 1}`;
+    searchParams = [...searchParams, JSON.stringify(filters.isNotifiedByEmail)];
   }
 
   return {

--- a/back/src/domains/core/authentication/inclusion-connect/port/UserRepository.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/port/UserRepository.ts
@@ -14,6 +14,7 @@ import {
 export type InclusionConnectedFilters = Partial<WithAgencyRole> & {
   agencyId?: AgencyId;
   email?: Email;
+  isNotifiedByEmail?: boolean;
 };
 
 export interface UserRepository {

--- a/back/src/domains/core/events/events.ts
+++ b/back/src/domains/core/events/events.ts
@@ -10,8 +10,9 @@ import {
   Role,
   SiretDto,
   UserId,
-  UserParamsForAgency,
   WithAgencyDto,
+  WithAgencyId,
+  WithAgencyIdAndUserId,
   WithAssessmentDto,
   WithConventionDto,
   WithConventionIdLegacy,
@@ -141,7 +142,7 @@ export type DomainEvent =
   // AGENCY RELATED
   | GenericEvent<"NewAgencyAdded", WithAgencyDto & WithTriggeredBy>
   | GenericEvent<"AgencyActivated", WithAgencyDto & WithTriggeredBy>
-  | GenericEvent<"AgencyUpdated", WithAgencyDto & WithTriggeredBy>
+  | GenericEvent<"AgencyUpdated", WithAgencyId & WithTriggeredBy>
   | GenericEvent<"AgencyRejected", WithAgencyDto & WithTriggeredBy>
 
   // IMMERSION ASSESSMENT related
@@ -156,7 +157,7 @@ export type DomainEvent =
   // We don't put full OAuth in payload to avoid private data in logs etc...
   | GenericEvent<"UserAuthenticatedSuccessfully", UserAuthenticatedPayload & WithTriggeredBy>
   | GenericEvent<"AgencyRegisteredToInclusionConnectedUser", { userId: UserId; agencyIds: AgencyId[] } & WithTriggeredBy>
-  | GenericEvent<"IcUserAgencyRightChanged", UserParamsForAgency & WithTriggeredBy>
+  | GenericEvent<"IcUserAgencyRightChanged", WithAgencyIdAndUserId & WithTriggeredBy>
   | GenericEvent<"IcUserAgencyRightRejected", RejectIcUserRoleForAgencyParams & WithTriggeredBy>
   // API CONSUMER related
   | GenericEvent<"ApiConsumerSaved", { consumerId: string } & WithTriggeredBy>

--- a/back/src/domains/core/events/subscribeToEvents.ts
+++ b/back/src/domains/core/events/subscribeToEvents.ts
@@ -164,11 +164,7 @@ const getUseCasesByTopics = (
   ],
   IcUserAgencyRightChanged: [
     useCases.notifyIcUserAgencyRightChanged,
-    {
-      useCaseName: useCases.updateAgencyReferringToUpdatedAgency.useCaseName,
-      execute: ({ agencyId }) =>
-        useCases.updateAgencyReferringToUpdatedAgency.execute({ agencyId }),
-    },
+    useCases.updateAgencyReferringToUpdatedAgency,
   ],
   IcUserAgencyRightRejected: [useCases.notifyIcUserAgencyRightRejected],
 

--- a/back/src/domains/core/events/subscribeToEvents.ts
+++ b/back/src/domains/core/events/subscribeToEvents.ts
@@ -162,7 +162,14 @@ const getUseCasesByTopics = (
   UserAuthenticatedSuccessfully: [
     useCases.linkFranceTravailUsersToTheirAgencies,
   ],
-  IcUserAgencyRightChanged: [useCases.notifyIcUserAgencyRightChanged],
+  IcUserAgencyRightChanged: [
+    useCases.notifyIcUserAgencyRightChanged,
+    {
+      useCaseName: useCases.updateAgencyReferringToUpdatedAgency.useCaseName,
+      execute: ({ agencyId }) =>
+        useCases.updateAgencyReferringToUpdatedAgency.execute({ agencyId }),
+    },
+  ],
   IcUserAgencyRightRejected: [useCases.notifyIcUserAgencyRightRejected],
 
   //Api Consumer related:

--- a/back/src/domains/inclusion-connected-users/use-cases/CreateUserForAgency.unit.test.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/CreateUserForAgency.unit.test.ts
@@ -88,38 +88,6 @@ describe("CreateUserForAgency", () => {
     );
   });
 
-  it("throws not found if agency does not exist", async () => {
-    userRepository.setInclusionConnectedUsers([
-      backofficeAdminUser,
-      {
-        ...notAdminUser,
-        agencyRights: [],
-        dashboards: {
-          agencies: {},
-          establishments: {},
-        },
-      },
-    ]);
-
-    const agencyId = "Fake-Agency-Id";
-
-    await expectPromiseToFailWithError(
-      createUserForAgency.execute(
-        {
-          userId: uuidGenerator.new(),
-          roles: ["counsellor"],
-          agencyId,
-          isNotifiedByEmail: true,
-          email: "notAdminUser@email.fr",
-        },
-        backofficeAdminUser,
-      ),
-      errors.agency.notFound({
-        agencyId,
-      }),
-    );
-  });
-
   describe("Agency with refers to agency", () => {
     const agencyWithRefersTo = new AgencyDtoBuilder()
       .withId("agency-with-refers-to")
@@ -149,6 +117,8 @@ describe("CreateUserForAgency", () => {
       );
     });
   });
+
+  describe("Agency with refers to agency", () => {});
 
   it("create new user with its agency rights", async () => {
     const newUserId = uuidGenerator.new();

--- a/back/src/domains/inclusion-connected-users/use-cases/CreateUserForAgency.unit.test.ts
+++ b/back/src/domains/inclusion-connected-users/use-cases/CreateUserForAgency.unit.test.ts
@@ -88,6 +88,38 @@ describe("CreateUserForAgency", () => {
     );
   });
 
+  it("throws not found if agency does not exist", async () => {
+    userRepository.setInclusionConnectedUsers([
+      backofficeAdminUser,
+      {
+        ...notAdminUser,
+        agencyRights: [],
+        dashboards: {
+          agencies: {},
+          establishments: {},
+        },
+      },
+    ]);
+
+    const agencyId = "Fake-Agency-Id";
+
+    await expectPromiseToFailWithError(
+      createUserForAgency.execute(
+        {
+          userId: uuidGenerator.new(),
+          roles: ["counsellor"],
+          agencyId,
+          isNotifiedByEmail: true,
+          email: "notAdminUser@email.fr",
+        },
+        backofficeAdminUser,
+      ),
+      errors.agency.notFound({
+        agencyId,
+      }),
+    );
+  });
+
   describe("Agency with refers to agency", () => {
     const agencyWithRefersTo = new AgencyDtoBuilder()
       .withId("agency-with-refers-to")
@@ -117,8 +149,6 @@ describe("CreateUserForAgency", () => {
       );
     });
   });
-
-  describe("Agency with refers to agency", () => {});
 
   it("create new user with its agency rights", async () => {
     const newUserId = uuidGenerator.new();

--- a/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
@@ -11,10 +11,10 @@ import {
   InclusionConnectJwt,
   InclusionConnectedUser,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserInList,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
   WithUserFilters,
   createApiConsumerParamsFromApiConsumer,
 } from "shared";
@@ -226,7 +226,7 @@ export class HttpAdminGateway implements AdminGateway {
   }
 
   public removeUserFromAgency$(
-    params: RemoveAgencyUserParams,
+    params: WithAgencyIdAndUserId,
     token: string,
   ): Observable<void> {
     return from(

--- a/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
@@ -13,9 +13,9 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   UserInList,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
 } from "shared";
 import { AdminGateway } from "src/core-logic/ports/AdminGateway";
 
@@ -187,7 +187,7 @@ export class SimulatedAdminGateway implements AdminGateway {
   }
 
   public removeUserFromAgency$(
-    _params: RemoveAgencyUserParams,
+    _params: WithAgencyIdAndUserId,
     _token: string,
   ): Observable<void> {
     return of(undefined);

--- a/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
@@ -10,10 +10,10 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserInList,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
 } from "shared";
 import { AdminGateway } from "src/core-logic/ports/AdminGateway";
 
@@ -112,7 +112,7 @@ export class TestAdminGateway implements AdminGateway {
   }
 
   public removeUserFromAgency$(
-    _params: RemoveAgencyUserParams,
+    _params: WithAgencyIdAndUserId,
     _token: string,
   ): Observable<void> {
     return this.removeUserFromAgencyResponse$;

--- a/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
+++ b/front/src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice.ts
@@ -6,10 +6,10 @@ import {
   InclusionConnectedUser,
   OmitFromExistingKeys,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   User,
   UserId,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
   WithUserFilters,
 } from "shared";
 import { SubmitFeedBack } from "src/core-logic/domain/SubmitFeedback";
@@ -225,14 +225,14 @@ export const icUsersAdminSlice = createSlice({
 
     removeUserFromAgencyRequested: (
       state,
-      _action: PayloadActionWithFeedbackTopic<RemoveAgencyUserParams>,
+      _action: PayloadActionWithFeedbackTopic<WithAgencyIdAndUserId>,
     ) => {
       state.isUpdatingIcUserAgency = true;
     },
 
     removeUserFromAgencySucceeded: (
       state,
-      action: PayloadActionWithFeedbackTopic<RemoveAgencyUserParams>,
+      action: PayloadActionWithFeedbackTopic<WithAgencyIdAndUserId>,
     ) => {
       state.isUpdatingIcUserAgency = false;
       state.agencyUsers = filter(

--- a/front/src/core-logic/ports/AdminGateway.ts
+++ b/front/src/core-logic/ports/AdminGateway.ts
@@ -11,10 +11,10 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   SetFeatureFlagParam,
   UserInList,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
   WithUserFilters,
 } from "shared";
 
@@ -55,7 +55,7 @@ export interface AdminGateway {
   ): Observable<void>;
 
   removeUserFromAgency$(
-    params: RemoveAgencyUserParams,
+    params: WithAgencyIdAndUserId,
     token: InclusionConnectJwt,
   ): Observable<void>;
 

--- a/shared/src/admin/admin.dto.ts
+++ b/shared/src/admin/admin.dto.ts
@@ -12,15 +12,13 @@ import {
 import { SiretDto } from "../siret/siret";
 import { OmitFromExistingKeys } from "../utils";
 
-export type RemoveAgencyUserParams = {
+export type WithAgencyIdAndUserId = {
   agencyId: AgencyId;
   userId: UserId;
 };
 
-export type UserParamsForAgency = {
-  agencyId: AgencyId;
+export type UserParamsForAgency = WithAgencyIdAndUserId & {
   roles: AgencyRole[];
-  userId: UserId;
   isNotifiedByEmail: boolean;
   email: Email;
 };

--- a/shared/src/admin/admin.schema.ts
+++ b/shared/src/admin/admin.schema.ts
@@ -13,12 +13,12 @@ import {
   ManageConventionAdminForm,
   ManageEstablishmentAdminForm,
   RejectIcUserRoleForAgencyParams,
-  RemoveAgencyUserParams,
   UserParamsForAgency,
+  WithAgencyIdAndUserId,
   WithUserFilters,
 } from "./admin.dto";
 
-export const removeAgencyUserParamsSchema: z.Schema<RemoveAgencyUserParams> =
+export const withAgencyIdAndUserIdSchema: z.Schema<WithAgencyIdAndUserId> =
   z.object({
     agencyId: agencyIdSchema,
     userId: userIdSchema,


### PR DESCRIPTION
Mettre à jour les mails des valideurs de la structure d'accompagnement lorsque ceux de la structure prescriptrice parente ont changé.

Pour la mise à jour des infos déjà présentes en DB, les requêtes SQL à jouer sur la prod après mep de cette PR sont dans le  ticket: https://github.com/gip-inclusion/immersion-facile/issues/2269