### PR TITLE
#2388 - Empêcher de demander la synchronisation de la même convention plusieurs fois d'affilée.

### DIFF
--- a/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
@@ -1,4 +1,5 @@
 import { values } from "ramda";
+import { ConventionId } from "shared";
 import { createLogger } from "../../../../utils/logger";
 import { DomainEvent, EventStatus } from "../events";
 import { OutboxRepository } from "../ports/OutboxRepository";
@@ -34,5 +35,23 @@ export class InMemoryOutboxRepository implements OutboxRepository {
         status: "in-process",
       };
     });
+  }
+
+  public async getLastUnpublishedConventionBroadcastRequestedEventByConventionId(
+    conventionId: ConventionId,
+  ): Promise<DomainEvent | undefined> {
+    const filteredEvents = values(this._events).filter(
+      (event) =>
+        event.topic === "ConventionBroadcastRequested" &&
+        event.status !== "published" &&
+        event.payload.convention.id === conventionId,
+    );
+
+    const sortedEvents = filteredEvents.sort(
+      (a, b) =>
+        new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime(),
+    );
+
+    return sortedEvents[0] || undefined;
   }
 }

--- a/back/src/domains/core/events/ports/OutboxRepository.ts
+++ b/back/src/domains/core/events/ports/OutboxRepository.ts
@@ -1,7 +1,11 @@
+import { ConventionId } from "shared";
 import { DomainEvent, EventStatus } from "../events";
 
 export interface OutboxRepository {
   countAllEvents(params: { status: EventStatus }): Promise<number>;
   save: (event: DomainEvent) => Promise<void>;
   markEventsAsInProcess: (events: DomainEvent[]) => Promise<void>;
+  getLastUnpublishedConventionBroadcastRequestedEventByConventionId: (
+    conventionId: ConventionId,
+  ) => Promise<DomainEvent | undefined>;
 }

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -384,6 +384,10 @@ export const errors = {
           showGMT: true,
         })}. Merci d'essayer à nouveau dans ${params.formattedWaitingTime}.`,
       ),
+    requestAlreadyInProcess: () =>
+      new TooManyRequestApiError(
+        "Il y a déjà une synchronisation en cours. Cela peut prendre quelques instants. Merci de réessayer plus tard.",
+      ),
   },
   discussion: {
     badSiretFilter: () =>


### PR DESCRIPTION
- throw error when broadcast request already in process
- implement getLastUnpublishedConventionBroadcastRequestedEventByConventionId in outbox repo
