### PR TITLE
#1854 - wording Pole Emploi devient France Travail dans la page de partage de convention

### DIFF
--- a/front/src/app/pages/convention/ConventionImmersionPage.tsx
+++ b/front/src/app/pages/convention/ConventionImmersionPage.tsx
@@ -217,8 +217,8 @@ const SharedConventionMessage = ({
             "fr-link--icon-right",
           )}
         >
-          Ou continuer avec mes identifiants Pôle emploi (candidats inscrits à
-          Pôle emploi)
+          Ou continuer avec mes identifiants France Travail (candidats inscrits
+          à France Travail)
         </a>
       </p>
     </div>


### PR DESCRIPTION
Anciennement :

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/6f1ee9a9-e07d-4cd7-98fe-db45ffc8e716">

Devient :

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/c25f7532-2b2c-4439-9a21-9c6f12b2999a">
