### PR TITLE
#2363 - fix retours sur la page de convention

### DIFF
--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -672,7 +672,10 @@ const printWeekSchedule = (convention: ConventionReadDto, cx: Cx) => {
             {week.schedule.map((daySchedule) => (
               <li
                 key={daySchedule}
-                className={cx(conventionSummaryStyles.subsectionScheduleDay)}
+                className={cx(
+                  fr.cx("fr-text--sm"),
+                  conventionSummaryStyles.subsectionScheduleDay,
+                )}
               >
                 {daySchedule}
               </li>

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -576,14 +576,22 @@ const makeAdditionalInformationSubSections = (
           key: "individualProtection",
           label: "Protection individuelle",
           value: convention.individualProtection
-            ? `Oui: ${convention.individualProtectionDescription}`
+            ? `Oui${
+                convention.individualProtectionDescription
+                  ? ` : ${convention.individualProtectionDescription}`
+                  : ""
+              }`
             : "Non",
         },
         {
           key: "sanitaryPreventionDescription",
           label: "Mesures de prévention sanitaire",
           value: convention.sanitaryPrevention
-            ? `Oui: ${convention.sanitaryPreventionDescription}`
+            ? `Oui${
+                convention.sanitaryPreventionDescription
+                  ? ` : ${convention.sanitaryPreventionDescription}`
+                  : ""
+              }`
             : "Non",
         },
       ],

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -641,6 +641,7 @@ const printWeekSchedule = (convention: ConventionReadDto, cx: Cx) => {
             "fr-col-md-6",
             "fr-col-lg-4",
             "fr-col-xl-3",
+            "fr-my-3v",
           )}
           key={week.period.start.toISOString()}
         >
@@ -661,7 +662,7 @@ const printWeekSchedule = (convention: ConventionReadDto, cx: Cx) => {
           <div aria-hidden="true" className={fr.cx("fr-text--xs", "fr-m-0")}>
             --
           </div>
-          <p className={fr.cx("fr-text--xs")}>
+          <p className={fr.cx("fr-text--xs", "fr-mb-3v")}>
             {week.weeklyHours} heures de travail hebdomadaires
           </p>
           <ul

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -190,7 +190,7 @@ const makeSignatoriesSubsections = (
         },
         {
           key: "establishmentRepSiret",
-          label: "Siret",
+          label: "SIRET",
           value: renderSiret(convention.siret),
         },
       ]),
@@ -258,7 +258,7 @@ const makeSignatoriesSubsections = (
             },
             {
               key: "beneficiaryCurrentEmployerSiret",
-              label: "Siret",
+              label: "SIRET",
               value: renderSiret(
                 convention.signatories.beneficiaryCurrentEmployer.businessSiret,
               ),
@@ -428,7 +428,7 @@ const makeEstablishmentSubSections = (
         },
         {
           key: "siret",
-          label: "Siret",
+          label: "SIRET",
           value: renderSiret(convention.siret),
         },
       ],

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -503,7 +503,11 @@ const makeImmersionSubSections = (
       fields: [
         {
           key: "immersionObjective",
-          label: "Objectif",
+          label: `Objectif ${
+            convention.internshipKind === "immersion"
+              ? "de l'immersion"
+              : "du mini-stage"
+          }`,
           value: convention.immersionObjective,
         },
         {

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
@@ -22,12 +22,24 @@
     }
 
     img {
-      width: 100px;
+      max-width: 100px;
+      height: fit-content;
+
+      @include for-screen-min($bp-md) {
+        max-width: 100%;
+      }
     }
 
-    &--fluid {
-      justify-content: space-between;
+    &__header {
       align-items: center;
+
+      &__main {
+        @include for-screen-min($bp-md) {
+          padding-left: 20px;
+          justify-content: space-between;
+          align-items: center;
+        }
+      }
     }
 
     &__id {

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
@@ -4,6 +4,10 @@
   &__section {
     border: 1px solid var(--grey-900-175);
 
+    .fr-text--xs {
+      color: var(--grey-425-625);
+    }
+
     a[href] {
       text-underline-offset: 4px;
       word-break: break-word;

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
@@ -4,6 +4,13 @@
   &__section {
     border: 1px solid var(--grey-900-175);
 
+    a[href] {
+      text-underline-offset: 4px;
+      word-break: break-word;
+      text-decoration: underline;
+      background-image: none;
+    }
+
     h2 {
       @include for-screen-min($bp-md) {
         margin-bottom: 0 !important;

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.styles.ts
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.styles.ts
@@ -2,8 +2,9 @@ import "./ConventionSummary.scss";
 
 export const conventionSummaryStyles = {
   section: "im-convention-summary__section",
+  sectionHeader: "im-convention-summary__section__header",
+  sectionHeaderMain: "im-convention-summary__section__header__main",
   sectionId: "im-convention-summary__section__id",
-  sectionFluid: "im-convention-summary__section--fluid",
   subsection: "im-convention-summary__subsection",
   subsectionHighlighted: "im-convention-summary__subsection--highlighted",
   subsectionHorizontalSeparator:

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -227,15 +227,10 @@ const SubSection = ({
 };
 
 const Schedule = ({ fields }: { fields: ConventionSummaryField[] }) => {
-  return (
-    <>
-      {fields
-        .filter((field) => !!field)
-        .map((field) => {
-          return <span key={field.key}>{field.value}</span>;
-        })}
-    </>
-  );
+  const schedule = fields.at(0);
+
+  if (!schedule) return <></>;
+  return <>{schedule.value}</>;
 };
 
 const shouldDisplayHorizontalSeparator = (

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -63,16 +63,21 @@ export const ConventionSummary = ({
           className={cx(
             fr.cx("fr-grid-row", "fr-mb-3w", "fr-p-2w"),
             conventionSummaryStyles.section,
-            conventionSummaryStyles.sectionFluid,
+            conventionSummaryStyles.sectionHeader,
           )}
         >
-          <div className={fr.cx("fr-grid-row")}>
-            <img
-              src="https://immersion.cellar-c2.services.clever-cloud.com/document_administratif"
-              alt=""
-              className={fr.cx("fr-mr-3v")}
-            />
-            <div>
+          <img
+            src="https://immersion.cellar-c2.services.clever-cloud.com/document_administratif"
+            alt=""
+            className={fr.cx("fr-col-12", "fr-col-md-1")}
+          />
+          <div
+            className={cx(
+              fr.cx("fr-col-12", "fr-col-md-11", "fr-grid-row"),
+              conventionSummaryStyles.sectionHeaderMain,
+            )}
+          >
+            <div className={fr.cx("fr-col-12", "fr-col-md-8")}>
               <h4 className={fr.cx("fr-mb-0")}>Convention</h4>
               <div className={fr.cx("fr-text--xs", "fr-mb-2v")}>
                 Date de soumission : {submittedAt}
@@ -84,13 +89,14 @@ export const ConventionSummary = ({
                 {conventionId}
               </div>
             </div>
+            <CopyButton
+              label="Copier l'ID de convention"
+              textToCopy={conventionId}
+              withIcon={true}
+              withBorder={true}
+              className={fr.cx("fr-my-2v")}
+            />
           </div>
-          <CopyButton
-            label="Copier l'ID de convention"
-            textToCopy={conventionId}
-            withIcon={true}
-            withBorder={true}
-          />
         </section>
       )}
       {summary.map((section) => (

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -184,7 +184,7 @@ const SubSection = ({
                       key={field.key}
                       className={fr.cx("fr-col-12", "fr-mb-2w")}
                     >
-                      <Badge severity={field.badgeSeverity}>
+                      <Badge small severity={field.badgeSeverity}>
                         {field.badgeSeverity === "success" ? (
                           <>{field.value}</>
                         ) : (

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -200,12 +200,13 @@ const SubSection = ({
                     key={field.key}
                   >
                     {"label" in field && (
-                      <div className={fr.cx("fr-text--xs", "fr-m-0")}>
+                      <div>
                         <div className={fr.cx("fr-text--xs", "fr-m-0")}>
                           {field.label}
                         </div>
                         <div
                           className={cx(
+                            fr.cx("fr-text--sm", "fr-m-0"),
                             conventionSummaryStyles.subsectionValue,
                           )}
                         >

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -28,15 +28,15 @@ export type ConventionSummarySubSection = {
 export type ConventionSummaryField = { key: string } & (
   | {
       label: string;
-      value: string | ReactNode;
+      value: string | NonNullable<ReactNode>;
       copyButton?: string | ReactNode;
       hasBackgroundColor?: boolean;
     }
   | {
-      value: string | ReactNode;
+      value: string | NonNullable<ReactNode>;
       badgeSeverity: "success" | "warning";
     }
-  | { value: ReactNode }
+  | { value: NonNullable<ReactNode> }
 );
 
 export const ConventionSummary = ({
@@ -188,14 +188,16 @@ const SubSection = ({
                   return (
                     <div
                       key={field.key}
-                      className={fr.cx("fr-col-12", "fr-mb-2w")}
+                      className={cx(
+                        fr.cx("fr-col-12"),
+                        field.key !== "dateApproval" &&
+                          field.key !== "dateValidation"
+                          ? "fr-mb-2w"
+                          : "",
+                      )}
                     >
                       <Badge small severity={field.badgeSeverity}>
-                        {field.badgeSeverity === "success" ? (
-                          <>{field.value}</>
-                        ) : (
-                          "Signature en attente"
-                        )}
+                        {field.value}
                       </Badge>
                     </div>
                   );

--- a/libs/react-design-system/src/immersionFacile/components/copy-button/CopyButton.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/copy-button/CopyButton.tsx
@@ -6,6 +6,7 @@ import Styles from "./CopyButton.styles";
 export type CopyButtonProperties = {
   textToCopy: string;
   withBorder?: boolean;
+  className?: string;
 } & ({ label: string; withIcon: boolean } | { withIcon: true });
 
 export const CopyButton = (props: CopyButtonProperties) => {
@@ -45,6 +46,7 @@ export const CopyButton = (props: CopyButtonProperties) => {
           props.withIcon && "fr-btn--icon-left",
         ),
         props.withBorder && Styles.copyButtonBorder,
+        props.className,
       )}
       type="button"
     >


### PR DESCRIPTION
## 🌈 Description

Prise en compte des retours sur la page de convention:
- ne plus avoir de chevauchements entre adresse mail et numéro de téléphone pour les résolutions entre 768 et 1200 px lorsqu'une adresse est trop longue
- dans le bloc "Métier observé", remplacer "Objectif" par "Objectif de l'immersion", comme sur la maquette
- passer le mot "SIRET" en lettres capitales
- ajouter plus d'espace entre les lignes de semaines pour gagner en lisibilité
- ajouter les flags "En attente de signature" pour les parties prenantes n'ayant pas encore signé
- bloc "Information complémentaire" : ne mettre les ":" après le "Oui" que lorsque le champ de détail a été rempli
- bloc "Convention" : Sur mobile le bouton passe sous l'illustration, il devrait être aligné avec l'ID de la convention
- les textes sont en Corps de texte SM - 14px
- les badges utilisés pour le statut de signature est le SM en font-size 12px

## 💯 Remarque

Pour la remarque:
> Les adresses mail ne sont pas alignées en hauteur avec les valeurs des champs d'à côté (constaté dans tous les blocs) 

Ceci est dû à l'icone qui permet de copier qui a une taille fixe définie par le DSFR.
Je verrai avec Enguerran dans un second temps ce que l'on peut faire.
Sinon, vu avec Gaël, ce n'est pas grave si pas possible de faire ce fix.