### PR TITLE
#2657 - Fix inversion agence et structure d'accompagnement sur l'affichage de la convention

### DIFF
--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -325,11 +325,11 @@ const makeSignatoriesSubsections = (
           ? {
               key: "agencyWithRefersTo",
               label: "Structure d'accompagnement",
-              value: convention.agencyRefersTo.name,
+              value: convention.agencyName,
               copyButton: (
                 <CopyButton
                   withIcon={true}
-                  textToCopy={convention.agencyRefersTo.name}
+                  textToCopy={convention.agencyName}
                 />
               ),
             }
@@ -352,9 +352,18 @@ const makeSignatoriesSubsections = (
         {
           key: "agencyName",
           label: `Prescripteur ${convention.agencyRefersTo ? "lié" : ""}`,
-          value: convention.agencyName,
+          value: convention.agencyRefersTo
+            ? convention.agencyRefersTo.name
+            : convention.agencyName,
           copyButton: (
-            <CopyButton withIcon={true} textToCopy={convention.agencyName} />
+            <CopyButton
+              withIcon={true}
+              textToCopy={
+                convention.agencyRefersTo
+                  ? convention.agencyRefersTo.name
+                  : convention.agencyName
+              }
+            />
           ),
         },
       ]),


### PR DESCRIPTION
## 🤖 Problème

Sur la page de récap d'une convention, le nom affiché de l'agence et la structure d'accompagnement sont inversés.