### PR TITLE
#2586 - Fix soumission d'un formulaire de convention édité

### DIFF
--- a/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
+++ b/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
@@ -38,12 +38,12 @@ export const ScheduleSection = () => {
 
   const formContents = getFormFields();
 
-  const [dateMax, setDateMax] = useState(
-    addDays(
-      isStringDate(values.dateStart) ? new Date(values.dateStart) : new Date(),
-      maximumCalendarDayByInternshipKind[values.internshipKind],
-    ).toISOString(),
-  );
+  const computeDatePickerMaxDate = addDays(
+    isStringDate(values.dateStart) ? new Date(values.dateStart) : new Date(),
+    maximumCalendarDayByInternshipKind[values.internshipKind],
+  ).toISOString();
+
+  const [dateMax, setDateMax] = useState<string>(computeDatePickerMaxDate);
 
   const excludedDays =
     values.internshipKind === "mini-stage-cci"
@@ -135,7 +135,8 @@ export const ScheduleSection = () => {
         convertLocaleDateToUtcTimezoneDate(new Date(values.dateEnd)),
       ),
     );
-  }, [values.dateStart, values.dateEnd]);
+    setDateMax(computeDatePickerMaxDate);
+  }, [values.dateStart, values.dateEnd, computeDatePickerMaxDate]);
 
   return (
     <>


### PR DESCRIPTION
## 🤖 Problème

Il n'est pas possible de valider un formulaire d'édition de convention.

## 💯 Solution

Nous avons un useEffect qui met à jour la valeur des champs de début et fin de l'immersion.
Mais ce hook n'inclut pas la mise à jour de la valeur maximale du champ de date de fin.

Le formulaire est donc toujours invalide car on se retrouve alors avec date de fin > date de fin max.