### PR TITLE
fix migration

### DIFF
--- a/back/src/config/pg/migrations/1732192784073_establishment-contacts-to-establishment-rights.ts
+++ b/back/src/config/pg/migrations/1732192784073_establishment-contacts-to-establishment-rights.ts
@@ -80,7 +80,7 @@ const C_insertMissingContactAdminUsers = (pgm: MigrationBuilder) => {
     SELECT 
       gen_random_uuid(), email, firstname, lastname
     FROM (
-      SELECT DISTINCT contact_admins.email, contact_admins.firstname, contact_admins.lastname
+      SELECT DISTINCT ON (contact_admins.email) contact_admins.email, contact_admins.firstname, contact_admins.lastname
       FROM (
         SELECT email, siret, firstname, lastname
         FROM establishments_contacts


### PR DESCRIPTION
- apply default contact mode for establishments without legacy contacts
- avoid conflict of insert of contact admins with same email