### PR TITLE
#2893 - Afficher un message d'erreur si accès à un document de convention annulée

### DIFF
--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -1,4 +1,5 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 import Button from "@codegouvfr/react-dsfr/Button";
 import React, { useEffect, useState } from "react";
 import {
@@ -194,6 +195,9 @@ export const ConventionDocumentPage = ({
   return (
     <MainWrapper layout="default" vSpacing={8}>
       {isPdfLoading && <Loader />}
+      {!canShowConvention && (
+        <Alert severity="error" title="La convention n'est pas accessible" />
+      )}
       {canShowConvention && (
         <ConventionDocument
           logos={logos}


### PR DESCRIPTION
## 🐛 Problème

- la convention est validée par le prescripteur
- le bénéficiaire reçoit un mail de notification de validation de la convention avec un lien d'accès au document de convention
- puis la convention est annulée
- le bénéficiaire accède à la convention à partir du mail précédent
- il constate alors une page blanche

## 💯 Remarque

PR en draft en attendant la validation de la solution par Gaël