### PR TITLE
#2363 - Mise à jour du badge de l'agence sur la page de récap de convention

### DIFF
--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -30,9 +30,9 @@ const makeSignatoriesSubsections = (
               key: "beneficiarySignedAt",
               value:
                 convention.signatories.beneficiary.signedAt &&
-                toDisplayedDate({
+                `Signée - Le ${toDisplayedDate({
                   date: new Date(convention.signatories.beneficiary.signedAt),
-                }),
+                })}`,
               badgeSeverity: convention.signatories.beneficiary.signedAt
                 ? "success"
                 : "warning",
@@ -83,12 +83,12 @@ const makeSignatoriesSubsections = (
                   key: "beneficiaryRepSignedAt",
                   value:
                     convention.signatories.beneficiaryRepresentative.signedAt &&
-                    toDisplayedDate({
+                    `Signée - Le ${toDisplayedDate({
                       date: new Date(
                         convention.signatories.beneficiaryRepresentative
                           .signedAt,
                       ),
-                    }),
+                    })}`,
                   badgeSeverity: convention.signatories
                     .beneficiaryRepresentative.signedAt
                     ? "success"
@@ -142,11 +142,11 @@ const makeSignatoriesSubsections = (
               key: "establishmentRepSignedAt",
               value:
                 convention.signatories.establishmentRepresentative.signedAt &&
-                toDisplayedDate({
+                `Signée - Le ${toDisplayedDate({
                   date: new Date(
                     convention.signatories.establishmentRepresentative.signedAt,
                   ),
-                }),
+                })}`,
               badgeSeverity: convention.signatories.establishmentRepresentative
                 .signedAt
                 ? "success"
@@ -206,12 +206,12 @@ const makeSignatoriesSubsections = (
                   value:
                     convention.signatories.beneficiaryCurrentEmployer
                       .signedAt &&
-                    toDisplayedDate({
+                    `Signée - Le ${toDisplayedDate({
                       date: new Date(
                         convention.signatories.beneficiaryCurrentEmployer
                           .signedAt,
                       ),
-                    }),
+                    })}`,
                   badgeSeverity: convention.signatories
                     .beneficiaryCurrentEmployer.signedAt
                     ? "success"
@@ -282,9 +282,9 @@ const makeSignatoriesSubsections = (
               key: "dateApproval",
               value:
                 convention.dateApproval &&
-                toDisplayedDate({
+                `Pré-validée - Le ${toDisplayedDate({
                   date: new Date(convention.dateApproval),
-                }),
+                })}`,
               badgeSeverity: convention.dateApproval ? "success" : "warning",
             } satisfies ConventionSummaryField)
           : null,
@@ -306,9 +306,9 @@ const makeSignatoriesSubsections = (
               key: "dateValidation",
               value:
                 convention.dateValidation &&
-                toDisplayedDate({
+                `Validée - Le ${toDisplayedDate({
                   date: new Date(convention.dateValidation),
-                }),
+                })}`,
               badgeSeverity: convention.dateValidation ? "success" : "warning",
             } satisfies ConventionSummaryField)
           : null,

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -185,9 +185,11 @@ const SubSection = ({
                       className={fr.cx("fr-col-12", "fr-mb-2w")}
                     >
                       <Badge severity={field.badgeSeverity}>
-                        {field.badgeSeverity === "success"
-                          ? `Signée - Le ${field.value}`
-                          : "Signature en attente"}
+                        {field.badgeSeverity === "success" ? (
+                          <>field.value</>
+                        ) : (
+                          "Signature en attente"
+                        )}
                       </Badge>
                     </div>
                   );


### PR DESCRIPTION
## 🌈 Description
Une fois la convention validée, un flag apparaît dans l'encart "Structure du bénéficiaire" :
![image](https://github.com/user-attachments/assets/7e9a8c57-66f7-4193-9f1d-d2f8af9e4a9a)
Ce flag devrait mentionner "Validée" plutôt que "Signée"