### PR TITLE
TECH - définir le déclencheur comme étant le crawler quand le usecase a été déclenché par lui

### DIFF
--- a/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferingToUpdatedAgency.unit.test.ts
@@ -93,8 +93,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
                 validatorEmails: updatedAgency.validatorEmails,
               },
               triggeredBy: {
-                kind: "inclusion-connected",
-                userId: icUser.id,
+                kind: "crawler",
               },
             },
           }),
@@ -109,8 +108,7 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
                 validatorEmails: updatedAgency.validatorEmails,
               },
               triggeredBy: {
-                kind: "inclusion-connected",
-                userId: icUser.id,
+                kind: "crawler",
               },
             },
           }),

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
@@ -26,11 +26,7 @@ export class UpdateAgencyReferringToUpdatedAgency extends TransactionalUseCase<
     this.#createNewEvent = createNewEvent;
   }
 
-  public async _execute(
-    params: WithAgencyDto,
-    uow: UnitOfWork,
-    currentUser: InclusionConnectedUser,
-  ): Promise<void> {
+  public async _execute(params: WithAgencyDto, uow: UnitOfWork): Promise<void> {
     const updatedRelatedAgencies: AgencyDto[] = (
       await uow.agencyRepository.getAgenciesRelatedToAgency(params.agency.id)
     ).map((agency) => ({
@@ -47,8 +43,7 @@ export class UpdateAgencyReferringToUpdatedAgency extends TransactionalUseCase<
             payload: {
               agency,
               triggeredBy: {
-                kind: "inclusion-connected",
-                userId: currentUser.id,
+                kind: "crawler",
               },
             },
           }),

--- a/back/src/domains/core/events/events.ts
+++ b/back/src/domains/core/events/events.ts
@@ -79,7 +79,8 @@ export type UserAuthenticatedPayload = {
 export type TriggeredBy =
   | { kind: "inclusion-connected"; userId: UserId }
   | { kind: "convention-magic-link"; role: Role }
-  | { kind: "establishment-magic-link"; siret: SiretDto };
+  | { kind: "establishment-magic-link"; siret: SiretDto }
+  | { kind: "crawler" };
 
 export const triggeredBySchema: z.Schema<TriggeredBy> = z.discriminatedUnion(
   "kind",


### PR DESCRIPTION
## Problème

Lorsqu'un usecase a été déclenché par l'outbox, il n'a pas de `currentUser` de défini.
Or dans le usecase `UpdateAgencyReferringToUpdatedAgency` on cherchait à accéder à l'id de ce `currentUser` qui est undefined. On obtenait finalement l'erreur:

> Cannot read properties of undefined (reading 'id')"

## Solution

Définir le déclencheur comme étant le crawler quand le usecase a été déclenché par lui