### PR TITLE
#2641 - récupérer le siret de l'utilisateur Pro Connecté

### DIFF
--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -324,7 +324,7 @@ export class AppConfig {
           ? "https://fake-pro-connect.url"
           : undefined,
       ),
-      scope: "openid given_name usual_name email custom",
+      scope: "openid given_name usual_name email custom siret",
     };
   }
 

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/oauth-gateway/HttpOAuthGateway.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/oauth-gateway/HttpOAuthGateway.ts
@@ -152,6 +152,7 @@ export class HttpOAuthGateway implements OAuthGateway {
         lastName: oAuthIdTokenPayload.usual_name,
         email: oAuthIdTokenPayload.email,
         structure_pe: oAuthIdTokenPayload.custom.structureTravail,
+        siret: oAuthIdTokenPayload.siret,
       },
     };
   }

--- a/back/src/domains/core/authentication/inclusion-connect/entities/OAuthIdTokenPayload.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/entities/OAuthIdTokenPayload.ts
@@ -1,4 +1,4 @@
-import { Email, ExternalId, emailSchema } from "shared";
+import { Email, ExternalId, SiretDto, emailSchema, siretSchema } from "shared";
 import { z } from "zod";
 
 type ProviderTokenPayloadBase = {
@@ -15,6 +15,7 @@ export type IcOAuthIdTokenPayload = ProviderTokenPayloadBase & {
 
 export type ProConnectOAuthIdTokenPayload = ProviderTokenPayloadBase & {
   usual_name: string;
+  siret: SiretDto;
   custom: {
     structureTravail?: string;
   };
@@ -39,4 +40,5 @@ export const proConnectAuthTokenPayloadSchema: z.Schema<ProConnectOAuthIdTokenPa
     custom: z.object({
       structureTravail: z.string().optional(),
     }),
+    siret: siretSchema,
   });

--- a/back/src/domains/core/authentication/inclusion-connect/port/OAuthGateway.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/port/OAuthGateway.ts
@@ -22,6 +22,7 @@ export type GetAccessTokenPayload = {
   lastName: string;
   email: Email;
   structure_pe?: string;
+  siret?: string; // remove optional when inclusion connect is removed
 };
 
 export type GetAccessTokenResult = {

--- a/back/src/domains/core/authentication/inclusion-connect/use-cases/AuthenticateWithInclusionCode.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/use-cases/AuthenticateWithInclusionCode.ts
@@ -189,6 +189,7 @@ export class AuthenticateWithInclusionCode extends TransactionalUseCase<
       firstName: newOrUpdatedAuthenticatedUser.firstName,
       lastName: newOrUpdatedAuthenticatedUser.lastName,
       email: newOrUpdatedAuthenticatedUser.email,
+      siret: payload.siret,
       idToken,
     })}`;
   }

--- a/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
+++ b/front/src/app/routes/InclusionConnectedPrivateRoute.tsx
@@ -22,6 +22,7 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { FrontAdminRouteTab } from "src/app/pages/admin/AdminTabs";
 import { routes } from "src/app/routes/routes";
 import { loginIllustration } from "src/assets/img/illustrations";
+import { outOfReduxDependencies } from "src/config/dependencies";
 import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { authSlice } from "src/core-logic/domain/auth/auth.slice";
 import { featureFlagSelectors } from "src/core-logic/domain/featureFlags/featureFlags.selector";
@@ -133,6 +134,7 @@ export const InclusionConnectedPrivateRoute = ({
       firstName = "",
       lastName = "",
       idToken = "",
+      siret = "",
     } = route.params;
 
     if (token) {
@@ -148,6 +150,10 @@ export const InclusionConnectedPrivateRoute = ({
           },
           feedbackTopic: "auth-global",
         }),
+      );
+      outOfReduxDependencies.localDeviceRepository.set(
+        "connectedUserSiret",
+        siret,
       );
       const { token: _, ...routeParams } = route.params;
       routes[route.name](routeParams as any).replace();

--- a/front/src/app/routes/routes.ts
+++ b/front/src/app/routes/routes.ts
@@ -33,6 +33,7 @@ export type AcquisitionParams = Partial<{
 type AcquisitionParamsKeys = keyof typeof acquisitionParams;
 
 const inclusionConnectedParams = createInclusionConnectedParams({
+  siret: param.query.optional.string,
   page: param.query.optional.string,
   token: param.query.optional.string,
   firstName: param.query.optional.string,

--- a/front/src/core-logic/domain/auth/auth.epics.ts
+++ b/front/src/core-logic/domain/auth/auth.epics.ts
@@ -79,6 +79,7 @@ const deleteFederatedIdentityFromDevice: AuthEpic = (
   action$.pipe(
     filter(authSlice.actions.federatedIdentityDeletionTriggered.match),
     tap(() => localDeviceRepository.delete("federatedIdentityWithUser")),
+    tap(() => localDeviceRepository.delete("connectedUserSiret")),
     tap(() => localDeviceRepository.delete("partialConventionInUrl")),
     map(() => authSlice.actions.federatedIdentityInDeviceDeletionSucceeded()),
   );

--- a/front/src/core-logic/ports/DeviceRepository.ts
+++ b/front/src/core-logic/ports/DeviceRepository.ts
@@ -13,7 +13,8 @@ export type LocalStoragePair =
   | GenericPair<"partialConventionInUrl", Partial<ConventionParamsInUrl>>
   | GenericPair<"adminToken", string>
   | GenericPair<"federatedIdentityWithUser", FederatedIdentityWithUser>
-  | GenericPair<"searchResultExternal", SearchResultDto>;
+  | GenericPair<"searchResultExternal", SearchResultDto>
+  | GenericPair<"connectedUserSiret", string>;
 
 export type SessionStoragePair =
   | GenericPair<"acquisitionParams", WithAcquisition>

--- a/shared/src/inclusionConnect/inclusionConnect.dto.ts
+++ b/shared/src/inclusionConnect/inclusionConnect.dto.ts
@@ -28,6 +28,7 @@ export type WithSourcePage = {
 export type AuthenticatedUserQueryParams = {
   token: InclusionConnectJwt;
   idToken: string;
+  siret?: string; // remove optional when inclusion connect is removed
 } & Pick<User, "email" | "firstName" | "lastName">;
 
 type InclusionConnectConventionManageAllowedRole =


### PR DESCRIPTION
## Description

Première partie de ce ticket: [#2641](https://github.com/gip-inclusion/immersion-facile/issues/2641)
Dans cette PR on récupère dans le front le siret de l'utilusateur pro connecté et on le stocke dans le le local storage.

On n'en fait rien pour l'instant. Ca viendra dans la suite de ce ticket.