### PR TITLE
TECH - supprimer les pièces jointes des emails de MER s'il ne s'agit pas d'un blob

### DIFF
--- a/back/src/domains/core/notifications/adapters/BrevoNotificationGateway.manual.test.ts
+++ b/back/src/domains/core/notifications/adapters/BrevoNotificationGateway.manual.test.ts
@@ -91,6 +91,15 @@ describe("BrevoNotificationGateway manual", () => {
     expect(base64).toBe(ifLogoInBase64);
   });
 
+  it("should not retrieve attachment if it is not a blob", async () => {
+    const downloadToken =
+      "eyJmb2xkZXIiOiIyMDI1MDEwOTA5MDQ1OC45Ni45MTM3NjE2OTgiLCJmaWxlbmFtZSI6Ii4rQ0lERitCRUxGT1JUKy52Y2YifQ";
+
+    const attachment =
+      await notificationGateway.getAttachmentContent(downloadToken);
+    expect(attachment).toBe(null);
+  });
+
   it("should send email with attachment correctly", async () => {
     const response = await notificationGateway.sendEmail({
       kind: "EDIT_FORM_ESTABLISHMENT_LINK",

--- a/back/src/domains/core/notifications/adapters/BrevoNotificationGateway.ts
+++ b/back/src/domains/core/notifications/adapters/BrevoNotificationGateway.ts
@@ -70,7 +70,9 @@ export class BrevoNotificationGateway implements NotificationGateway {
     };
   }
 
-  public async getAttachmentContent(downloadToken: string): Promise<Base64> {
+  public async getAttachmentContent(
+    downloadToken: string,
+  ): Promise<Base64 | null> {
     const response = await this.config.httpClient.getAttachmentContent({
       urlParams: { downloadToken },
       headers: {
@@ -86,6 +88,9 @@ export class BrevoNotificationGateway implements NotificationGateway {
           2,
         )}`,
       );
+    if (!(response.body instanceof Blob)) {
+      return null;
+    }
 
     const blob: Blob = response.body;
     return Buffer.from(await blob.arrayBuffer()).toString("base64");

--- a/back/src/domains/core/notifications/adapters/InMemoryNotificationGateway.ts
+++ b/back/src/domains/core/notifications/adapters/InMemoryNotificationGateway.ts
@@ -22,9 +22,10 @@ export class InMemoryNotificationGateway implements NotificationGateway {
     private readonly numberOfEmailToKeep: number | null = null,
   ) {}
 
-  public async getAttachmentContent(link: string): Promise<Base64> {
+  public async getAttachmentContent(link: string): Promise<Base64 | null> {
     const attachment = this.attachmentsByLinks[link];
     if (!attachment) throw new Error(`No attachment found by link ${link}.`);
+    if (attachment === "not-a-blob") return null;
     return attachment;
   }
 

--- a/back/src/domains/core/notifications/ports/NotificationGateway.ts
+++ b/back/src/domains/core/notifications/ports/NotificationGateway.ts
@@ -11,5 +11,5 @@ export interface NotificationGateway {
     sendSmsParams: TemplatedSms,
     notificationId?: NotificationId,
   ): Promise<void>;
-  getAttachmentContent(downloadToken: string): Promise<Base64>;
+  getAttachmentContent(downloadToken: string): Promise<Base64 | null>;
 }

--- a/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.ts
+++ b/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.ts
@@ -1,4 +1,5 @@
 import {
+  EmailAttachment,
   Exchange,
   WithDiscussionId,
   createOpaqueEmail,
@@ -60,12 +61,16 @@ export class SendExchangeToRecipient extends TransactionalUseCase<WithDiscussion
         appellationCode: discussion.appellationCode,
       });
 
-    const attachments = await Promise.all(
-      lastExchange.attachments.map(async ({ name, link }) => ({
-        name,
-        content: await this.#notificationGateway.getAttachmentContent(link),
-      })),
-    );
+    const attachments = (
+      await Promise.all(
+        lastExchange.attachments.map(async ({ name, link }) => ({
+          name,
+          content: await this.#notificationGateway.getAttachmentContent(link),
+        })),
+      )
+    ).filter(
+      (emailAttachment) => emailAttachment.content !== null,
+    ) as EmailAttachment[];
 
     await this.#saveNotificationAndRelatedEvent(uow, {
       kind: "email",


### PR DESCRIPTION
## Description

Nous avons fréquemment cette erreur de prod `blob.arrayBuffer is not a function` lorsque nous récupérons une pièce jointe depuis Brevo. Lorsque nous avons un code de retour 200, nous assumons qu'il s'agit d'un blob et nous appellons la focntion ` blob.arrayBuffer()`. Or ce n'est pas toujours un blob.

## Solution

Nous ignorons dans cette PR les pièces jointes qui ne sont pas des blobs. Ainsi, les utilisateurs reçoivent tout de même leurs mails, même sans pièce jointe.