### PR TITLE
Create Accusé réception MEC

### DIFF
--- a/Accusé réception MEC
+++ b/Accusé réception MEC
@@ -1,0 +1,2 @@
+Nous avons régulièrement des demandes de candidats qui s'inquiètent de savoir si leur demandes de contact a bien été envoyée car il ne recevoivent pas de mail de confirmation. 
+Idem de la part des prescripteurs qui accompagnent les publics les plus éloignés. Je pense que ca serait interessant de rajouter ce template.


### PR DESCRIPTION
Nous avons souvent des remontés sur le support de candidats et/ou de prescripteurs qui accompagnent les publics les plus éloignés sur ce sujet. Ils s'inquiètent de ne pas avoir reçu d'accusé réception de leur demande de contact avec avec une entreprise et nous écrivent au support à ce sujet. Je pense que cela aurait du sens pour aider les candidats à organiser leurs recherches et donc leurs relances.