### PR TITLE
#2388 - ajout d'un delai de 10 secondes avant de pouvoir diffuser de nouveau une convention

### DIFF
--- a/front/src/core-logic/domain/convention/convention.epics.ts
+++ b/front/src/core-logic/domain/convention/convention.epics.ts
@@ -1,4 +1,4 @@
-import { concatMap, filter, map, switchMap } from "rxjs";
+import { concatMap, delay, filter, map, switchMap } from "rxjs";
 import { isEstablishmentTutorIsEstablishmentRepresentative } from "shared";
 import { getAdminToken } from "src/core-logic/domain/admin/admin.helpers";
 import { catchEpicError } from "src/core-logic/storeConfig/catchEpicError";
@@ -172,10 +172,12 @@ const renewConventionEpic: ConventionEpic = (
     ),
   );
 
+const minimumDelayBeforeItIsPossibleToBroadcastAgainMs = 10_000;
+
 const broadcastConventionAgainEpic: ConventionEpic = (
   action$,
   state$,
-  { conventionGateway },
+  { conventionGateway, scheduler },
 ) =>
   action$.pipe(
     filter(conventionSlice.actions.broadcastConventionToPartnerRequested.match),
@@ -186,6 +188,7 @@ const broadcastConventionAgainEpic: ConventionEpic = (
           getAdminToken(state$.value),
         )
         .pipe(
+          delay(minimumDelayBeforeItIsPossibleToBroadcastAgainMs, scheduler),
           map(() =>
             conventionSlice.actions.broadcastConventionToPartnerSucceeded({
               feedbackTopic: payload.feedbackTopic,

--- a/front/src/core-logic/domain/convention/convention.test.ts
+++ b/front/src/core-logic/domain/convention/convention.test.ts
@@ -887,7 +887,7 @@ describe("Convention slice", () => {
   });
 
   describe("Broadcast convention to partner", () => {
-    it("successfully trigger the broadcast", () => {
+    it("successfully trigger the broadcast, than needs to wait for a delay before broadcast is considered successfull", () => {
       store.dispatch(
         conventionSlice.actions.broadcastConventionToPartnerRequested({
           conventionId: "aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa",
@@ -903,8 +903,15 @@ describe("Convention slice", () => {
       );
 
       expectConventionState({
+        isBroadcasting: true,
+      });
+
+      fastForwardObservables();
+
+      expectConventionState({
         isBroadcasting: false,
       });
+
       expectToEqual(feedbacksSelectors.feedbacks(store.getState()), {
         "broadcast-convention-again": {
           on: "create",
@@ -1322,16 +1329,21 @@ describe("Convention slice", () => {
   const expectIsMinorToBe = (expected: boolean) => {
     expectToEqual(conventionSelectors.isMinor(store.getState()), expected);
   };
+
   const expectIsLoadingToBe = (expected: boolean) => {
     expectToEqual(conventionSelectors.isLoading(store.getState()), expected);
   };
+
   const expectIsTutorEstablishmentRepresentativeToBe = (expected: boolean) => {
     expectToEqual(
       conventionSelectors.isTutorEstablishmentRepresentative(store.getState()),
       expected,
     );
   };
+
   const expectFeedbackToBe = (expected: ConventionSubmitFeedback) => {
     expectToEqual(conventionSelectors.feedback(store.getState()), expected);
   };
+
+  const fastForwardObservables = () => dependencies.scheduler.flush();
 });

--- a/front/src/core-logic/domain/feedback/feedback.slice.ts
+++ b/front/src/core-logic/domain/feedback/feedback.slice.ts
@@ -85,6 +85,12 @@ export const feedbackMapping: Record<
       message:
         "La convention a bien été rediffusée au partenaire. Vous pouvez vous rapprocher du partenaire pour le vérifier.",
     },
+    "create.info": {
+      action: conventionSlice.actions.broadcastConventionToPartnerRequested,
+      title: "La convention est en cours de rediffusion",
+      message:
+        "La convention est en cours de rediffusion au partenaire. Cela peut prendre une quinzaine de secondes.",
+    },
     "create.error": {
       action: conventionSlice.actions.broadcastConventionToPartnerFailed,
       title: "Problème rencontré lors de la rediffusion au partenaire",


### PR DESCRIPTION
Après clique sur "Rediffuser", on a ce message :
<img width="626" alt="image" src="https://github.com/user-attachments/assets/234edc6a-0c08-4288-85b9-55f5e5ef890c">

Et au bout de 10 secondes :
<img width="732" alt="image" src="https://github.com/user-attachments/assets/3b53d2db-dff1-44e7-93dd-0e5f7cf46102">

