### PR TITLE
Tech - params de filterParamsForRoute sous forme d'objet

### DIFF
--- a/front/src/app/components/forms/convention/useUpdateConventionValuesInUrl.ts
+++ b/front/src/app/components/forms/convention/useUpdateConventionValuesInUrl.ts
@@ -2,12 +2,7 @@ import { useEffect } from "react";
 import { objectToDependencyList } from "shared";
 import { useDebounce } from "src/app/hooks/useDebounce";
 import { ConventionParamsInUrl } from "src/app/routes/routeParams/convention";
-import {
-  conventionForExternalParams,
-  conventionParams,
-  routes,
-  useRoute,
-} from "src/app/routes/routes";
+import { conventionParams, routes, useRoute } from "src/app/routes/routes";
 import {
   filterParamsForRoute,
   getUrlParameters,
@@ -35,11 +30,11 @@ export const useUpdateConventionValuesInUrl = (
         route.name === "conventionCustomAgency" ||
         route.name === "conventionMiniStage"
       ) {
-        const filteredParams = filterParamsForRoute(
+        const filteredParams = filterParamsForRoute({
           urlParams,
-          conventionParams,
-          ["fedId", "fedIdProvider"],
-        );
+          matchingParams: conventionParams,
+          forceExcludeParams: ["fedId", "fedIdProvider"],
+        });
         const {
           fedId: _,
           fedIdProvider: __,
@@ -52,11 +47,11 @@ export const useUpdateConventionValuesInUrl = (
       }
 
       if (route.name === "conventionImmersionForExternals") {
-        const filteredParams = filterParamsForRoute(
+        const filteredParams = filterParamsForRoute({
           urlParams,
-          conventionForExternalParams,
-          ["fedId", "fedIdProvider"],
-        );
+          matchingParams: conventionParams,
+          forceExcludeParams: ["fedId", "fedIdProvider"],
+        });
         routes
           .conventionImmersionForExternals({
             ...filteredParams,

--- a/front/src/app/components/forms/establishment/EstablishmentForm.tsx
+++ b/front/src/app/components/forms/establishment/EstablishmentForm.tsx
@@ -249,10 +249,10 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
 
   useEffect(() => {
     if (isEstablishmentCreation) {
-      const filteredParams = filterParamsForRoute(
-        initialUrlParams.current,
-        establishmentParams,
-      );
+      const filteredParams = filterParamsForRoute({
+        urlParams: initialUrlParams.current,
+        matchingParams: establishmentParams,
+      });
       routes
         .formEstablishment(
           formEstablishmentDtoToFormEstablishmentWithAcquisitionQueryParams({

--- a/front/src/app/hooks/search.hooks.ts
+++ b/front/src/app/hooks/search.hooks.ts
@@ -26,13 +26,13 @@ export const useSearchUseCase = ({
     dispatch(
       searchSlice.actions.searchRequested({ ...values, appellationCodes }),
     );
-    const updatedUrlParams = filterParamsForRoute(
-      {
+    const updatedUrlParams = filterParamsForRoute({
+      urlParams: {
         ...urlParams,
         ...values,
       },
-      searchParams,
-    );
+      matchingParams: searchParams,
+    });
     const updatedUrlParamsWithEncodedUriValues = {
       ...updatedUrlParams,
       ...encodedSearchUriParams.reduce((acc, currentKey) => {

--- a/front/src/app/utils/url.utils.ts
+++ b/front/src/app/utils/url.utils.ts
@@ -3,11 +3,15 @@ export const getUrlParameters: (location: Location) => {
 } = (location) =>
   Object.fromEntries(new URLSearchParams(location.search).entries());
 
-export const filterParamsForRoute = (
-  urlParams: Record<string, unknown>,
-  matchingParams: Record<string, unknown>,
-  forceExcludeParams?: string[],
-) =>
+export const filterParamsForRoute = ({
+  urlParams,
+  matchingParams,
+  forceExcludeParams,
+}: {
+  urlParams: Record<string, unknown>;
+  matchingParams: Record<string, unknown>;
+  forceExcludeParams?: string[];
+}) =>
   Object.fromEntries(
     Object.entries(urlParams).filter(
       ([key]) => key in matchingParams && !forceExcludeParams?.includes(key),

--- a/front/src/app/utils/url.utils.unit.test.ts
+++ b/front/src/app/utils/url.utils.unit.test.ts
@@ -26,7 +26,7 @@ describe("url.utils", () => {
         param1: "value1",
       };
 
-      const result = filterParamsForRoute(urlParams, matchingParams);
+      const result = filterParamsForRoute({ urlParams, matchingParams });
       expect(result).toEqual({
         param1: "value1",
       });


### PR DESCRIPTION
- **always update businessName from siret, stop infinite loop on route params**
- **filterParamsForRoute params as obj**
