### PR TITLE
#2400 - Fix bouton de retour au pilotage des établissements uniquement en admin

### DIFF
--- a/front/src/app/components/forms/establishment/EstablishmentForm.tsx
+++ b/front/src/app/components/forms/establishment/EstablishmentForm.tsx
@@ -395,15 +395,17 @@ export const EstablishmentForm = ({ mode }: EstablishmentFormProps) => {
           {match(currentStep)
             .with(null, () => (
               <>
-                <Button
-                  onClick={() => {
-                    routes.adminEstablishments().push();
-                  }}
-                  children="Retour au pilotage des établissements"
-                  type="button"
-                  priority="secondary"
-                  className={fr.cx("fr-mb-4w")}
-                />
+                {isEstablishmentAdmin && (
+                  <Button
+                    onClick={() => {
+                      routes.adminEstablishments().push();
+                    }}
+                    children="Retour au pilotage des établissements"
+                    type="button"
+                    priority="secondary"
+                    className={fr.cx("fr-mb-4w")}
+                  />
+                )}
                 <h1>Pilotage de l'entreprise {formValues.siret}</h1>
                 <h2>{steps[1].title}</h2>
                 <AvailabilitySection


### PR DESCRIPTION
Vérification en local:
- Création établissement en mode form à étape > exclu
- Modification établissement par lien magique en mode form à étape > exclu
- Modification établissement en mode connecté en mode form complet mais en mode tab > exclu tant qu'on a pas un approche responsable d'établissements multiple

Il reste la modification en mode Pilotage Etablissement en Admin qui navigue sur une page dédiée et nécessite un retour au menu de pilotage des établissement où on peut avoir le tableau de bord Metabase des établissements.