### PR TITLE
TECH - envoyer des notifications sur Slack depuis nos github actions

### DIFF
--- a/.github/workflows/continous-delivery.yml
+++ b/.github/workflows/continous-delivery.yml
@@ -59,9 +59,11 @@ jobs:
       environment: staging
       tag: "v${{ github.run_number }}"
       isPreRelease: true
+      slackChannel: "#if-staging-déploiement"
     secrets:
       SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   deploy-pentest:
     name: Deploy pentest
@@ -86,9 +88,11 @@ jobs:
       tag: "v${{ github.run_number }}"
       region: "osc-secnum-fr1"
       isPreRelease: false
+      slackChannel: "#if-prod-déploiement"
     secrets:
       SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   create-release:
     needs:

--- a/.github/workflows/deploy-to-scalingo.yml
+++ b/.github/workflows/deploy-to-scalingo.yml
@@ -16,10 +16,15 @@ on:
         required: false
         type: string
         default: "osc-fr1"
+      slackChannel:
+        type: string
+        required: true
     secrets:
       SCALINGO_API_TOKEN:
         required: true
       DISCORD_WEBHOOK_URL:
+        required: true
+      SLACK_BOT_TOKEN:
         required: true
 
 jobs:
@@ -49,6 +54,53 @@ jobs:
         run: scalingo --app if-${{ inputs.environment }}-back --region ${{ inputs.region }} deploy back-build.tar.gz ${{ inputs.tag }}
       - name: Deploy front
         run: scalingo --app if-${{ inputs.environment }}-front --region ${{ inputs.region }} deploy front-build.tar.gz ${{ inputs.tag }}
+      - name: Send Slack notification
+        run: |
+          releaseSuffix=$([[ "${{ inputs.isPreRelease }}" == "true" ]] && echo "-rc" || echo "")
+          curl --location "https://slack.com/api/chat.postMessage" -H "Content-Type: application/json" -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" -d @- <<EOF
+          {
+            "channel": "${{ inputs.slackChannel }}",
+            "blocks": [
+              {"type": "header", "text": {"type": "plain_text", "text": "${{ inputs.tag }}${releaseSuffix}"}},
+              {"type": "section", "text": {"type": "plain_text", "text": "La version ${{ inputs.tag }}${releaseSuffix} est déployée en ${{ inputs.environment }}${releaseSuffix}."}},
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "style": "primary",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Voir les changements"
+                    },
+                    "url": "https://github.com/gip-inclusion/immersion-facile/releases/tag/${{ inputs.tag }}${releaseSuffix}"
+                  }, {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Voir les releases"
+                    },
+                    "url": "https://github.com/gip-inclusion/immersion-facile/releases"
+                  }, {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Aller sur l'application"
+                    },
+                    "url": "https://${{ inputs.environment }}.immersion-facile.beta.gouv.fr"
+                  }, {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Voir le workfow github"
+                    },
+                    "url": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
       - name: Send Discord notification
         run: |
           releaseSuffix=$([[ "${{ inputs.isPreRelease }}" == "true" ]] && echo "-rc" || echo "")


### PR DESCRIPTION
## 🌈 Description

Suite au passage de Discord à Slack, j'ajoute dans cette PR les envois de notifications à Slack.
![Screenshot 2025-01-21 at 12 16 56](https://github.com/user-attachments/assets/875aac66-26ca-46a3-9c27-97d0acb939d3)

## 💯 Pour tester
Il est possible de voir le visuel sur le canal #if-mise-en-recette sur Slack. Tous les boutons n'y sont pas fonctionnels car les liens ne sont pas corrects.
