### PR TITLE
#1815 - Gestion des agences de rattachement utilisateur

### DIFF
--- a/back/src/adapters/primary/routers/agencies/createAgenciesRouter.ts
+++ b/back/src/adapters/primary/routers/agencies/createAgenciesRouter.ts
@@ -34,5 +34,16 @@ export const createAgenciesRouter = (deps: AppDependencies) => {
     ),
   );
 
+  sharedAgencyRouter.updateUserRoleForAgency(
+    deps.inclusionConnectAuthMiddleware,
+    (req, res) =>
+      sendHttpResponse(req, res.status(200), () =>
+        deps.useCases.updateUserForAgency.execute(
+          req.body,
+          req.payloads?.currentUser,
+        ),
+      ),
+  );
+
   return expressRouter;
 };

--- a/back/src/adapters/primary/routers/agencies/createAgenciesRouter.ts
+++ b/back/src/adapters/primary/routers/agencies/createAgenciesRouter.ts
@@ -37,7 +37,7 @@ export const createAgenciesRouter = (deps: AppDependencies) => {
   sharedAgencyRouter.updateUserRoleForAgency(
     deps.inclusionConnectAuthMiddleware,
     (req, res) =>
-      sendHttpResponse(req, res.status(200), () =>
+      sendHttpResponse(req, res, () =>
         deps.useCases.updateUserForAgency.execute(
           req.body,
           req.payloads?.currentUser,

--- a/back/src/domains/inclusion-connected-users/helpers/agencyRights.helper.ts
+++ b/back/src/domains/inclusion-connected-users/helpers/agencyRights.helper.ts
@@ -16,6 +16,32 @@ export const rejectIfEditionOfValidatorsOfAgencyWithRefersTo = (
   }
 };
 
+export const rejectIfEditionOfRolesWhenNotBackofficeAdminNorAgencyAdmin = (
+  initialRoles: AgencyRole[],
+  requestedRole: AgencyRole[],
+  isBackofficeAdminNorAgencyAdmin: boolean,
+) => {
+  const areRolesUpdated =
+    initialRoles.sort().join() !== requestedRole.sort().join();
+
+  if (!isBackofficeAdminNorAgencyAdmin && areRolesUpdated)
+    throw errors.user.forbiddenRolesUpdate();
+};
+
+export const rejectIfEditionOfNotificationPreferencesWhenNotAdminNorOwnPreferences =
+  (
+    isOwnPreferences: boolean,
+    areNotificationPreferencesUpdated: boolean,
+    isBackofficeAdminNorAgencyAdmin: boolean,
+  ) => {
+    if (
+      !isBackofficeAdminNorAgencyAdmin &&
+      !isOwnPreferences &&
+      areNotificationPreferencesUpdated
+    )
+      throw errors.user.forbiddenNotificationsPreferencesUpdate();
+  };
+
 export function validateAgencyRights(
   agencyId: AgencyId,
   agencyRights: AgencyUsersRights,

--- a/front/src/app/components/UserDetail.tsx
+++ b/front/src/app/components/UserDetail.tsx
@@ -159,6 +159,7 @@ const AgenciesTable = ({
               {addressDtoToString(agencyRight.agency.address)}
             </span>
 
+            {/* TODO: agency-admin will be able to go to agency page event if not backOfficeAdmin */}
             {agencyRight.roles.includes("agency-admin") &&
               isBackofficeAdmin && (
                 <a

--- a/front/src/app/components/agency/AgencyUserModificationForm.tsx
+++ b/front/src/app/components/agency/AgencyUserModificationForm.tsx
@@ -6,37 +6,29 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import React, { useEffect, useState } from "react";
 import { keys } from "react-design-system";
 import { FormProvider, useForm } from "react-hook-form";
-import { useDispatch } from "react-redux";
 import {
   UserParamsForAgency,
   domElementIds,
   toLowerCaseWithoutDiacritics,
   userParamsForAgencySchema,
 } from "shared";
-import {
-  UserFormMode,
-  agencyRoleToDisplay,
-} from "src/app/components/agency/AgencyUsers";
+import { agencyRoleToDisplay } from "src/app/components/agency/AgencyUsers";
 import { EmailValidationInput } from "src/app/components/forms/commons/EmailValidationInput";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
-import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
-import { match } from "ts-pattern";
 
 export const AgencyUserModificationForm = ({
   agencyUser,
   closeModal,
-  mode,
   agencyHasRefersTo,
   isEmailDisabled,
+  onSubmit,
 }: {
   agencyUser: UserParamsForAgency & { isIcUser: boolean };
   closeModal: () => void;
-  mode: UserFormMode;
   agencyHasRefersTo: boolean;
   isEmailDisabled?: boolean;
+  onSubmit: (userParamsForAgency: UserParamsForAgency) => void;
 }) => {
-  const dispatch = useDispatch();
-
   const methods = useForm<UserParamsForAgency>({
     resolver: zodResolver(userParamsForAgencySchema),
     mode: "onTouched",
@@ -53,35 +45,10 @@ export const AgencyUserModificationForm = ({
     const validatedUserRoles = values.roles.filter(
       (role) => role !== "to-review",
     );
-    match(mode)
-      .with("add", () => {
-        dispatch(
-          icUsersAdminSlice.actions.createUserOnAgencyRequested({
-            ...values,
-            roles: validatedUserRoles,
-            feedbackTopic: "agency-user",
-          }),
-        );
-      })
-      .with("update", () => {
-        dispatch(
-          icUsersAdminSlice.actions.updateUserOnAgencyRequested({
-            ...values,
-            roles: validatedUserRoles,
-            feedbackTopic: "agency-user",
-          }),
-        );
-      })
-      .with("register", () => {
-        dispatch(
-          icUsersAdminSlice.actions.registerAgencyWithRoleToUserRequested({
-            ...values,
-            roles: validatedUserRoles,
-          }),
-        );
-      })
-      .exhaustive();
-
+    onSubmit({
+      ...values,
+      roles: validatedUserRoles,
+    });
     closeModal();
   };
 

--- a/front/src/app/components/agency/AgencyUserModificationForm.tsx
+++ b/front/src/app/components/agency/AgencyUserModificationForm.tsx
@@ -8,7 +8,6 @@ import { keys } from "react-design-system";
 import { FormProvider, useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
 import {
-  AgencyDtoWithoutEmails,
   UserParamsForAgency,
   domElementIds,
   toLowerCaseWithoutDiacritics,
@@ -27,12 +26,14 @@ export const AgencyUserModificationForm = ({
   agencyUser,
   closeModal,
   mode,
-  agency,
+  agencyHasRefersTo,
+  isEmailDisabled,
 }: {
   agencyUser: UserParamsForAgency & { isIcUser: boolean };
   closeModal: () => void;
   mode: UserFormMode;
-  agency: AgencyDtoWithoutEmails;
+  agencyHasRefersTo: boolean;
+  isEmailDisabled?: boolean;
 }) => {
   const dispatch = useDispatch();
 
@@ -111,7 +112,7 @@ export const AgencyUserModificationForm = ({
   });
 
   const checkboxOptionsWithFilter = () => {
-    if (agency && agency.refersToAgencyId !== null)
+    if (agencyHasRefersTo)
       return checkboxOptions.filter((option) => option.label !== "Validateur");
     return checkboxOptions;
   };
@@ -139,7 +140,7 @@ export const AgencyUserModificationForm = ({
             },
           }}
           {...getFieldError("email")}
-          disabled={agencyUser.isIcUser}
+          disabled={isEmailDisabled ?? agencyUser.isIcUser}
           onEmailValidationFeedback={({ state, stateRelatedMessage }) => {
             setInvalidEmailMessage(
               state === "error" ? stateRelatedMessage : null,

--- a/front/src/app/components/agency/AgencyUserModificationForm.tsx
+++ b/front/src/app/components/agency/AgencyUserModificationForm.tsx
@@ -21,12 +21,14 @@ export const AgencyUserModificationForm = ({
   closeModal,
   agencyHasRefersTo,
   isEmailDisabled,
+  areRolesDisabled,
   onSubmit,
 }: {
   agencyUser: UserParamsForAgency & { isIcUser: boolean };
   closeModal: () => void;
   agencyHasRefersTo: boolean;
   isEmailDisabled?: boolean;
+  areRolesDisabled?: boolean;
   onSubmit: (userParamsForAgency: UserParamsForAgency) => void;
 }) => {
   const methods = useForm<UserParamsForAgency>({
@@ -120,6 +122,7 @@ export const AgencyUserModificationForm = ({
           legend="Rôles :"
           {...getFieldError("roles")}
           options={checkboxOptionsWithFilter()}
+          disabled={!!areRolesDisabled}
         />
 
         <ToggleSwitch

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -221,7 +221,7 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
                 agencyUser={selectedUserData}
                 closeModal={() => manageUserModal.close()}
                 mode={mode}
-                agency={agency}
+                agencyHasRefersTo={!!agency.refersToAgencyId}
               />
             </>
           )}

--- a/front/src/app/components/agency/AgencyUsers.tsx
+++ b/front/src/app/components/agency/AgencyUsers.tsx
@@ -71,8 +71,6 @@ export const agencyRoleToDisplay: Record<
   },
 };
 
-export type UserFormMode = "add" | "update" | "register";
-
 const manageUserModal = createModal({
   isOpenedByDefault: false,
   id: domElementIds.admin.agencyTab.editAgencyManageUserModal,
@@ -94,7 +92,7 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
     (UserParamsForAgency & { isIcUser: boolean }) | null
   >(null);
 
-  const [mode, setMode] = useState<UserFormMode | null>(null);
+  const [mode, setMode] = useState<"add" | "update" | null>(null);
 
   const provider = enableProConnect ? "ProConnect" : "Inclusion Connect";
 
@@ -133,6 +131,26 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
         values(agencyUsersById),
       )
     : [values(agencyUsersById), []];
+
+  const onUserUpdateSubmitted = (userParamsForAgency: UserParamsForAgency) => {
+    dispatch(
+      icUsersAdminSlice.actions.updateUserOnAgencyRequested({
+        ...userParamsForAgency,
+        feedbackTopic: "agency-user",
+      }),
+    );
+  };
+
+  const onUserCreationSubmitted = (
+    userParamsForAgency: UserParamsForAgency,
+  ) => {
+    dispatch(
+      icUsersAdminSlice.actions.createUserOnAgencyRequested({
+        ...userParamsForAgency,
+        feedbackTopic: "agency-user",
+      }),
+    );
+  };
 
   return (
     <>
@@ -220,8 +238,12 @@ export const AgencyUsers = ({ agency }: AgencyUsersProperties) => {
               <AgencyUserModificationForm
                 agencyUser={selectedUserData}
                 closeModal={() => manageUserModal.close()}
-                mode={mode}
                 agencyHasRefersTo={!!agency.refersToAgencyId}
+                onSubmit={
+                  mode === "add"
+                    ? onUserCreationSubmitted
+                    : onUserUpdateSubmitted
+                }
               />
             </>
           )}

--- a/front/src/app/components/agency/IcUserAgenciesToReview.tsx
+++ b/front/src/app/components/agency/IcUserAgenciesToReview.tsx
@@ -11,15 +11,14 @@ import {
   AgencyDtoWithoutEmails,
   AgencyId,
   AgencyRight,
-  ExtractFromExisting,
   RejectIcUserRoleForAgencyParams,
   User,
   UserId,
+  UserParamsForAgency,
   domElementIds,
   rejectIcUserRoleForAgencyParamsSchema,
 } from "shared";
 import { AgencyUserModificationForm } from "src/app/components/agency/AgencyUserModificationForm";
-import { UserFormMode } from "src/app/components/agency/AgencyUsers";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
 import { routes } from "src/app/routes/routes";
 import { icUsersAdminSlice } from "src/core-logic/domain/admin/icUsersAdmin/icUsersAdmin.slice";
@@ -30,7 +29,7 @@ type IcUserAgenciesToReviewProps = {
 };
 type IcUserAgenciesToReviewModalProps = {
   title: string;
-  mode: ExtractFromExisting<UserFormMode, "register"> | "reject";
+  mode: "register" | "reject";
 };
 
 function AgencyReviewForm({
@@ -109,10 +108,21 @@ export const IcUserAgenciesToReview = ({
   agenciesNeedingReviewForUser,
   selectedUser,
 }: IcUserAgenciesToReviewProps) => {
+  const dispatch = useDispatch();
   const [selectedAgency, setSelectedAgency] =
     useState<AgencyDtoWithoutEmails>();
   const [modalProps, setModalProps] =
     useState<IcUserAgenciesToReviewModalProps | null>(null);
+
+  const onUserRegistrationSubmitted = (
+    userParamsForAgency: UserParamsForAgency,
+  ) => {
+    dispatch(
+      icUsersAdminSlice.actions.registerAgencyWithRoleToUserRequested(
+        userParamsForAgency,
+      ),
+    );
+  };
 
   return (
     <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
@@ -145,7 +155,7 @@ export const IcUserAgenciesToReview = ({
                   isNotifiedByEmail: true,
                 }}
                 closeModal={closeIcUserRegistrationToAgencyModal}
-                mode={modalProps.mode}
+                onSubmit={onUserRegistrationSubmitted}
                 agencyHasRefersTo={!!selectedAgency.refersToAgencyId}
               />
             )

--- a/front/src/app/components/agency/IcUserAgenciesToReview.tsx
+++ b/front/src/app/components/agency/IcUserAgenciesToReview.tsx
@@ -146,7 +146,7 @@ export const IcUserAgenciesToReview = ({
                 }}
                 closeModal={closeIcUserRegistrationToAgencyModal}
                 mode={modalProps.mode}
-                agency={selectedAgency}
+                agencyHasRefersTo={!!selectedAgency.refersToAgencyId}
               />
             )
           ) : (

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect } from "react";
 import { Loader } from "react-design-system";
 import { useDispatch } from "react-redux";
+import { UserParamsForAgency } from "shared";
 import { UserDetail } from "src/app/components/UserDetail";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { routes } from "src/app/routes/routes";
 import { adminFetchUserSelectors } from "src/core-logic/domain/admin/fetchUser/fetchUser.selectors";
 import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
+import { updateUserOnAgencySelectors } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.selectors";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
+import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
+import { feedbackSlice } from "src/core-logic/domain/feedback/feedback.slice";
 import { Route } from "type-route";
 
 type AdminUserDetailProps = {
@@ -15,7 +20,23 @@ type AdminUserDetailProps = {
 export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
   const icUser = useAppSelector(adminFetchUserSelectors.fetchedUser);
   const isFetchingUser = useAppSelector(adminFetchUserSelectors.isFetching);
+  const isUpdatingUser = useAppSelector(updateUserOnAgencySelectors.isLoading);
   const dispatch = useDispatch();
+
+  const userConnectedJwt = useAppSelector(authSelectors.inclusionConnectToken);
+
+  if (!userConnectedJwt)
+    return <p>Merci de vous connecter pour accéder à cette page.</p>;
+
+  const onUserUpdateRequested = (userParamsForAgency: UserParamsForAgency) => {
+    dispatch(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightRequested({
+        user: userParamsForAgency,
+        jwt: userConnectedJwt,
+        feedbackTopic: "user",
+      }),
+    );
+  };
 
   useEffect(() => {
     dispatch(
@@ -25,7 +46,11 @@ export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
     );
   }, [route.params.userId, dispatch]);
 
-  if (isFetchingUser) return <Loader />;
+  useEffect(() => {
+    dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
+  }, [dispatch]);
+
+  if (isFetchingUser || isUpdatingUser) return <Loader />;
   if (!icUser) return <p>Aucun utilisateur trouvé</p>;
 
   const title =
@@ -33,5 +58,11 @@ export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
       ? `${icUser.firstName} ${icUser.lastName}`
       : icUser.email;
 
-  return <UserDetail title={title} userWithRights={icUser} />;
+  return (
+    <UserDetail
+      title={title}
+      userWithRights={icUser}
+      onUserUpdateRequested={onUserUpdateRequested}
+    />
+  );
 };

--- a/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
@@ -9,6 +9,7 @@ import {
   InclusionConnectJwt,
   ListAgencyOptionsRequestDto,
   UpdateAgencyStatusParams,
+  UserParamsForAgency,
   WithAgencyId,
 } from "shared";
 import { HttpClient } from "shared-routes";
@@ -126,6 +127,30 @@ export class HttpAgencyGateway implements AgencyGateway {
             .with({ status: 200 }, () => undefined)
             .with({ status: 401 }, logBodyAndThrow)
             .with({ status: 409 }, logBodyAndThrow)
+            .otherwise(otherwiseThrow),
+        ),
+    );
+  }
+
+  public updateUserAgencyRight$(
+    params: UserParamsForAgency,
+    token: InclusionConnectJwt,
+  ): Observable<void> {
+    return from(
+      this.httpClient
+        .updateUserRoleForAgency({
+          headers: { authorization: token },
+          urlParams: {
+            agencyId: params.agencyId,
+          },
+          body: params,
+        })
+        .then((response) =>
+          match(response)
+            .with({ status: 200 }, () => undefined)
+            .with({ status: 400 }, logBodyAndThrow)
+            .with({ status: 401 }, logBodyAndThrow)
+            .with({ status: 404 }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
     );

--- a/front/src/core-logic/adapters/AgencyGateway/SimulatedAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/SimulatedAgencyGateway.ts
@@ -145,6 +145,10 @@ export class SimulatedAgencyGateway implements AgencyGateway {
     return of(undefined);
   }
 
+  public updateUserAgencyRight$(): Observable<void> {
+    return of(undefined);
+  }
+
   public validateOrRejectAgency$(
     adminToken: InclusionConnectJwt,
     updateAgencyStatusParams: UpdateAgencyStatusParams,

--- a/front/src/core-logic/adapters/AgencyGateway/TestAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/TestAgencyGateway.ts
@@ -28,6 +28,8 @@ export class TestAgencyGateway implements AgencyGateway {
 
   public updateAgencyResponse$ = new Subject<undefined>();
 
+  public updateUserAgencyRightResponse$ = new Subject<undefined>();
+
   public addAgencyResponse$ = new Subject<undefined>();
 
   #agencies: Record<string, AgencyDto> = {};
@@ -62,6 +64,10 @@ export class TestAgencyGateway implements AgencyGateway {
     _adminToken: InclusionConnectJwt,
   ): Observable<void> {
     return this.updateAgencyResponse$;
+  }
+
+  public updateUserAgencyRight$(): Observable<void> {
+    return this.updateUserAgencyRightResponse$;
   }
 
   public validateOrRejectAgency$(

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
@@ -1,5 +1,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { InclusionConnectedUser, UserId } from "shared";
+import { updateUserAgencyRights } from "src/core-logic/domain/agencies/agencies.helpers";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 
 type FetchUserState = {
   user: InclusionConnectedUser | null;
@@ -25,5 +27,14 @@ export const fetchUserSlice = createSlice({
       state.user = action.payload;
       state.isFetching = false;
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded,
+      (state, action) => {
+        if (!state.user) return;
+        state.user = updateUserAgencyRights(state.user, action.payload);
+      },
+    );
   },
 });

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
@@ -1,10 +1,14 @@
 import {
+  AgencyDtoBuilder,
+  AgencyRight,
   InclusionConnectedUser,
   InclusionConnectedUserBuilder,
   expectToEqual,
 } from "shared";
+import { adminPreloadedState } from "src/core-logic/domain/admin/adminPreloadedState";
 import { adminFetchUserSelectors } from "src/core-logic/domain/admin/fetchUser/fetchUser.selectors";
 import { fetchUserSlice } from "src/core-logic/domain/admin/fetchUser/fetchUser.slice";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 import {
   TestDependencies,
   createTestStore,
@@ -38,6 +42,50 @@ describe("Admin Users slice", () => {
       adminFetchUserSelectors.fetchedUser(store.getState()),
       icUser,
     );
+  });
+
+  it("update the user rights successfully", () => {
+    const agency = new AgencyDtoBuilder().build();
+    const agencyRight: AgencyRight = {
+      agency,
+      roles: ["validator"],
+      isNotifiedByEmail: false,
+    };
+    const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+      .withId("user-id")
+      .withIsAdmin(false)
+      .withAgencyRights([agencyRight])
+      .build();
+
+    ({ store, dependencies } = createTestStore({
+      admin: adminPreloadedState({
+        fetchUser: {
+          user,
+          isFetching: false,
+        },
+      }),
+    }));
+
+    store.dispatch(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+        userId: user.id,
+        agencyId: agency.id,
+        email: user.email,
+        roles: [...agencyRight.roles, "counsellor"],
+        isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+        feedbackTopic: "user",
+      }),
+    );
+
+    expectToEqual(adminFetchUserSelectors.fetchedUser(store.getState()), {
+      ...user,
+      agencyRights: [
+        {
+          ...agencyRight,
+          roles: [...agencyRight.roles, "counsellor"],
+        },
+      ],
+    });
   });
 
   const feedWithUsers = (icUser: InclusionConnectedUser) => {

--- a/front/src/core-logic/domain/agencies/agencies.helpers.ts
+++ b/front/src/core-logic/domain/agencies/agencies.helpers.ts
@@ -1,0 +1,27 @@
+import { InclusionConnectedUser, UserParamsForAgency, errors } from "shared";
+
+export const updateUserAgencyRights = (
+  user: InclusionConnectedUser,
+  requestedUpdate: UserParamsForAgency,
+): InclusionConnectedUser => {
+  const remainingAgencyRights = user.agencyRights.filter(
+    (agencyRight) => agencyRight.agency.id !== requestedUpdate.agencyId,
+  );
+  const updatedAgencyRight = user.agencyRights.find(
+    (agencyight) => agencyight.agency.id === requestedUpdate.agencyId,
+  );
+  if (!updatedAgencyRight)
+    throw errors.agency.notFound({ agencyId: requestedUpdate.agencyId });
+  return {
+    ...user,
+    email: requestedUpdate.email,
+    agencyRights: [
+      ...remainingAgencyRights,
+      {
+        ...updatedAgencyRight,
+        isNotifiedByEmail: requestedUpdate.isNotifiedByEmail,
+        roles: requestedUpdate.roles,
+      },
+    ],
+  };
+};

--- a/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.epic.ts
+++ b/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.epic.ts
@@ -1,0 +1,41 @@
+import { filter, map, switchMap } from "rxjs";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
+import { catchEpicError } from "src/core-logic/storeConfig/catchEpicError";
+import {
+  ActionOfSlice,
+  AppEpic,
+} from "src/core-logic/storeConfig/redux.helpers";
+
+type UpdateUserOnAgencyAction = ActionOfSlice<typeof updateUserOnAgencySlice>;
+type UpdateUserOnAgencyEpic = AppEpic<UpdateUserOnAgencyAction>;
+
+const updateUserAgencyRightEpic: UpdateUserOnAgencyEpic = (
+  action$,
+  _state$,
+  { agencyGateway },
+) =>
+  action$.pipe(
+    filter(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightRequested.match,
+    ),
+    switchMap((action) =>
+      agencyGateway
+        .updateUserAgencyRight$(action.payload.user, action.payload.jwt)
+        .pipe(
+          map(() =>
+            updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+              ...action.payload.user,
+              feedbackTopic: "user",
+            }),
+          ),
+          catchEpicError((error) =>
+            updateUserOnAgencySlice.actions.updateUserAgencyRightFailed({
+              errorMessage: error.message,
+              feedbackTopic: action.payload.feedbackTopic,
+            }),
+          ),
+        ),
+    ),
+  );
+
+export const updateUserOnAgencyEpics = [updateUserAgencyRightEpic];

--- a/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.selectors.ts
+++ b/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.selectors.ts
@@ -1,0 +1,12 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { RootState } from "src/core-logic/storeConfig/store";
+
+const updateUserOnAgencyState = ({ agency }: RootState) =>
+  agency.updateUserOnAgency;
+
+export const updateUserOnAgencySelectors = {
+  isLoading: createSelector(
+    updateUserOnAgencyState,
+    ({ isLoading }) => isLoading,
+  ),
+};

--- a/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice.ts
+++ b/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { InclusionConnectJwt, UserParamsForAgency } from "shared";
+import { PayloadActionWithFeedbackTopic } from "src/core-logic/domain/feedback/feedback.slice";
+
+type UpdateUserOnAgencyState = {
+  isLoading: boolean;
+};
+
+const initialState: UpdateUserOnAgencyState = {
+  isLoading: false,
+};
+
+export const updateUserOnAgencySlice = createSlice({
+  name: "updateUserOnAgency",
+  initialState,
+  reducers: {
+    updateUserAgencyRightRequested: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<{
+        user: UserParamsForAgency;
+        jwt: InclusionConnectJwt;
+      }>,
+    ) => {
+      state.isLoading = true;
+    },
+    updateUserAgencyRightSucceeded: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<UserParamsForAgency>,
+    ) => {
+      state.isLoading = false;
+    },
+    updateUserAgencyRightFailed: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<{ errorMessage: string }>,
+    ) => {
+      state.isLoading = false;
+    },
+  },
+});

--- a/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.test.ts
+++ b/front/src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.test.ts
@@ -1,0 +1,77 @@
+import {
+  AgencyDtoBuilder,
+  AgencyRight,
+  InclusionConnectedUser,
+  InclusionConnectedUserBuilder,
+  expectToEqual,
+} from "shared";
+import { adminPreloadedState } from "src/core-logic/domain/admin/adminPreloadedState";
+import { updateUserOnAgencySelectors } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.selectors";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
+import {
+  TestDependencies,
+  createTestStore,
+} from "src/core-logic/storeConfig/createTestStore";
+import { ReduxStore } from "src/core-logic/storeConfig/store";
+
+describe("UpdateUserOnAgency slice", () => {
+  let store: ReduxStore;
+  let dependencies: TestDependencies;
+
+  beforeEach(() => {
+    ({ store, dependencies } = createTestStore());
+  });
+
+  it("update the user rights successfully", () => {
+    const agency = new AgencyDtoBuilder().build();
+    const agencyRight: AgencyRight = {
+      agency,
+      roles: ["validator"],
+      isNotifiedByEmail: false,
+    };
+    const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+      .withId("user-id")
+      .withIsAdmin(false)
+      .withAgencyRights([agencyRight])
+      .build();
+    ({ store, dependencies } = createTestStore({
+      admin: adminPreloadedState({
+        fetchUser: {
+          user,
+          isFetching: false,
+        },
+      }),
+      agency: {
+        updateUserOnAgency: {
+          isLoading: false,
+        },
+      },
+    }));
+
+    store.dispatch(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightRequested({
+        user: {
+          userId: user.id,
+          agencyId: agency.id,
+          email: user.email,
+          roles: [...agencyRight.roles, "counsellor"],
+          isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+        },
+        jwt: "coonected-user-jwt",
+        feedbackTopic: "user",
+      }),
+    );
+
+    expectToEqual(
+      updateUserOnAgencySelectors.isLoading(store.getState()),
+      true,
+    );
+
+    dependencies.agencyGateway.updateUserAgencyRightResponse$.next(undefined);
+
+    expectToEqual(
+      updateUserOnAgencySelectors.isLoading(store.getState()),
+      false,
+    );
+  });
+});

--- a/front/src/core-logic/domain/feedback/feedback.slice.ts
+++ b/front/src/core-logic/domain/feedback/feedback.slice.ts
@@ -4,6 +4,7 @@ import {
   createSlice,
 } from "@reduxjs/toolkit";
 import { keys } from "shared";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 import { apiConsumerSlice } from "src/core-logic/domain/apiConsumer/apiConsumer.slice";
 import { conventionSlice } from "src/core-logic/domain/convention/convention.slice";
 import { discussionSlice } from "src/core-logic/domain/discussion/discussion.slice";
@@ -23,6 +24,7 @@ const topics = [
   "dashboard-agency-register-user",
   "auth-global",
   "establishments-batch",
+  "user",
 ] as const;
 
 export type FeedbackLevel = "info" | "success" | "warning" | "error";
@@ -212,6 +214,19 @@ export const feedbackMapping: Record<
       action: establishmentBatchSlice.actions.addEstablishmentBatchSucceeded,
       title: "Le groupe d'entreprises a bien été créé",
       message: "L'import en masse a réussi, voici le détail :",
+    },
+  },
+  user: {
+    "update.success": {
+      action: updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded,
+      title: "L'utilisateur a été mis à jour",
+      message: "Les données de l'utilisateur (rôles) ont été mises à jour.",
+    },
+    "update.error": {
+      action: updateUserOnAgencySlice.actions.updateUserAgencyRightFailed,
+      title: "Problème lors de la mise à jour de l'utilisateur",
+      message:
+        "Une erreur est survenue lors de la mise à jour de l'utilisateur",
     },
   },
 };

--- a/front/src/core-logic/domain/inclusionConnected/inclusionConnected.slice.ts
+++ b/front/src/core-logic/domain/inclusionConnected/inclusionConnected.slice.ts
@@ -1,5 +1,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { AgencyDto, InclusionConnectedUser, WithAgencyIds } from "shared";
+import { updateUserAgencyRights } from "src/core-logic/domain/agencies/agencies.helpers";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 import {
   PayloadActionWithFeedbackTopic,
   PayloadActionWithFeedbackTopicError,
@@ -59,5 +61,17 @@ export const inclusionConnectedSlice = createSlice({
     ) => {
       state.isLoading = false;
     },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(
+      updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded,
+      (state, action) => {
+        if (!state.currentUser) return;
+        state.currentUser = updateUserAgencyRights(
+          state.currentUser,
+          action.payload,
+        );
+      },
+    );
   },
 });

--- a/front/src/core-logic/ports/AgencyGateway.ts
+++ b/front/src/core-logic/ports/AgencyGateway.ts
@@ -8,6 +8,7 @@ import {
   InclusionConnectJwt,
   ListAgencyOptionsRequestDto,
   UpdateAgencyStatusParams,
+  UserParamsForAgency,
   WithAgencyId,
 } from "shared";
 
@@ -29,6 +30,10 @@ export interface AgencyGateway {
   updateAgency$(
     agencyDto: AgencyDto,
     adminToken: InclusionConnectJwt,
+  ): Observable<void>;
+  updateUserAgencyRight$(
+    params: UserParamsForAgency,
+    token: InclusionConnectJwt,
   ): Observable<void>;
   validateOrRejectAgency$(
     adminToken: InclusionConnectJwt,

--- a/front/src/core-logic/storeConfig/store.ts
+++ b/front/src/core-logic/storeConfig/store.ts
@@ -15,6 +15,8 @@ import { listUsersEpics } from "src/core-logic/domain/admin/listUsers/listUsers.
 import { listUsersSlice } from "src/core-logic/domain/admin/listUsers/listUsers.slice";
 import { notificationsEpics } from "src/core-logic/domain/admin/notifications/notifications.epics";
 import { notificationsSlice } from "src/core-logic/domain/admin/notifications/notificationsSlice";
+import { updateUserOnAgencyEpics } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.epic";
+import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 import { apiConsumerEpics } from "src/core-logic/domain/apiConsumer/apiConsumer.epics";
 import { apiConsumerSlice } from "src/core-logic/domain/apiConsumer/apiConsumer.slice";
 import { assessmentEpics } from "src/core-logic/domain/assessment/assessment.epics";
@@ -73,6 +75,7 @@ const allEpics: AppEpic<any>[] = [
   ...siretEpics,
   ...listUsersEpics,
   ...fetchUserEpics,
+  ...updateUserOnAgencyEpics,
 ];
 
 const appReducer = combineReducers({
@@ -84,6 +87,9 @@ const appReducer = combineReducers({
     [apiConsumerSlice.name]: apiConsumerSlice.reducer,
     [listUsersSlice.name]: listUsersSlice.reducer,
     [fetchUserSlice.name]: fetchUserSlice.reducer,
+  }),
+  agency: combineReducers({
+    [updateUserOnAgencySlice.name]: updateUserOnAgencySlice.reducer,
   }),
   [agencyAdminSlice.name]: agencyAdminSlice.reducer,
   [agenciesSlice.name]: agenciesSlice.reducer,

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -403,6 +403,14 @@ export const errors = {
       new ForbiddenError(
         "Il n'est pas possible de modifier un mail d'un utilisateur inclusion connecté.",
       ),
+    forbiddenNotificationsPreferencesUpdate: () =>
+      new ForbiddenError(
+        "Vous n'avez pas les droits nécessaires pour modifier ces préférences de notifications.",
+      ),
+    forbiddenRolesUpdate: () =>
+      new ForbiddenError(
+        "Vous n'avez pas les droits nécessaires pour modifier ces rôles.",
+      ),
   },
   broadcastFeedback: {
     notFound: ({

--- a/shared/src/routes/agencyRoutes.ts
+++ b/shared/src/routes/agencyRoutes.ts
@@ -1,4 +1,5 @@
 import { defineRoute, defineRoutes } from "shared-routes";
+import { userParamsForAgencySchema } from "../admin/admin.schema";
 import {
   agencyIdResponseSchema,
   agencyOptionsSchema,
@@ -81,5 +82,17 @@ export const agencyRoutes = defineRoutes({
     url: "/agency-public-info-by-id",
     queryParamsSchema: withAgencyIdSchema,
     responses: { 200: agencyPublicDisplaySchema },
+  }),
+  updateUserRoleForAgency: defineRoute({
+    method: "patch",
+    url: "/agencies/:agencyId/users",
+    requestBodySchema: userParamsForAgencySchema,
+    ...withAuthorizationHeaders,
+    responses: {
+      200: expressEmptyResponseBody,
+      400: httpErrorSchema,
+      401: httpErrorSchema,
+      404: httpErrorSchema,
+    },
   }),
 });


### PR DESCRIPTION
## 🌈 Description

- ETQ Admin IF, pouvoir modifier les rôles et préférences de notifications d'un utilisateur sur la page /admin/users/:idUser
- ETQ Admin d'agence, modifier les rôles et préférences de notifications d'un utilisateur sur la page /admin/users/:idUser
- ETQ utilisateur, pouvoir modifier ses préférences de notifications sur la page /mon-profil

![Screenshot 2024-11-27 at 19 45 08](https://github.com/user-attachments/assets/a1811123-e43d-4ff0-aed2-865cf915da81)
