### PR TITLE
TECH - bilan: récupérer les heures manquées si l'info est présente

### DIFF
--- a/back/src/domains/convention/adapters/PgAssessmentRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgAssessmentRepository.integration.test.ts
@@ -133,6 +133,27 @@ describe("PgAssessmentRepository", () => {
         minimalAssessment,
       );
     });
+
+    it("returns partially completed assessment with 0 missed hours", async () => {
+      const assessment: AssessmentEntity = {
+        conventionId: "aaaaac99-9c0b-1bbb-bb6d-6bb9bd38aaaa",
+        status: "PARTIALLY_COMPLETED",
+        numberOfMissedHours: 0,
+        lastDayOfPresence: new Date("2024-10-17").toISOString(),
+        endedWithAJob: false,
+        establishmentFeedback: "Ca s'est bien passé",
+        establishmentAdvices: "mon conseil",
+        _entityName: "Assessment",
+      };
+
+      await assessmentRepository.save(assessment);
+
+      expectToEqual(
+        await assessmentRepository.getByConventionId(assessment.conventionId),
+        assessment,
+      );
+    });
+
     it("returns assessment found with all fields", async () => {
       await assessmentRepository.save(fullAssessment);
 

--- a/back/src/domains/convention/adapters/PgAssessmentRepository.ts
+++ b/back/src/domains/convention/adapters/PgAssessmentRepository.ts
@@ -55,7 +55,7 @@ export class PgAssessmentRepository implements AssessmentRepository {
       ...(assessment.lastDayOfPresence
         ? { lastDayOfPresence: assessment.lastDayOfPresence }
         : {}),
-      ...(assessment.numberOfMissedHours
+      ...(assessment.numberOfMissedHours !== null
         ? { numberOfMissedHours: assessment.numberOfMissedHours }
         : {}),
     });


### PR DESCRIPTION
## Description

Les heures manquées renseignées sont parfois de 0.
Au moment de la création du dto, on veut pouvoir récupérer cette information car on ne la remontait pas si c'était 0 avant.