### PR TITLE
#2308 - suppression du block warning dans le formulaire de convention (ces infos sont toujours présentes après la soumission du form)

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -505,28 +505,6 @@ export const ConventionForm = ({
                     </Accordion>
                   </div>
 
-                  <Alert
-                    small
-                    severity="warning"
-                    className={fr.cx("fr-my-2w")}
-                    description={
-                      <ol>
-                        <li>
-                          Une fois le formulaire envoyé, chaque signataire de la
-                          convention va recevoir un email.
-                        </li>
-                        <li>
-                          Pensez à vérifier votre boîte email et votre dossier
-                          de spams.
-                        </li>
-                        <li>
-                          Pensez également à informer les autres signataires de
-                          la convention qu'ils devront vérifier leur boîte email
-                          et leur dossier de spams.
-                        </li>
-                      </ol>
-                    }
-                  />
                   <ErrorNotifications
                     labels={getFormErrors()}
                     errors={displayReadableError(errors)}


### PR DESCRIPTION
Version initial :

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/5a5c6b20-ab14-4d2b-b974-9a9c81fdd7dc">


Devient :

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/7b6637ee-66a2-45f8-b8e8-85dbcc7f3473">
