### PR TITLE
#2760 - Deconnexion possible tout de suite après connexion (suppr. du param token dans l'url)

### DIFF
--- a/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
+++ b/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
@@ -149,6 +149,8 @@ export const InclusionConnectedPrivateRoute = ({
           feedbackTopic: "auth-global",
         }),
       );
+      const { token: _, ...routeParams } = route.params;
+      routes[route.name](routeParams as any).replace();
     }
   }, [route.params, dispatch, afterLoginRedirectionUrl]);
 


### PR DESCRIPTION
avec un gros `as` des familles.