### PR TITLE
#2448 - création de la page de détail d'un utilisateur (pour les super admin uniquement) - accessible depuis l'onglet admin - utilisateurs

### DIFF
--- a/back/src/adapters/primary/routers/admin/createAdminRouter.ts
+++ b/back/src/adapters/primary/routers/admin/createAdminRouter.ts
@@ -77,6 +77,17 @@ export const createAdminRouter = (deps: AppDependencies): Router => {
       ),
   );
 
+  sharedAdminRouter.getIcUser(deps.inclusionConnectAuthMiddleware, (req, res) =>
+    sendHttpResponse(req, res, () => {
+      const currentUser = req.payloads?.currentUser;
+      if (!currentUser) throw errors.user.unauthorized();
+      return deps.useCases.getInclusionConnectedUser.execute(
+        { userId: req.params.userId },
+        currentUser,
+      );
+    }),
+  );
+
   sharedAdminRouter.updateUserRoleForAgency(
     deps.inclusionConnectAuthMiddleware,
     (req, res) =>

--- a/front/src/app/components/agency/AgencyTag.tsx
+++ b/front/src/app/components/agency/AgencyTag.tsx
@@ -1,5 +1,5 @@
-import Tag from "@codegouvfr/react-dsfr/Tag";
 import React from "react";
+import { Tag } from "react-design-system";
 import { WithAgencyDto } from "shared";
 
 export const AgencyTag = ({
@@ -7,9 +7,11 @@ export const AgencyTag = ({
   className,
 }: WithAgencyDto & { className?: string }) =>
   agency.refersToAgencyId ? (
-    <Tag className={className}>
-      Structure d'accompagnement liée à {agency.refersToAgencyName}
-    </Tag>
+    <Tag
+      theme={"structureAccompagnement"}
+      label={`Structure d'accompagnement liée à ${agency.refersToAgencyName}`}
+      className={className}
+    />
   ) : (
-    <Tag className={className}>Prescripteur</Tag>
+    <Tag theme={"prescripteur"} className={className} />
   );

--- a/front/src/app/components/agency/AgencyTag.tsx
+++ b/front/src/app/components/agency/AgencyTag.tsx
@@ -1,13 +1,15 @@
-import { fr } from "@codegouvfr/react-dsfr";
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import React from "react";
 import { WithAgencyDto } from "shared";
 
-export const AgencyTag = ({ agency }: WithAgencyDto) =>
+export const AgencyTag = ({
+  agency,
+  className,
+}: WithAgencyDto & { className?: string }) =>
   agency.refersToAgencyId ? (
-    <Tag className={fr.cx("fr-my-4w")}>
+    <Tag className={className}>
       Structure d'accompagnement liée à {agency.refersToAgencyName}
     </Tag>
   ) : (
-    <Tag className={fr.cx("fr-my-4w")}>Prescripteur</Tag>
+    <Tag className={className}>Prescripteur</Tag>
   );

--- a/front/src/app/components/agency/EditAgency.tsx
+++ b/front/src/app/components/agency/EditAgency.tsx
@@ -1,7 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import React from "react";
+import { AgencyTag } from "src/app/components/agency/AgencyTag";
 import { AgencyUsers } from "src/app/components/agency/AgencyUsers";
-import { AgencyTag } from "src/app/components/forms/agency/AgencyTag";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import "src/assets/admin.css";
 import { agencyAdminSelectors } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.selectors";
@@ -24,7 +24,7 @@ export const EditAgency = () => {
       </div>
       {agency && (
         <>
-          <AgencyTag agency={agency} />
+          <AgencyTag agency={agency} className={fr.cx("fr-my-4w")} />
           <EditAgencyForm agency={agency} />
         </>
       )}

--- a/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
+++ b/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
@@ -6,8 +6,8 @@ import { Loader } from "react-design-system";
 import { useDispatch } from "react-redux";
 import { SubmitFeedbackNotification } from "src/app/components/SubmitFeedbackNotification";
 import { agencyAdminSubmitMessageByKind } from "src/app/components/agency/AgencySubmitFeedback";
+import { AgencyTag } from "src/app/components/agency/AgencyTag";
 import { AgencyUsers } from "src/app/components/agency/AgencyUsers";
-import { AgencyTag } from "src/app/components/forms/agency/AgencyTag";
 import { EditAgencyForm } from "src/app/components/forms/agency/EditAgencyForm";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { useCopyButton } from "src/app/hooks/useCopyButton";
@@ -67,7 +67,7 @@ export const AdminAgencyDetail = ({ route }: AdminAgencyDetailProps) => {
       />
       {agency && (
         <>
-          <AgencyTag agency={agency} />
+          <AgencyTag agency={agency} className={fr.cx("fr-my-2w")} />
           <EditAgencyForm agency={agency} />
         </>
       )}

--- a/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
+++ b/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
@@ -48,8 +48,7 @@ export const AdminAgencyDetail = ({ route }: AdminAgencyDetailProps) => {
 
   return (
     <div>
-      <h1 className={fr.cx("fr-h1")}>Détail de l'agence</h1>
-      <h2 className={fr.cx("fr-h2")}>{agency.name}</h2>
+      <h1 className={fr.cx("fr-h1")}>{agency.name}</h1>
       <div>
         Id de l'agence : <Badge severity="success">{agency.id}</Badge>{" "}
         <Button

--- a/front/src/app/pages/admin/AdminTabs.tsx
+++ b/front/src/app/pages/admin/AdminTabs.tsx
@@ -38,13 +38,13 @@ const rawAdminTabs: Record<AdminTabRouteName, RawAdminTab> = {
     label: "Agences",
     content: <AgencyTab />,
   },
-  adminUsers: {
-    label: "Utilisateurs",
-    content: <UsersTab />,
-  },
   adminEstablishments: {
     label: "Établissements",
     content: <EstablishmentsTab />,
+  },
+  adminUsers: {
+    label: "Utilisateurs",
+    content: <UsersTab />,
   },
   adminNotifications: {
     label: "Notifications",

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -75,6 +75,7 @@ const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
           "Type d'agence",
           "Roles",
           "Reçoit les notifications",
+          "Actions",
         ]}
         data={agencyRights.map((agencyRight) => {
           return [
@@ -88,6 +89,11 @@ const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
               .map((role) => agencyRoleToDisplay[role].label)
               .join(", "),
             agencyRight.isNotifiedByEmail ? "Oui" : "Non",
+            <a
+              {...routes.adminAgencyDetail({ agencyId: agencyRight.agency.id })}
+            >
+              Voir l'agence
+            </a>,
           ];
         })}
       />

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -1,0 +1,76 @@
+import { Table } from "@codegouvfr/react-dsfr/Table";
+import { useEffect } from "react";
+import { Loader } from "react-design-system";
+import { useDispatch } from "react-redux";
+import { AgencyRight, agencyKindToLabel } from "shared";
+import { useAppSelector } from "src/app/hooks/reduxHooks";
+import { routes } from "src/app/routes/routes";
+import { adminFetchUserSelectors } from "src/core-logic/domain/admin/fetchUser/fetchUser.selectors";
+import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
+import { Route } from "type-route";
+
+type AdminUserDetailProps = {
+  route: Route<typeof routes.adminUserDetail>;
+};
+
+export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
+  const icUser = useAppSelector(adminFetchUserSelectors.fetchedUser);
+  const isFetchingUser = useAppSelector(adminFetchUserSelectors.isFetching);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(
+      fetchUserSlice.actions.fetchUserRequested({
+        userId: route.params.userId,
+      }),
+    );
+  }, [route.params.userId, dispatch]);
+
+  if (isFetchingUser) return <Loader />;
+  if (!icUser) return <p>Aucun utilisateur trouvé</p>;
+
+  return (
+    <div>
+      <h1>Utilisateur</h1>
+
+      <ul>
+        <li>Id : {icUser.id}</li>
+        <li>Email : {icUser.email}</li>
+        {icUser.firstName && <li>Prénom : {icUser.firstName}</li>}
+        {icUser.lastName && <li>Nom : {icUser.lastName}</li>}
+      </ul>
+      <AgenciesTable
+        agencyRights={[...icUser.agencyRights].sort((a, b) =>
+          a.agency.name.localeCompare(b.agency.name),
+        )}
+      />
+    </div>
+  );
+};
+
+const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
+  if (!agencyRights.length)
+    return <p>Cet utilisateur n'est lié à aucune agence</p>;
+
+  return (
+    <>
+      <h2>Agences liées ({agencyRights.length} agences)</h2>
+
+      <Table
+        fixed
+        headers={[
+          "Nom d'agence",
+          "Type d'agence",
+          "Roles",
+          "Reçoit les notifications",
+        ]}
+        data={agencyRights.map((agencyRight) => [
+          agencyRight.agency.name,
+          agencyKindToLabel[agencyRight.agency.kind],
+          agencyRight.roles.join(", "),
+          agencyRight.isNotifiedByEmail ? "Oui" : "Non",
+        ])}
+      />
+    </>
+  );
+};

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -3,7 +3,11 @@ import { Table } from "@codegouvfr/react-dsfr/Table";
 import React, { useEffect } from "react";
 import { Loader } from "react-design-system";
 import { useDispatch } from "react-redux";
-import { AgencyRight, agencyKindToLabelIncludingIF } from "shared";
+import {
+  AgencyRight,
+  addressDtoToString,
+  agencyKindToLabelIncludingIF,
+} from "shared";
 import { AgencyTag } from "src/app/components/agency/AgencyTag";
 import { agencyRoleToDisplay } from "src/app/components/agency/AgencyUsers";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
@@ -83,6 +87,10 @@ const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
               <AgencyTag agency={agencyRight.agency} />
               <br />
               <span>{agencyRight.agency.name}</span>
+              <br />
+              <span className={fr.cx("fr-hint-text")}>
+                {addressDtoToString(agencyRight.agency.address)}
+              </span>
             </>,
             agencyKindToLabelIncludingIF[agencyRight.agency.kind],
             agencyRight.roles

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -1,8 +1,11 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import { Table } from "@codegouvfr/react-dsfr/Table";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { Loader } from "react-design-system";
 import { useDispatch } from "react-redux";
-import { AgencyRight, agencyKindToLabel } from "shared";
+import { AgencyRight, agencyKindToLabelIncludingIF } from "shared";
+import { AgencyTag } from "src/app/components/agency/AgencyTag";
+import { agencyRoleToDisplay } from "src/app/components/agency/AgencyUsers";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { routes } from "src/app/routes/routes";
 import { adminFetchUserSelectors } from "src/core-logic/domain/admin/fetchUser/fetchUser.selectors";
@@ -29,16 +32,24 @@ export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
   if (isFetchingUser) return <Loader />;
   if (!icUser) return <p>Aucun utilisateur trouvé</p>;
 
+  const title =
+    icUser.firstName && icUser.lastName
+      ? `${icUser.firstName} ${icUser.lastName}`
+      : icUser.email;
+
   return (
     <div>
-      <h1>Utilisateur</h1>
+      <h1>{title}</h1>
 
-      <ul>
-        <li>Id : {icUser.id}</li>
+      <p className={fr.cx("fr-text--bold")}>Informations personnelles</p>
+
+      <ul className={fr.cx("fr-text--sm")}>
+        <li>Id de l'utilisateur: {icUser.id}</li>
         <li>Email : {icUser.email}</li>
         {icUser.firstName && <li>Prénom : {icUser.firstName}</li>}
         {icUser.lastName && <li>Nom : {icUser.lastName}</li>}
       </ul>
+
       <AgenciesTable
         agencyRights={[...icUser.agencyRights].sort((a, b) =>
           a.agency.name.localeCompare(b.agency.name),
@@ -54,22 +65,31 @@ const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
 
   return (
     <>
-      <h2>Agences liées ({agencyRights.length} agences)</h2>
+      <p className={fr.cx("fr-text--bold")}>
+        Organismes rattachés au profil ({agencyRights.length} agences)
+      </p>
 
       <Table
-        fixed
         headers={[
           "Nom d'agence",
           "Type d'agence",
           "Roles",
           "Reçoit les notifications",
         ]}
-        data={agencyRights.map((agencyRight) => [
-          agencyRight.agency.name,
-          agencyKindToLabel[agencyRight.agency.kind],
-          agencyRight.roles.join(", "),
-          agencyRight.isNotifiedByEmail ? "Oui" : "Non",
-        ])}
+        data={agencyRights.map((agencyRight) => {
+          return [
+            <>
+              <AgencyTag agency={agencyRight.agency} />
+              <br />
+              <span>{agencyRight.agency.name}</span>
+            </>,
+            agencyKindToLabelIncludingIF[agencyRight.agency.kind],
+            agencyRight.roles
+              .map((role) => agencyRoleToDisplay[role].label)
+              .join(", "),
+            agencyRight.isNotifiedByEmail ? "Oui" : "Non",
+          ];
+        })}
       />
     </>
   );

--- a/front/src/app/pages/admin/UsersTab.tsx
+++ b/front/src/app/pages/admin/UsersTab.tsx
@@ -7,6 +7,7 @@ import { domElementIds } from "shared";
 import { NameAndEmailInTable } from "src/app/components/admin/NameAndEmailInTable";
 import { UsersWithoutNameHint } from "src/app/components/agency/UsersWithoutNameHint";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
+import { routes } from "src/app/routes/routes";
 import { listUsersSelectors } from "src/core-logic/domain/admin/listUsers/listUsers.selectors";
 import { listUsersSlice } from "src/core-logic/domain/admin/listUsers/listUsers.slice";
 
@@ -71,7 +72,7 @@ const UsersTable = () => {
     <Table
       fixed
       id={domElementIds.admin.usersTab.usersTable}
-      headers={["Utilisateur", "Nombre d'agences liées"]}
+      headers={["Utilisateur", "Nombre d'agences liées", "Actions"]}
       data={users.map((user) => [
         <NameAndEmailInTable
           firstName={user.firstName}
@@ -79,6 +80,7 @@ const UsersTable = () => {
           email={user.email}
         />,
         user.numberOfAgencies,
+        <a {...routes.adminUserDetail({ userId: user.id })}>Détails</a>,
       ])}
     />
   );

--- a/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
+++ b/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
@@ -30,6 +30,7 @@ import { Route } from "type-route";
 
 export type FrontAdminRoute =
   | FrontAdminRouteTab
+  | Route<typeof routes.adminUserDetail>
   | Route<typeof routes.adminConventionDetail>
   | Route<typeof routes.adminAgencyDetail>;
 

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -95,6 +95,11 @@ const getPageByRouteName: {
       <AdminAgencyDetail route={route} />
     </AdminPrivateRoute>
   ),
+  adminUserDetail: (route) => (
+    <AdminPrivateRoute route={route}>
+      <div>User detail, user id is : ${route.params.userId}</div>
+    </AdminPrivateRoute>
+  ),
   agencyDashboard: (route) =>
     agencyDashboardTabsList.includes(route.params.tab as AgencyDashboardTab) ? (
       <InclusionConnectedPrivateRoute

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -12,6 +12,7 @@ import { Breadcrumbs } from "src/app/components/Breadcrumbs";
 import { AdminAgencyDetail } from "src/app/components/forms/agency/AdminAgencyDetail";
 import { StatsPage } from "src/app/pages/StatsPage";
 import { AdminTabs } from "src/app/pages/admin/AdminTabs";
+import { AdminUserDetail } from "src/app/pages/admin/AdminUserDetail";
 import { AgencyDashboardPage } from "src/app/pages/agency-dashboard/AgencyDashboardPage";
 import { AddAgencyPage } from "src/app/pages/agency/AddAgencyPage";
 import { BeneficiaryDashboardPage } from "src/app/pages/beneficiary-dashboard/BeneficiaryDashboardPage";
@@ -97,7 +98,7 @@ const getPageByRouteName: {
   ),
   adminUserDetail: (route) => (
     <AdminPrivateRoute route={route}>
-      <div>User detail, user id is : ${route.params.userId}</div>
+      <AdminUserDetail route={route} />
     </AdminPrivateRoute>
   ),
   agencyDashboard: (route) =>

--- a/front/src/app/routes/routes.ts
+++ b/front/src/app/routes/routes.ts
@@ -84,7 +84,7 @@ const admin = defineRoute(
   () => `/${frontRoutes.admin}`,
 );
 
-const { adminConventions, adminAgencies, ...restOfAdminRoutes } =
+const { adminConventions, adminAgencies, adminUsers, ...restOfAdminRoutes } =
   adminTabRouteNames.reduce(
     (acc, adminTabName) => ({
       ...acc,
@@ -102,6 +102,11 @@ export const { RouteProvider, useRoute, routes } = createRouter({
   adminConventionDetail: adminConventions.extend(
     { conventionId: param.path.string },
     ({ conventionId }) => `/${conventionId}`,
+  ),
+  adminUsers,
+  adminUserDetail: adminUsers.extend(
+    { userId: param.path.string },
+    ({ userId }) => `/${userId}`,
   ),
   adminAgencies,
   adminAgencyDetail: adminAgencies.extend(

--- a/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/HttpAdminGateway.ts
@@ -12,6 +12,7 @@ import {
   InclusionConnectedUser,
   RejectIcUserRoleForAgencyParams,
   SetFeatureFlagParam,
+  UserId,
   UserInList,
   UserParamsForAgency,
   WithAgencyIdAndUserId,
@@ -258,6 +259,22 @@ export class HttpAdminGateway implements AdminGateway {
             .with({ status: 401 }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
+    );
+  }
+
+  public getIcUser$(
+    params: { userId: UserId },
+    token: InclusionConnectJwt,
+  ): Observable<InclusionConnectedUser> {
+    return from(
+      this.httpClient
+        .getIcUser({ headers: { authorization: token }, urlParams: params })
+        .then((response) => {
+          return match(response)
+            .with({ status: 200 }, ({ body }) => body ?? undefined)
+            .with({ status: P.union(401, 403, 404) }, logBodyAndThrow)
+            .otherwise(otherwiseThrow);
+        }),
     );
   }
 }

--- a/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/SimulatedAdminGateway.ts
@@ -13,6 +13,7 @@ import {
   InclusionConnectedUser,
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
+  UserId,
   UserInList,
   UserParamsForAgency,
   WithAgencyIdAndUserId,
@@ -45,6 +46,7 @@ const simulatedAgencyDtos: AgencyRight[] = [
     isNotifiedByEmail: true,
   },
 ];
+
 export class SimulatedAdminGateway implements AdminGateway {
   public updateFeatureFlags$ = (): Observable<void> => of(undefined);
 
@@ -200,6 +202,27 @@ export class SimulatedAdminGateway implements AdminGateway {
     return of(
       simulatedUsers.filter((user) => user.email.includes(emailContains)),
     );
+  }
+
+  public getIcUser$(
+    params: {
+      userId: UserId;
+    },
+    _token: InclusionConnectJwt,
+  ): Observable<InclusionConnectedUser> {
+    const icUser = simulatedUsers.find((user) => user.id === params.userId);
+    if (!icUser) throw new Error(`User ${params.userId} not found`);
+    return of({
+      ...icUser,
+      agencyRights: [
+        {
+          agency: new AgencyDtoBuilder().build(),
+          roles: ["validator"],
+          isNotifiedByEmail: true,
+        },
+      ],
+      dashboards: { agencies: {}, establishments: {} },
+    });
   }
 }
 

--- a/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
+++ b/front/src/core-logic/adapters/AdminGateway/TestAdminGateway.ts
@@ -52,6 +52,8 @@ export class TestAdminGateway implements AdminGateway {
 
   public listUsersResponse$ = new Subject<UserInList[]>();
 
+  public getIcUserResponse$ = new Subject<InclusionConnectedUser>();
+
   public updateFeatureFlags$ = (
     params: SetFeatureFlagParam,
     _adminToken: InclusionConnectJwt,
@@ -123,5 +125,12 @@ export class TestAdminGateway implements AdminGateway {
     _token: string,
   ): Observable<UserInList[]> {
     return this.listUsersResponse$;
+  }
+
+  public getIcUser$(
+    _params: { userId: string },
+    _token: string,
+  ): Observable<InclusionConnectedUser> {
+    return this.getIcUserResponse$;
   }
 }

--- a/front/src/core-logic/domain/admin/adminPreloadedState.ts
+++ b/front/src/core-logic/domain/admin/adminPreloadedState.ts
@@ -1,5 +1,6 @@
 import { agencyAdminInitialState } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
 import { dashboardInitialState } from "src/core-logic/domain/admin/dashboardUrls/dashboardUrls.slice";
+import { fetchUserInitialState } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
 import { icUsersAdminInitialState } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 import { listUsersInitialState } from "src/core-logic/domain/admin/listUsers/listUsers.slice";
 import { notificationsInitialState } from "src/core-logic/domain/admin/notifications/notificationsSlice";
@@ -17,5 +18,6 @@ export const adminPreloadedState = (
   inclusionConnectedUsersAdmin: icUsersAdminInitialState,
   apiConsumer: apiConsumerInitialState,
   listUsers: listUsersInitialState,
+  fetchUser: fetchUserInitialState,
   ...state,
 });

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.epic.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.epic.ts
@@ -1,0 +1,24 @@
+import { filter, map, switchMap } from "rxjs";
+import { getAdminToken } from "src/core-logic/domain/admin/admin.helpers";
+import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
+import {
+  ActionOfSlice,
+  AppEpic,
+} from "src/core-logic/storeConfig/redux.helpers";
+
+type FetchUserAction = ActionOfSlice<typeof fetchUserSlice>;
+type FetchUserEpic = AppEpic<FetchUserAction>;
+
+const fetchUserEpic: FetchUserEpic = (action$, state$, { adminGateway }) =>
+  action$.pipe(
+    filter(fetchUserSlice.actions.fetchUserRequested.match),
+    switchMap((action) =>
+      adminGateway.getIcUser$(
+        { userId: action.payload.userId },
+        getAdminToken(state$.value),
+      ),
+    ),
+    map(fetchUserSlice.actions.fetchUserSucceeded),
+  );
+
+export const fetchUserEpics = [fetchUserEpic];

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.selectors.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.selectors.ts
@@ -1,0 +1,9 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { RootState } from "src/core-logic/storeConfig/store";
+
+const fetchUserState = ({ admin }: RootState) => admin.fetchUser;
+
+export const adminFetchUserSelectors = {
+  fetchedUser: createSelector(fetchUserState, ({ user }) => user),
+  isFetching: createSelector(fetchUserState, ({ isFetching }) => isFetching),
+};

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
@@ -1,0 +1,29 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { InclusionConnectedUser, UserId } from "shared";
+
+type FetchUserState = {
+  user: InclusionConnectedUser | null;
+  isFetching: boolean;
+};
+
+export const fetchUserInitialState: FetchUserState = {
+  user: null,
+  isFetching: false,
+};
+
+export const fetchUserSlice = createSlice({
+  name: "fetchUser",
+  initialState: fetchUserInitialState,
+  reducers: {
+    fetchUserRequested: (state, _action: PayloadAction<{ userId: UserId }>) => {
+      state.isFetching = true;
+    },
+    fetchUserSucceeded: (
+      state,
+      action: PayloadAction<InclusionConnectedUser>,
+    ) => {
+      state.user = action.payload;
+      state.isFetching = false;
+    },
+  },
+});

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
@@ -1,0 +1,46 @@
+import {
+  InclusionConnectedUser,
+  InclusionConnectedUserBuilder,
+  expectToEqual,
+} from "shared";
+import { adminFetchUserSelectors } from "src/core-logic/domain/admin/fetchUser/fetchUser.selectors";
+import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
+import {
+  TestDependencies,
+  createTestStore,
+} from "src/core-logic/storeConfig/createTestStore";
+import { ReduxStore } from "src/core-logic/storeConfig/store";
+
+const icUser = new InclusionConnectedUserBuilder().build();
+
+describe("Admin Users slice", () => {
+  let store: ReduxStore;
+  let dependencies: TestDependencies;
+
+  beforeEach(() => {
+    ({ store, dependencies } = createTestStore());
+  });
+
+  it("fetches the user successfully", () => {
+    expectToEqual(adminFetchUserSelectors.isFetching(store.getState()), false);
+    expectToEqual(adminFetchUserSelectors.fetchedUser(store.getState()), null);
+
+    store.dispatch(
+      fetchUserSlice.actions.fetchUserRequested({ userId: icUser.id }),
+    );
+
+    expectToEqual(adminFetchUserSelectors.isFetching(store.getState()), true);
+
+    feedWithUsers(icUser);
+
+    expectToEqual(adminFetchUserSelectors.isFetching(store.getState()), false);
+    expectToEqual(
+      adminFetchUserSelectors.fetchedUser(store.getState()),
+      icUser,
+    );
+  });
+
+  const feedWithUsers = (icUser: InclusionConnectedUser) => {
+    dependencies.adminGateway.getIcUserResponse$.next(icUser);
+  };
+});

--- a/front/src/core-logic/ports/AdminGateway.ts
+++ b/front/src/core-logic/ports/AdminGateway.ts
@@ -12,6 +12,7 @@ import {
   NotificationsByKind,
   RejectIcUserRoleForAgencyParams,
   SetFeatureFlagParam,
+  UserId,
   UserInList,
   UserParamsForAgency,
   WithAgencyIdAndUserId,
@@ -73,4 +74,9 @@ export interface AdminGateway {
     params: GetUsersFilters,
     token: InclusionConnectJwt,
   ): Observable<UserInList[]>;
+
+  getIcUser$(
+    params: { userId: UserId },
+    token: InclusionConnectJwt,
+  ): Observable<InclusionConnectedUser>;
 }

--- a/front/src/core-logic/storeConfig/store.ts
+++ b/front/src/core-logic/storeConfig/store.ts
@@ -7,6 +7,8 @@ import { agenciesAdminEpics } from "src/core-logic/domain/admin/agenciesAdmin/ag
 import { agencyAdminSlice } from "src/core-logic/domain/admin/agenciesAdmin/agencyAdmin.slice";
 import { dashboardUrlsEpics } from "src/core-logic/domain/admin/dashboardUrls/dashboardUrls.epics";
 import { dashboardUrlsSlice } from "src/core-logic/domain/admin/dashboardUrls/dashboardUrls.slice";
+import { fetchUserEpics } from "src/core-logic/domain/admin/fetchUser/fetchUser.epic";
+import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
 import { icUsersAdminEpics } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.epics";
 import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
 import { listUsersEpics } from "src/core-logic/domain/admin/listUsers/listUsers.epics";
@@ -70,6 +72,7 @@ const allEpics: AppEpic<any>[] = [
   ...searchEpics,
   ...siretEpics,
   ...listUsersEpics,
+  ...fetchUserEpics,
 ];
 
 const appReducer = combineReducers({
@@ -80,6 +83,7 @@ const appReducer = combineReducers({
     [notificationsSlice.name]: notificationsSlice.reducer,
     [apiConsumerSlice.name]: apiConsumerSlice.reducer,
     [listUsersSlice.name]: listUsersSlice.reducer,
+    [fetchUserSlice.name]: fetchUserSlice.reducer,
   }),
   [agencyAdminSlice.name]: agencyAdminSlice.reducer,
   [agenciesSlice.name]: agenciesSlice.reducer,

--- a/libs/react-design-system/src/immersionFacile/components/tag/Tag.scss
+++ b/libs/react-design-system/src/immersionFacile/components/tag/Tag.scss
@@ -16,4 +16,19 @@
     background-color: var(--background-contrast-blue-cumulus);
     border: 1px solid var(--text-label-blue-cumulus);
   }
+  &--prescripteur {
+    color: var(--text-label-purple-glycine);
+    background-color: var(--background-contrast-purple-glycine);
+    border: 1px solid var(--text-label-purple-glycine);
+  }
+  &--structureAccompagnement {
+    color: var(--text-label-purple-glycine);
+    background-color: var(--background-contrast-purple-glycine);
+    border: 1px solid var(--text-label-purple-glycine);
+  }
+  &--entreprise {
+    color: var(--text-label-blue-cumulus);
+    background-color: var(--background-contrast-blue-cumulus);
+    border: 1px solid var(--text-label-blue-cumulus);
+  }
 }

--- a/libs/react-design-system/src/immersionFacile/components/tag/Tag.styles.ts
+++ b/libs/react-design-system/src/immersionFacile/components/tag/Tag.styles.ts
@@ -6,4 +6,7 @@ export default {
   superEnterprise: "im-tag--super-enterprise",
   lbb: "im-tag--lbb",
   voluntaryToImmersion: "im-tag--voluntaryToImmersion",
+  prescripteur: "im-tag--prescripteur",
+  structureAccompagnement: "im-tag--structureAccompagnement",
+  entreprise: "im-tag--entreprise",
 };

--- a/libs/react-design-system/src/immersionFacile/components/tag/Tag.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/tag/Tag.tsx
@@ -7,10 +7,19 @@ import React from "react";
 import { useStyles } from "tss-react/dsfr";
 import Styles from "./Tag.styles";
 
-type ThemeTag = "rqth" | "superEnterprise" | "lbb" | "voluntaryToImmersion";
+type ThemeTag =
+  | "rqth"
+  | "superEnterprise"
+  | "lbb"
+  | "voluntaryToImmersion"
+  | "prescripteur"
+  | "structureAccompagnement"
+  | "entreprise";
 
 type TagProps = {
   theme: ThemeTag;
+  label?: string;
+  className?: string;
 };
 
 type Themes = Record<
@@ -38,9 +47,21 @@ const themes: Themes = {
     label: "Entreprise accueillante",
     iconId: "fr-icon-team-line",
   },
+  prescripteur: {
+    iconId: "fr-icon-map-pin-user-line",
+    label: "Prescripteur",
+  },
+  structureAccompagnement: {
+    iconId: "fr-icon-parent-line",
+    label: "Prescripteur",
+  },
+  entreprise: {
+    iconId: "fr-icon-building-line",
+    label: "Entreprise",
+  },
 };
 
-export const Tag = ({ theme }: TagProps) => {
+export const Tag = ({ theme, label, className }: TagProps) => {
   const selectedTheme = themes[theme];
   const { cx } = useStyles();
   return (
@@ -49,10 +70,11 @@ export const Tag = ({ theme }: TagProps) => {
         fr.cx("fr-mx-1w", "fr-my-1v", "fr-text--xs"),
         Styles.root,
         Styles[theme],
+        className,
       )}
       iconId={selectedTheme.iconId}
     >
-      {selectedTheme.label}
+      {label ?? selectedTheme.label}
     </DsfrTag>
   );
 };

--- a/shared/src/admin/admin.routes.ts
+++ b/shared/src/admin/admin.routes.ts
@@ -154,4 +154,15 @@ export const adminRoutes = defineRoutes({
       401: httpErrorSchema,
     },
   }),
+  getIcUser: defineRoute({
+    method: "get",
+    url: "/admin/inclusion-connected-users/:userId",
+    ...withAuthorizationHeaders,
+    responses: {
+      200: inclusionConnectedUserSchema,
+      401: httpErrorSchema,
+      403: httpErrorSchema,
+      404: httpErrorSchema,
+    },
+  }),
 });

--- a/shared/src/admin/adminTabs.ts
+++ b/shared/src/admin/adminTabs.ts
@@ -18,12 +18,12 @@ export const adminTabs = {
     slug: "agencies",
     isVisible: () => true,
   },
-  adminUsers: {
-    slug: "users",
-    isVisible: () => true,
-  },
   adminEstablishments: {
     slug: "establishments",
+    isVisible: () => true,
+  },
+  adminUsers: {
+    slug: "users",
     isVisible: () => true,
   },
   adminNotifications: {

--- a/shared/src/agency/agency.dto.ts
+++ b/shared/src/agency/agency.dto.ts
@@ -79,7 +79,7 @@ export const agencyKindList = [
 
 export type AllowedAgencyKindToAdd = Exclude<AgencyKind, "immersion-facile">;
 
-export const agencyKindToLabel: Record<AgencyKind, string> = {
+export const agencyKindToLabel: Record<AllowedAgencyKindToAdd, string> = {
   "mission-locale": "Mission Locale",
   "pole-emploi": "France Travail (anciennement Pôle emploi)",
   "cap-emploi": "Cap Emploi",
@@ -91,7 +91,11 @@ export const agencyKindToLabel: Record<AgencyKind, string> = {
   cma: "Chambre des métiers de l'Artisanat",
   "chambre-agriculture": "Chambre d'agriculture",
   autre: "Autre",
-  "immersion-facile": "Immersion Facile",
+};
+
+export const agencyKindToLabelIncludingIF: Record<AgencyKind, string> = {
+  ...agencyKindToLabel,
+  "immersion-facile": "Immersion Facilitée",
 };
 
 export const allAgencyKindsAllowedToAdd = keys(agencyKindToLabel);

--- a/shared/src/agency/agency.dto.ts
+++ b/shared/src/agency/agency.dto.ts
@@ -79,7 +79,7 @@ export const agencyKindList = [
 
 export type AllowedAgencyKindToAdd = Exclude<AgencyKind, "immersion-facile">;
 
-export const agencyKindToLabel: Record<AllowedAgencyKindToAdd, string> = {
+export const agencyKindToLabel: Record<AgencyKind, string> = {
   "mission-locale": "Mission Locale",
   "pole-emploi": "France Travail (anciennement Pôle emploi)",
   "cap-emploi": "Cap Emploi",
@@ -91,6 +91,7 @@ export const agencyKindToLabel: Record<AllowedAgencyKindToAdd, string> = {
   cma: "Chambre des métiers de l'Artisanat",
   "chambre-agriculture": "Chambre d'agriculture",
   autre: "Autre",
+  "immersion-facile": "Immersion Facile",
 };
 
 export const allAgencyKindsAllowedToAdd = keys(agencyKindToLabel);


### PR DESCRIPTION
- **rework admin front routes to avoid using a params for tabs, making it easier to extend**
- **fix playwright typecheck**
- **add slug to admin routes**
- **making manage convention admin sub part of admin routes (/admin/conventions/:conventionId)**
- **add admin user detail route**
- **implement Redux logic to fetch a user as an admin + add a backend route specific for this (using an existing usecaes)**
