### PR TITLE
#2376 - etq utilisateur je peux initier une convention de plus de 30 jours

### DIFF
--- a/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
+++ b/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
@@ -1,7 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { addDays, differenceInDays } from "date-fns";
+import { addDays, differenceInCalendarDays, differenceInDays } from "date-fns";
 import React, { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import {
@@ -52,9 +52,12 @@ export const ScheduleSection = () => {
 
   const getFieldError = makeFieldError(formState);
 
-  const shouldUpdateDateAndSchedule = (dateStart: string, dateEnd: string) =>
-    differenceInDays(new Date(dateEnd), new Date(dateStart)) <=
-    maximumCalendarDayByInternshipKind[values.internshipKind];
+  const shouldUpdateDateAndSchedule = (dateStart: Date, dateEnd: Date) => {
+    return (
+      differenceInCalendarDays(dateEnd, dateStart) <=
+      maximumCalendarDayByInternshipKind[values.internshipKind]
+    );
+  };
 
   const [dateStartInputValue, setDateStartInputValue] = useState<string>(
     values.dateStart,
@@ -86,12 +89,7 @@ export const ScheduleSection = () => {
           newDates.start = newDates.end;
       }
 
-      if (
-        !shouldUpdateDateAndSchedule(
-          newDates.start.toISOString(),
-          newDates.end.toISOString(),
-        )
-      ) {
+      if (!shouldUpdateDateAndSchedule(newDates.start, newDates.end)) {
         alert(
           `Attention, votre ${
             values.internshipKind === "immersion" ? "immersion" : "stage"

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -60,16 +60,14 @@ export const errors = {
   convention: {
     updateBadStatusInParams: ({ id }: { id: ConventionId }) =>
       new ForbiddenError(
-        `Convention ${id} with modifications should have status READY_TO_SIGNaaaaa`,
+        `Convention ${id} with modifications should have status READY_TO_SIGN`,
       ),
     updateBadStatusInRepo: ({ id }: { id: ConventionId }) =>
       new BadRequestError(
-        `Convention ${id} cannot be modified as it has status PARTIALLY_SIGNEDaaaaaa`,
+        `Convention ${id} cannot be modified as it has status PARTIALLY_SIGNED`,
       ),
     updateForbidden: ({ id }: { id: ConventionId }) =>
-      new ForbiddenError(
-        `User is not allowed to update convention ${id}aaaaaaaaaa`,
-      ),
+      new ForbiddenError(`User is not allowed to update convention ${id}`),
     missingFTAdvisor: ({ ftExternalId }: { ftExternalId: PeExternalId }) =>
       new NotFoundError(
         `Il n'y a pas de conseiller France Travail attaché à l'identifiant OAuth ftExternalId '${ftExternalId}'.`,
@@ -138,7 +136,7 @@ export const errors = {
       kind,
     }: { convention: ConventionDto; kind: ReminderKind }) =>
       new ForbiddenError(
-        `Convention with id: '${convention.id}' and status: '${convention.status}' is not supported for reminder ${kind}.aaaaaaa`,
+        `Convention with id: '${convention.id}' and status: '${convention.status}' is not supported for reminder ${kind}.`,
       ),
   },
   establishment: {
@@ -166,7 +164,7 @@ export const errors = {
       ),
     missingOrClosed: ({ siret }: { siret: SiretDto }) =>
       new BadRequestError(
-        `Ce SIRET (${siret}) n'est pas attribué ou correspond à un établissement fermé. Veuillez le corriger.aaaaaaaaaaaaa`,
+        `Ce SIRET (${siret}) n'est pas attribué ou correspond à un établissement fermé. Veuillez le corriger.`,
       ),
     notFound: ({ siret }: { siret: SiretDto }) =>
       new NotFoundError(
@@ -284,7 +282,7 @@ export const errors = {
       ),
     emailNotFound: ({ agencyId }: { agencyId: AgencyId }) =>
       new NotFoundError(
-        `Mail not found for agency with id: ${agencyId} on agency repository.aaaaaaaaa`,
+        `Mail not found for agency with id: ${agencyId} on agency repository.`,
       ),
     notEnoughCounsellors: ({ agencyId }: { agencyId: AgencyId }) =>
       new BadRequestError(
@@ -481,9 +479,9 @@ export const errors = {
   },
   delegation: {
     missingLabel: ({ label }: { label: ShortLinkId }) =>
-      new BadRequestError(`No value found for label "${label}".aaaaaa`),
+      new BadRequestError(`No value found for label "${label}".`),
     missingEmail: ({ province }: { province: ShortLinkId }) =>
-      new BadRequestError(`Province ${province} not foundaaaaaaaaaa`),
+      new BadRequestError(`Province ${province} not found`),
   },
   routeParams: {
     missingJwt: () =>


### PR DESCRIPTION
## 🤖 Problème

Lorsque l'on soumet une convention sur ces deux dates:
- date start: 18/10
- date end: 18/11

et que l'on convertit en objet Date, on obtient:
- Fri Oct 18 2024 02:00:00 GMT+0200 (Central European Summer Time)
- Mon Nov 18 2024 01:00:00 GMT+0100 (Central European Standard Time)

La différence de jour entre les deux dates est bien de 30 jours et non 31.
La création est alors créée alors que l'on ne le souhaite pas car elle excède pas 30 jours.

==> à noter que l'on a seulement ce soucis sur ces dates à cause du changement d'heure. Sur les autres mois de l'année, il n'y avait pas de soucis.

## 🌈 Solution

- éviter de convertir une Date en string puis Date à nouveau
- utiliser differenceInCalendarDays de date-fns au lieu de differenceInDays