### PR TITLE
#2190 - dans la vue d'agence admin, les utilsateurs sont séparés entre structure d'accompagnement et agence parente

### DIFF
--- a/front/src/app/components/agency/AgencyTag.tsx
+++ b/front/src/app/components/agency/AgencyTag.tsx
@@ -1,15 +1,14 @@
 import React from "react";
 import { Tag } from "react-design-system";
-import { WithAgencyDto } from "shared";
 
 export const AgencyTag = ({
-  agency,
+  refersToAgencyName,
   className,
-}: WithAgencyDto & { className?: string }) =>
-  agency.refersToAgencyId ? (
+}: { refersToAgencyName: string | null } & { className?: string }) =>
+  refersToAgencyName ? (
     <Tag
       theme={"structureAccompagnement"}
-      label={`Structure d'accompagnement liée à ${agency.refersToAgencyName}`}
+      label={`Structure d'accompagnement liée à ${refersToAgencyName}`}
       className={className}
     />
   ) : (

--- a/front/src/app/components/agency/AgencyUsersTable.tsx
+++ b/front/src/app/components/agency/AgencyUsersTable.tsx
@@ -1,0 +1,77 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
+import { ButtonsGroup } from "@codegouvfr/react-dsfr/ButtonsGroup";
+import { Table } from "@codegouvfr/react-dsfr/Table";
+import React from "react";
+import { AgencyDto, domElementIds } from "shared";
+import { NameAndEmailInTable } from "src/app/components/admin/NameAndEmailInTable";
+import { agencyRoleToDisplay } from "src/app/components/agency/AgencyUsers";
+import { NormalizedInclusionConnectedUser } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
+
+type AgencyUsersTableProps = {
+  agencyUsers: NormalizedInclusionConnectedUser[];
+  agency: AgencyDto;
+  onModifyClicked: (user: NormalizedInclusionConnectedUser) => void;
+  onDeleteClicked: (user: NormalizedInclusionConnectedUser) => void;
+};
+
+export const AgencyUsersTable = ({
+  agency,
+  agencyUsers,
+  onModifyClicked,
+  onDeleteClicked,
+}: AgencyUsersTableProps) => (
+  <Table
+    fixed
+    id={domElementIds.admin.agencyTab.agencyUsersTable}
+    headers={[
+      "Utilisateurs",
+      "Préférence de communication",
+      "Rôles",
+      "Actions",
+    ]}
+    data={agencyUsers.map((agencyUser, index) => [
+      <NameAndEmailInTable
+        firstName={agencyUser.firstName}
+        lastName={agencyUser.lastName}
+        email={agencyUser.email}
+      />,
+      agencyUser.agencyRights[agency.id].isNotifiedByEmail
+        ? "Reçoit les notifications"
+        : "Ne reçoit pas les notifications",
+      agencyUser.agencyRights[agency.id].roles.map((role) => {
+        return (
+          <Badge
+            small
+            className={fr.cx(agencyRoleToDisplay[role].className, "fr-mr-1w")}
+          >
+            {agencyRoleToDisplay[role].label}
+          </Badge>
+        );
+      }),
+      <ButtonsGroup
+        inlineLayoutWhen={"always"}
+        buttons={[
+          {
+            children: "Modifier",
+            priority: "secondary",
+            disabled:
+              agency.refersToAgencyId !== null &&
+              agencyUser.agencyRights[agency.id].roles.includes("validator"),
+            id: `${domElementIds.admin.agencyTab.editAgencyUserRoleButton}-${agency.id}-${index}`,
+            onClick: () => onModifyClicked(agencyUser),
+          },
+          {
+            children: "Supprimer",
+            priority: "secondary",
+            disabled:
+              agency.refersToAgencyId !== null &&
+              agencyUser.agencyRights[agency.id].roles.includes("validator"),
+            id: `${domElementIds.admin.agencyTab.editAgencyRemoveUserButton}-${agency.id}-${index}`,
+            onClick: () => onDeleteClicked(agencyUser),
+          },
+        ]}
+      />,
+    ])}
+  />
+);

--- a/front/src/app/components/agency/EditAgency.tsx
+++ b/front/src/app/components/agency/EditAgency.tsx
@@ -24,7 +24,10 @@ export const EditAgency = () => {
       </div>
       {agency && (
         <>
-          <AgencyTag agency={agency} className={fr.cx("fr-my-4w")} />
+          <AgencyTag
+            refersToAgencyName={agency.refersToAgencyName}
+            className={fr.cx("fr-my-4w")}
+          />
           <EditAgencyForm agency={agency} />
         </>
       )}

--- a/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
+++ b/front/src/app/components/forms/agency/AdminAgencyDetail.tsx
@@ -66,7 +66,10 @@ export const AdminAgencyDetail = ({ route }: AdminAgencyDetailProps) => {
       />
       {agency && (
         <>
-          <AgencyTag agency={agency} className={fr.cx("fr-my-2w")} />
+          <AgencyTag
+            refersToAgencyName={agency.refersToAgencyName}
+            className={fr.cx("fr-my-2w")}
+          />
           <EditAgencyForm agency={agency} />
         </>
       )}

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -84,7 +84,9 @@ const AgenciesTable = ({ agencyRights }: { agencyRights: AgencyRight[] }) => {
         data={agencyRights.map((agencyRight) => {
           return [
             <>
-              <AgencyTag agency={agencyRight.agency} />
+              <AgencyTag
+                refersToAgencyName={agencyRight.agency.refersToAgencyName}
+              />
               <br />
               <span>{agencyRight.agency.name}</span>
               <br />

--- a/front/src/core-logic/domain/admin/listUsers/listUsers.epics.ts
+++ b/front/src/core-logic/domain/admin/listUsers/listUsers.epics.ts
@@ -34,7 +34,7 @@ const triggerFetchOnQueryChangeEpic: ListUserActionEpic = (
     distinctUntilChanged(),
     map((action) =>
       listUsersSlice.actions.fetchUsersRequested({
-        emailContains: action.payload,
+        emailContains: action.payload.trim(),
       }),
     ),
   );


### PR DESCRIPTION
Voilà un aperçu de la nouvelle version pour les structures d'accompagnement :
![Image](https://github.com/user-attachments/assets/9d3ee0b1-6130-4d33-b96e-8e7c9e851655)



Et pour les prescripteurs (une agence qui ne réfère pas à une autre) :
![Image](https://github.com/user-attachments/assets/16a0a0eb-c42f-4625-8cf5-5a78120603b1)

