### PR TITLE
#2652 - remplacer les caractères spéciaux du texte recherché par un espace

### DIFF
--- a/shared/src/routes/formCompletion.routes.ts
+++ b/shared/src/routes/formCompletion.routes.ts
@@ -2,11 +2,11 @@ import { defineRoute, defineRoutes } from "shared-routes";
 import { z } from "zod";
 import { httpErrorSchema } from "../httpClient/httpErrors.schema";
 import { appellationSearchResponseSchema } from "../romeAndAppellationDtos/romeAndAppellation.schema";
+import { searchTextSchema } from "../search/searchText.schema";
 import {
   getSiretInfoSchema,
   isSiretExistResponseSchema,
 } from "../siret/siret.schema";
-import { zStringMinLength1 } from "../zodUtils";
 
 export type FormCompletionRoutes = typeof formCompletionRoutes;
 export const formCompletionRoutes = defineRoutes({
@@ -43,7 +43,7 @@ export const formCompletionRoutes = defineRoutes({
     method: "get",
     url: "/appellation",
     queryParamsSchema: z.object({
-      searchText: zStringMinLength1,
+      searchText: searchTextSchema,
       naturalLanguage: z.literal("true").optional(),
     }),
     responses: {

--- a/shared/src/search/searchText.schema.ts
+++ b/shared/src/search/searchText.schema.ts
@@ -1,0 +1,5 @@
+import { zStringMinLength1 } from "../zodUtils";
+
+const sanitize = (text: string) => text.replace(/[^a-zA-ZÀ-ÿ\-]/g, " ").trim();
+
+export const searchTextSchema = zStringMinLength1.transform(sanitize);

--- a/shared/src/search/searchText.unit.test.ts
+++ b/shared/src/search/searchText.unit.test.ts
@@ -1,0 +1,34 @@
+import { searchTextSchema } from "./searchText.schema";
+
+describe("searchTextSchema", () => {
+  it("accepts if not empty", () => {
+    expect(() => searchTextSchema.parse("")).toThrow();
+    expect(() => searchTextSchema.parse("taxi")).not.toThrow();
+  });
+
+  it.each([
+    { initialSearchText: "<lapins", expectedSearchText: "lapins" },
+    {
+      initialSearchText: "montage-assemblage",
+      expectedSearchText: "montage-assemblage",
+    },
+    {
+      initialSearchText: "secrétaire",
+      expectedSearchText: "secrétaire",
+    },
+    {
+      initialSearchText: "secrétaire#",
+      expectedSearchText: "secrétaire",
+    },
+    {
+      initialSearchText: "boulanger / patissier",
+      expectedSearchText: "boulanger   patissier",
+    },
+  ])(
+    "for $initialSearchText, replace special characters by space then trim",
+    ({ initialSearchText, expectedSearchText }) => {
+      const newSearchText = searchTextSchema.parse(initialSearchText);
+      expect(newSearchText).toBe(expectedSearchText);
+    },
+  );
+});


### PR DESCRIPTION
## 🤖 Problème

Lorsque l'on saisie des caractères spéciaux dans le champ de recherche, on obtient une erreur sql:
![Image](https://github.com/user-attachments/assets/42da1f66-244a-47ab-a97e-abd08775f6e8)
```
durationInSeconds: 0.0021460669999942184
error: {
  "error": "syntax error in tsquery: \"<toto\"",
  "query": "select \"public_appellations_data\".\"ogr_appellation\", \"public_appellations_data\".\"libelle_appellation_long\", \"public_romes_data\".\"libelle_rome\", \"public_romes_data\".\"code_rome\" from \"public_appellations_data\" inner join \"public_romes_data\" on \"public_appellations_data\".\"code_rome\" = \"public_romes_data\".\"code_rome\" where ((\"libelle_appellation_long_without_special_char\" @@ to_tsquery('french', $1) and \"libelle_appellation_long_without_special_char\" ilike $2) or (\"libelle_appellation_long_without_special_char\" ilike $3 and \"libelle_appellation_long_without_special_char\" ilike $4)) limit $5",
  "params": [
    "<toto",
    "%<toto%",
    "%<toto%",
    "%<toto%",
    80
  ]
}
message: "SQL ERROR"
```

## 💯 Solution

Remplacer les caractères spéciaux par des espaces.

