### PR TITLE
remise en place du bouton 'piloter la convention' pour accès rapide à une convention avec son ID

### DIFF
--- a/front/src/app/components/SelectConventionFromIdForm.tsx
+++ b/front/src/app/components/SelectConventionFromIdForm.tsx
@@ -1,0 +1,73 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { zodResolver } from "@hookform/resolvers/zod";
+import React from "react";
+import { useForm } from "react-hook-form";
+import {
+  ManageConventionAdminForm,
+  domElementIds,
+  manageConventionAdminFormSchema,
+} from "shared";
+import { makeFieldError } from "src/app/hooks/formContents.hooks";
+import { routes } from "src/app/routes/routes";
+import { Route } from "type-route";
+
+type SelectConventionFromIdFormProps = {
+  routeNameToRedirectTo: Route<
+    | typeof routes.adminConventionDetail
+    | typeof routes.manageConventionInclusionConnected
+  >["name"];
+};
+
+export const SelectConventionFromIdForm = ({
+  routeNameToRedirectTo,
+}: SelectConventionFromIdFormProps): JSX.Element => {
+  const { register, handleSubmit, formState, setValue } =
+    useForm<ManageConventionAdminForm>({
+      resolver: zodResolver(manageConventionAdminFormSchema),
+      mode: "onTouched",
+    });
+  const { isValid } = formState;
+  return (
+    <>
+      <h2 className={fr.cx("fr-h5", "fr-mb-2w")}>Piloter une convention</h2>
+      <div className={fr.cx("fr-card", "fr-px-4w", "fr-py-2w", "fr-mb-4w")}>
+        <form
+          onSubmit={handleSubmit(({ conventionId }) => {
+            routes[routeNameToRedirectTo]({ conventionId }).push();
+          })}
+        >
+          <div className={fr.cx("fr-grid-row")}>
+            <Input
+              label="Id de la convention *"
+              nativeInputProps={{
+                ...register("conventionId"),
+                id: "manageConventionAdminForm-conventionId",
+                placeholder: "Id de la convention",
+                onChange: (event) => {
+                  setValue("conventionId", event.currentTarget.value.trim(), {
+                    shouldValidate: true,
+                  });
+                },
+              }}
+              className={fr.cx("fr-col-12", "fr-col-lg-6")}
+              {...makeFieldError(formState)("conventionId")}
+            />
+          </div>
+          <Button
+            title="Piloter la convention"
+            disabled={!isValid}
+            className={fr.cx("fr-mt-2w")}
+            id={
+              domElementIds.establishmentDashboard.manageConventionForm
+                .submitButton
+            }
+          >
+            Piloter la convention
+          </Button>
+        </form>
+      </div>
+    </>
+  );
+};

--- a/front/src/app/pages/admin/ConventionTab.tsx
+++ b/front/src/app/pages/admin/ConventionTab.tsx
@@ -1,6 +1,7 @@
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import React from "react";
 import { MetabaseView } from "src/app/components/MetabaseView";
+import { SelectConventionFromIdForm } from "src/app/components/SelectConventionFromIdForm";
 import { useAdminDashboard } from "src/app/pages/admin/useAdminDashboard";
 
 export const ConventionTab = () => {
@@ -8,10 +9,13 @@ export const ConventionTab = () => {
   return error ? (
     <Alert severity="error" title="Erreur" description={error} />
   ) : (
-    <MetabaseView
-      title="Consulter les conventions"
-      subtitle="Cliquer sur l'identifiant de la convention pour y accéder."
-      url={url}
-    />
+    <>
+      <SelectConventionFromIdForm routeNameToRedirectTo="adminConventionDetail" />
+      <MetabaseView
+        title="Consulter les conventions"
+        subtitle="Cliquer sur l'identifiant de la convention pour y accéder."
+        url={url}
+      />
+    </>
   );
 };

--- a/front/src/app/pages/agency-dashboard/AgencyDashboardPage.tsx
+++ b/front/src/app/pages/agency-dashboard/AgencyDashboardPage.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Loader } from "react-design-system";
 import { AgencyRight, InclusionConnectedUser, domElementIds } from "shared";
 import { MetabaseView } from "src/app/components/MetabaseView";
+import { SelectConventionFromIdForm } from "src/app/components/SelectConventionFromIdForm";
 import { SubmitFeedbackNotification } from "src/app/components/SubmitFeedbackNotification";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { isAgencyDashboardTab } from "src/app/routes/routeParams/agencyDashboardTabs";
@@ -45,11 +46,14 @@ export const AgencyDashboardPage = ({
             tabId: "dashboard",
             label: "Tableau de bord",
             content: (
-              <MetabaseView
-                title="Tableau de bord agence"
-                subtitle="Cliquer sur l'identifiant de la convention pour y accéder."
-                url={agencyDashboardUrl}
-              />
+              <>
+                <SelectConventionFromIdForm routeNameToRedirectTo="manageConventionInclusionConnected" />
+                <MetabaseView
+                  title="Tableau de bord agence"
+                  subtitle="Cliquer sur l'identifiant de la convention pour y accéder."
+                  url={agencyDashboardUrl}
+                />
+              </>
             ),
           },
         ]

--- a/front/src/app/pages/establishment-dashboard/EstablishmentDashboardPage.tsx
+++ b/front/src/app/pages/establishment-dashboard/EstablishmentDashboardPage.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { Loader } from "react-design-system";
 import { EstablishmentRole, InclusionConnectedUser } from "shared";
 import { MetabaseView } from "src/app/components/MetabaseView";
+import { SelectConventionFromIdForm } from "src/app/components/SelectConventionFromIdForm";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 
 import { DiscussionManageContent } from "src/app/components/admin/establishments/DiscussionManageContent";
@@ -45,6 +46,7 @@ export const EstablishmentDashboardPage = ({
       tabId: "conventions",
       content: (
         <>
+          <SelectConventionFromIdForm routeNameToRedirectTo="manageConventionInclusionConnected" />
           {conventions ? (
             <MetabaseView
               title={`Tableau des conventions en cours


### PR DESCRIPTION
Retour de ce bloc :

<img width="954" alt="image" src="https://github.com/user-attachments/assets/ab21a31e-3bd3-4daf-80ca-b5ed656fa993">
