### PR TITLE
FIX - Pouvoir sélectionner une date à cheval sur le changement d'heure

### DIFF
--- a/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
@@ -1,5 +1,5 @@
 import { fr } from "@codegouvfr/react-dsfr";
-import { addDays, differenceInDays } from "date-fns";
+import { addDays, differenceInCalendarDays } from "date-fns";
 import { uniq } from "ramda";
 import React from "react";
 import {
@@ -43,7 +43,7 @@ export const WeekdayPicker = ({
     day: WeekdayNumber,
     { start, end }: DateIntervalDto,
   ) => {
-    const startEndDiff = differenceInDays(end, start);
+    const startEndDiff = differenceInCalendarDays(end, start);
     if (startEndDiff > maximumCalendarDayByInternshipKind[internshipKind])
       return false;
     const uniqueWeekDaysOnInterval = uniq(


### PR DESCRIPTION
## Problème

Sur une création de convention du 26/10/2024 au 01/11/2024, le vendredi du WeekdayPicker est grisé et impossible de le sélectionner.