### PR TITLE
#2764 - Fix choix de jour sur le formulaire de convention pour autres timezones

### DIFF
--- a/front/src/app/components/forms/commons/SchedulePicker/ComplexSchedulePicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/ComplexSchedulePicker.tsx
@@ -10,6 +10,7 @@ import {
   TimePeriodsDto,
   calculateNumberOfWorkedDays,
   calculateTotalImmersionHoursFromComplexSchedule,
+  convertLocaleDateToUtcTimezoneDate,
 } from "shared";
 import { useStyles } from "tss-react/dsfr";
 import { DayPicker } from "./DayPicker";
@@ -40,8 +41,10 @@ export const ComplexSchedulePicker = ({
           complexSchedule={values.schedule.complexSchedule}
           selectedDate={selectedDate}
           interval={{
-            start: new Date(values.dateStart),
-            end: new Date(values.dateEnd),
+            start: convertLocaleDateToUtcTimezoneDate(
+              new Date(values.dateStart),
+            ),
+            end: convertLocaleDateToUtcTimezoneDate(new Date(values.dateEnd)),
           }}
           onChange={(lastSelectedDate) => {
             const updatedSchedule = clone(values.schedule);
@@ -69,7 +72,12 @@ export const ComplexSchedulePicker = ({
                 values.schedule.complexSchedule.find(
                   (dailySchedule) =>
                     selectedDate &&
-                    isSameDay(selectedDate, new Date(dailySchedule.date)),
+                    isSameDay(
+                      selectedDate,
+                      convertLocaleDateToUtcTimezoneDate(
+                        new Date(dailySchedule.date),
+                      ),
+                    ),
                 )?.timePeriods ?? []
               }
               onValueChange={(newTimePeriods) => {
@@ -105,7 +113,11 @@ const makeUpdatedScheduleWithTimePeriodForSelectedDate = (
   newTimePeriods: TimePeriodsDto,
 ): ScheduleDto => {
   const newComplexSchedule = schedule.complexSchedule.map((dailySchedule) =>
-    selectedDate && isSameDay(selectedDate, new Date(dailySchedule.date))
+    selectedDate &&
+    isSameDay(
+      selectedDate,
+      convertLocaleDateToUtcTimezoneDate(new Date(dailySchedule.date)),
+    )
       ? {
           ...dailySchedule,
           timePeriods: newTimePeriods,

--- a/front/src/app/components/forms/commons/SchedulePicker/RegularSchedulePicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/RegularSchedulePicker.tsx
@@ -12,6 +12,7 @@ import {
   calculateNumberOfWorkedDays,
   calculateTotalImmersionHoursFromComplexSchedule,
   calculateWeeklyHoursFromSchedule,
+  convertLocaleDateToUtcTimezoneDate,
   regularTimePeriods,
   selectedDaysFromComplexSchedule,
 } from "shared";
@@ -122,8 +123,10 @@ export const RegularSchedulePicker = (props: RegularSchedulePickerProps) => {
           <WeeksHoursIndicator
             schedule={values.schedule}
             interval={{
-              start: new Date(values.dateStart),
-              end: new Date(values.dateEnd),
+              start: convertLocaleDateToUtcTimezoneDate(
+                new Date(values.dateStart),
+              ),
+              end: convertLocaleDateToUtcTimezoneDate(new Date(values.dateEnd)),
             }}
           />
         </div>

--- a/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
+++ b/front/src/app/components/forms/commons/SchedulePicker/WeekdayPicker.tsx
@@ -8,6 +8,7 @@ import {
   SelectedDaysOfTheWeekDto,
   WeekdayNumber,
   arrayFromNumber,
+  convertLocaleDateToUtcTimezoneDate,
   frenchDayMapping,
   maximumCalendarDayByInternshipKind,
   removeAtIndex,
@@ -49,8 +50,12 @@ export const WeekdayPicker = ({
     const uniqueWeekDaysOnInterval = uniq(
       arrayFromNumber(startEndDiff + 1).map(
         (dayIndex) =>
-          frenchDayMapping(addDays(new Date(start), dayIndex).toISOString())
-            .frenchDay,
+          frenchDayMapping(
+            addDays(
+              convertLocaleDateToUtcTimezoneDate(new Date(start)),
+              dayIndex,
+            ).toISOString(),
+          ).frenchDay,
       ),
     );
     return !uniqueWeekDaysOnInterval.includes(day);

--- a/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
+++ b/front/src/app/components/forms/convention/sections/schedule/ScheduleSection.tsx
@@ -208,8 +208,8 @@ export const ScheduleSection = () => {
 
       <SchedulePicker
         interval={{
-          start: new Date(values.dateStart),
-          end: new Date(values.dateEnd),
+          start: convertLocaleDateToUtcTimezoneDate(new Date(values.dateStart)),
+          end: convertLocaleDateToUtcTimezoneDate(new Date(values.dateEnd)),
         }}
         excludedDays={excludedDays}
       />


### PR DESCRIPTION
## 🤖 Problème

Une utilisatrice en Martinique veut saisir une convention du 02/01 au 16/01, avec des horaires irrégulières.
Sur le dernier jour, le 16/01, elle ne peut pas ajouter d'horaires.

![image](https://github.com/user-attachments/assets/43b3a848-4eba-41f9-babf-effd0ccf1323)

## 💯 Remarques

On avait constaté ce problème sur la saisie des horaires irrégulières, mais les horaires régulières avaient aussi un problème avec les changements de timezones.