### PR TITLE
#1815 - Fix multiples sur #1815

### DIFF
--- a/front/src/app/components/UserDetail.tsx
+++ b/front/src/app/components/UserDetail.tsx
@@ -23,6 +23,7 @@ import { routes } from "src/app/routes/routes";
 
 type UserDetailProps = {
   title: string;
+  currentUser: InclusionConnectedUser;
   userWithRights: InclusionConnectedUser;
   editInformationsLink?: string;
   onUserUpdateRequested: (userParamsForAgency: UserParamsForAgency) => void;
@@ -35,6 +36,7 @@ const manageUserModal = createModal({
 
 export const UserDetail = ({
   title,
+  currentUser,
   userWithRights,
   editInformationsLink,
   onUserUpdateRequested,
@@ -72,7 +74,7 @@ export const UserDetail = ({
         agencyRights={[...userWithRights.agencyRights].sort((a, b) =>
           a.agency.name.localeCompare(b.agency.name),
         )}
-        isBackofficeAdmin={userWithRights.isBackofficeAdmin}
+        isBackofficeAdmin={currentUser.isBackofficeAdmin}
         onUserUpdateRequested={onUserUpdateRequested}
       />
     </div>

--- a/front/src/app/pages/MyProfile.tsx
+++ b/front/src/app/pages/MyProfile.tsx
@@ -72,6 +72,7 @@ export const MyProfile = (_: MyProfileProps) => {
     <>
       <UserDetail
         title={`Mon profil : ${userDisplayed}`}
+        currentUser={currentUser}
         userWithRights={currentUser}
         editInformationsLink={getLinkToUpdateAccountInfo(
           enableProConnect.isActive,

--- a/front/src/app/pages/admin/AdminUserDetail.tsx
+++ b/front/src/app/pages/admin/AdminUserDetail.tsx
@@ -11,6 +11,7 @@ import { updateUserOnAgencySelectors } from "src/core-logic/domain/agencies/upda
 import { updateUserOnAgencySlice } from "src/core-logic/domain/agencies/update-user-on-agency/updateUserOnAgency.slice";
 import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { feedbackSlice } from "src/core-logic/domain/feedback/feedback.slice";
+import { inclusionConnectedSelectors } from "src/core-logic/domain/inclusionConnected/inclusionConnected.selectors";
 import { Route } from "type-route";
 
 type AdminUserDetailProps = {
@@ -18,6 +19,7 @@ type AdminUserDetailProps = {
 };
 
 export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
+  const currentUser = useAppSelector(inclusionConnectedSelectors.currentUser);
   const icUser = useAppSelector(adminFetchUserSelectors.fetchedUser);
   const isFetchingUser = useAppSelector(adminFetchUserSelectors.isFetching);
   const isUpdatingUser = useAppSelector(updateUserOnAgencySelectors.isLoading);
@@ -50,6 +52,7 @@ export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
     dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
   }, [dispatch]);
 
+  if (!currentUser) return <p>Vous n'êtes pas connecté...</p>;
   if (isFetchingUser || isUpdatingUser) return <Loader />;
   if (!icUser) return <p>Aucun utilisateur trouvé</p>;
 
@@ -61,6 +64,7 @@ export const AdminUserDetail = ({ route }: AdminUserDetailProps) => {
   return (
     <UserDetail
       title={title}
+      currentUser={currentUser}
       userWithRights={icUser}
       onUserUpdateRequested={onUserUpdateRequested}
     />

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.slice.ts
@@ -32,7 +32,7 @@ export const fetchUserSlice = createSlice({
     builder.addCase(
       updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded,
       (state, action) => {
-        if (!state.user) return;
+        if (!state.user || state.user.id !== action.payload.userId) return;
         state.user = updateUserAgencyRights(state.user, action.payload);
       },
     );

--- a/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
+++ b/front/src/core-logic/domain/admin/fetchUser/fetchUser.test.ts
@@ -44,47 +44,88 @@ describe("Admin Users slice", () => {
     );
   });
 
-  it("update the user rights successfully", () => {
-    const agency = new AgencyDtoBuilder().build();
-    const agencyRight: AgencyRight = {
-      agency,
-      roles: ["validator"],
-      isNotifiedByEmail: false,
-    };
-    const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
-      .withId("user-id")
-      .withIsAdmin(false)
-      .withAgencyRights([agencyRight])
-      .build();
+  describe("on updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded", () => {
+    it("if it is user in slice, update the user rights successfully", () => {
+      const agency = new AgencyDtoBuilder().build();
+      const agencyRight: AgencyRight = {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      };
+      const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+        .withId("user-id")
+        .withIsAdmin(false)
+        .withAgencyRights([agencyRight])
+        .build();
 
-    ({ store, dependencies } = createTestStore({
-      admin: adminPreloadedState({
-        fetchUser: {
-          user,
-          isFetching: false,
-        },
-      }),
-    }));
+      ({ store, dependencies } = createTestStore({
+        admin: adminPreloadedState({
+          fetchUser: {
+            user,
+            isFetching: false,
+          },
+        }),
+      }));
 
-    store.dispatch(
-      updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
-        userId: user.id,
-        agencyId: agency.id,
-        email: user.email,
-        roles: [...agencyRight.roles, "counsellor"],
-        isNotifiedByEmail: agencyRight.isNotifiedByEmail,
-        feedbackTopic: "user",
-      }),
-    );
-
-    expectToEqual(adminFetchUserSelectors.fetchedUser(store.getState()), {
-      ...user,
-      agencyRights: [
-        {
-          ...agencyRight,
+      store.dispatch(
+        updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+          userId: user.id,
+          agencyId: agency.id,
+          email: user.email,
           roles: [...agencyRight.roles, "counsellor"],
-        },
-      ],
+          isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+          feedbackTopic: "user",
+        }),
+      );
+
+      expectToEqual(adminFetchUserSelectors.fetchedUser(store.getState()), {
+        ...user,
+        agencyRights: [
+          {
+            ...agencyRight,
+            roles: [...agencyRight.roles, "counsellor"],
+          },
+        ],
+      });
+    });
+
+    it("if it is not user in slice, do nothing", () => {
+      const agency = new AgencyDtoBuilder().build();
+      const agencyRight: AgencyRight = {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      };
+      const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+        .withId("user-id")
+        .withIsAdmin(false)
+        .withAgencyRights([agencyRight])
+        .build();
+
+      ({ store, dependencies } = createTestStore({
+        admin: adminPreloadedState({
+          fetchUser: {
+            user,
+            isFetching: false,
+          },
+        }),
+      }));
+
+      store.dispatch(
+        updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+          userId: "another-user-id",
+          agencyId: agency.id,
+          email: "another-user-id@email.com",
+          roles: [...agencyRight.roles, "counsellor"],
+          isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+          feedbackTopic: "user",
+        }),
+      );
+
+      expectToEqual(
+        adminFetchUserSelectors.fetchedUser(store.getState()),
+        user,
+      );
     });
   });
 

--- a/front/src/core-logic/domain/agencies/agencies.helpers.ts
+++ b/front/src/core-logic/domain/agencies/agencies.helpers.ts
@@ -8,7 +8,7 @@ export const updateUserAgencyRights = (
     (agencyRight) => agencyRight.agency.id !== requestedUpdate.agencyId,
   );
   const updatedAgencyRight = user.agencyRights.find(
-    (agencyight) => agencyight.agency.id === requestedUpdate.agencyId,
+    (agencyRight) => agencyRight.agency.id === requestedUpdate.agencyId,
   );
   if (!updatedAgencyRight)
     throw errors.agency.notFound({ agencyId: requestedUpdate.agencyId });

--- a/front/src/core-logic/domain/inclusionConnected/inclusionConnected.slice.ts
+++ b/front/src/core-logic/domain/inclusionConnected/inclusionConnected.slice.ts
@@ -66,7 +66,11 @@ export const inclusionConnectedSlice = createSlice({
     builder.addCase(
       updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded,
       (state, action) => {
-        if (!state.currentUser) return;
+        if (
+          !state.currentUser ||
+          state.currentUser.id !== action.payload.userId
+        )
+          return;
         state.currentUser = updateUserAgencyRights(
           state.currentUser,
           action.payload,

--- a/front/src/core-logic/domain/inclusionConnected/inclusionConnected.test.ts
+++ b/front/src/core-logic/domain/inclusionConnected/inclusionConnected.test.ts
@@ -319,46 +319,86 @@ describe("InclusionConnected", () => {
     });
   });
 
-  it("update the user rights successfully", () => {
-    const agency = new AgencyDtoBuilder().build();
-    const agencyRight: AgencyRight = {
-      agency,
-      roles: ["validator"],
-      isNotifiedByEmail: false,
-    };
-    const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
-      .withId("user-id")
-      .withIsAdmin(false)
-      .withAgencyRights([agencyRight])
-      .build();
+  describe("on updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded", () => {
+    it("if it is currentUser, update the user rights successfully", () => {
+      const agency = new AgencyDtoBuilder().build();
+      const agencyRight: AgencyRight = {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      };
+      const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+        .withId("user-id")
+        .withIsAdmin(false)
+        .withAgencyRights([agencyRight])
+        .build();
 
-    ({ store, dependencies } = createTestStore({
-      inclusionConnected: {
-        currentUser: user,
-        agenciesToReview: [],
-        isLoading: false,
-      },
-    }));
-
-    store.dispatch(
-      updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
-        userId: user.id,
-        agencyId: agency.id,
-        email: user.email,
-        roles: [...agencyRight.roles, "counsellor"],
-        isNotifiedByEmail: agencyRight.isNotifiedByEmail,
-        feedbackTopic: "user",
-      }),
-    );
-
-    expectToEqual(inclusionConnectedSelectors.currentUser(store.getState()), {
-      ...user,
-      agencyRights: [
-        {
-          ...agencyRight,
-          roles: [...agencyRight.roles, "counsellor"],
+      ({ store, dependencies } = createTestStore({
+        inclusionConnected: {
+          currentUser: user,
+          agenciesToReview: [],
+          isLoading: false,
         },
-      ],
+      }));
+
+      store.dispatch(
+        updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+          userId: user.id,
+          agencyId: agency.id,
+          email: user.email,
+          roles: [...agencyRight.roles, "counsellor"],
+          isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+          feedbackTopic: "user",
+        }),
+      );
+
+      expectToEqual(inclusionConnectedSelectors.currentUser(store.getState()), {
+        ...user,
+        agencyRights: [
+          {
+            ...agencyRight,
+            roles: [...agencyRight.roles, "counsellor"],
+          },
+        ],
+      });
+    });
+
+    it("if it is not currentUser, do nothing", () => {
+      const agency = new AgencyDtoBuilder().build();
+      const agencyRight: AgencyRight = {
+        agency,
+        roles: ["validator"],
+        isNotifiedByEmail: false,
+      };
+      const user: InclusionConnectedUser = new InclusionConnectedUserBuilder()
+        .withId("user-id")
+        .withIsAdmin(false)
+        .withAgencyRights([agencyRight])
+        .build();
+
+      ({ store, dependencies } = createTestStore({
+        inclusionConnected: {
+          currentUser: user,
+          agenciesToReview: [],
+          isLoading: false,
+        },
+      }));
+
+      store.dispatch(
+        updateUserOnAgencySlice.actions.updateUserAgencyRightSucceeded({
+          userId: "another-user-id",
+          agencyId: agency.id,
+          email: "another-user-id@email.com",
+          roles: [...agencyRight.roles, "counsellor"],
+          isNotifiedByEmail: agencyRight.isNotifiedByEmail,
+          feedbackTopic: "user",
+        }),
+      );
+
+      expectToEqual(
+        inclusionConnectedSelectors.currentUser(store.getState()),
+        user,
+      );
     });
   });
 


### PR DESCRIPTION
## 🤖 Problème

1. ETQ admin IF, sur la page de détail d'un utilisateur, pouvoir modifier ses rôles dans la modale.
2. Lorsque je navigue entre les pages de modifications utilisateur, je veux voir les informations à jour
