### PR TITLE
TECH - rediriger les notifications Slack vers le bon canal

### DIFF
--- a/back/src/config/helpers/handleHttpJsonResponseError.ts
+++ b/back/src/config/helpers/handleHttpJsonResponseError.ts
@@ -4,7 +4,7 @@ import { Request, Response } from "express";
 import { HttpError, HttpErrorResponseBody } from "shared";
 import { ZodError } from "zod";
 import { LoggerParamsWithMessage, createLogger } from "../../utils/logger";
-import { notifyObjectToTeam } from "../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../utils/notifyTeam";
 
 const logger = createLogger(__filename);
 
@@ -105,5 +105,5 @@ const logErrorAndNotifyDiscord = (
   };
 
   logger.error(params);
-  notifyObjectToTeam(params);
+  notifyErrorObjectToTeam(params);
 };

--- a/back/src/config/pg/kysely/kyselyUtils.ts
+++ b/back/src/config/pg/kysely/kyselyUtils.ts
@@ -11,7 +11,7 @@ import {
 import { Pool, QueryResultRow } from "pg";
 import { Falsy } from "ramda";
 import { createLogger } from "../../../utils/logger";
-import { notifyObjectToTeam } from "../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../utils/notifyTeam";
 import { Database } from "./model/database";
 
 export const jsonBuildObject = <O extends Record<string, Expression<unknown>>>(
@@ -63,7 +63,7 @@ export const makeKyselyDb = (pool: Pool, options?: KyselyOptions): KyselyDb => {
             params: event.query.parameters,
           },
         };
-        notifyObjectToTeam(params);
+        notifyErrorObjectToTeam(params);
         logger.error(params);
       } else if (event.queryDurationMillis > 1_000) {
         logger.warn({

--- a/back/src/domains/convention/adapters/france-travail-gateway/HttpFranceTravailGateway.ts
+++ b/back/src/domains/convention/adapters/france-travail-gateway/HttpFranceTravailGateway.ts
@@ -16,7 +16,10 @@ import {
   LoggerParamsWithMessage,
   createLogger,
 } from "../../../../utils/logger";
-import { notifyObjectToTeam, notifyTeam } from "../../../../utils/notifyTeam";
+import {
+  notifyErrorObjectToTeam,
+  notifyTeam,
+} from "../../../../utils/notifyTeam";
 import { InMemoryCachingGateway } from "../../../core/caching-gateway/adapters/InMemoryCachingGateway";
 import {
   RetryStrategy,
@@ -172,11 +175,12 @@ export class HttpFranceTravailGateway implements FranceTravailGateway {
             },
           });
 
-          notifyTeam(
-            `HttpFranceTravailGateway notAxiosError ${
+          notifyTeam({
+            rawContent: `HttpFranceTravailGateway notAxiosError ${
               ftConvention.originalId
             }: ${JSON.stringify(error)}`,
-          );
+            isError: true,
+          });
 
           return {
             status: 500,
@@ -199,11 +203,12 @@ export class HttpFranceTravailGateway implements FranceTravailGateway {
             },
           });
 
-          notifyTeam(
-            `HttpFranceTravailGateway noResponseInAxiosError ${
+          notifyTeam({
+            rawContent: `HttpFranceTravailGateway noResponseInAxiosError ${
               ftConvention.originalId
             }: ${JSON.stringify(error)}`,
-          );
+            isError: true,
+          });
 
           return {
             status: 500,
@@ -252,7 +257,7 @@ export class HttpFranceTravailGateway implements FranceTravailGateway {
           },
         };
         logger.error(errorObject);
-        notifyObjectToTeam(errorObject);
+        notifyErrorObjectToTeam(errorObject);
 
         return {
           status: error.response.status,

--- a/back/src/domains/core/authentication/ft-connect/adapters/ft-connect-gateway/HttpFtConnectGateway.ts
+++ b/back/src/domains/core/authentication/ft-connect/adapters/ft-connect-gateway/HttpFtConnectGateway.ts
@@ -9,7 +9,7 @@ import {
   OpacifiedLogger,
   createLogger,
 } from "../../../../../../utils/logger";
-import { notifyObjectToTeam } from "../../../../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../../../../utils/notifyTeam";
 import { parseZodSchemaAndLogErrorOnParsingFailure } from "../../../../../../utils/schema.utils";
 import { AccessTokenDto } from "../../dto/AccessToken.dto";
 import { FtConnectAdvisorDto } from "../../dto/FtConnectAdvisor.dto";
@@ -301,7 +301,7 @@ export class HttpFtConnectGateway implements FtConnectGateway {
       );
       if (error instanceof ZodError) return [];
       if (isJobseekerButNoAdvisorsResponse(error)) {
-        notifyObjectToTeam({
+        notifyErrorObjectToTeam({
           message: `isJobseekerButNoAdvisorsResponse for token: ${headers.Authorization}`,
           error,
         });
@@ -348,7 +348,7 @@ const errorChecker = (
 ): void => (error instanceof Error ? cbOnError(error) : cbOnNotError(error));
 
 const notifyTeamOnNotError = (payload: unknown): void =>
-  notifyObjectToTeam({
+  notifyErrorObjectToTeam({
     message: "Should have been an error.",
     payload,
   });

--- a/back/src/domains/core/authentication/inclusion-connect/use-cases/AuthenticateWithInclusionCode.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/use-cases/AuthenticateWithInclusionCode.ts
@@ -148,10 +148,11 @@ export class AuthenticateWithInclusionCode extends TransactionalUseCase<
     };
 
     if (!newOrUpdatedAuthenticatedUser.externalId) {
-      notifyTeam(
-        `Usecase AuthenticateWithInclusionCode. No ongoing_oauths found for externalId:
+      notifyTeam({
+        rawContent: `Usecase AuthenticateWithInclusionCode. No ongoing_oauths found for externalId:
           ${newOrUpdatedAuthenticatedUser.id}`,
-      );
+        isError: true,
+      });
     }
 
     await uow.userRepository.save(newOrUpdatedAuthenticatedUser, provider);

--- a/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
+++ b/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
@@ -4,7 +4,7 @@ import {
   LoggerParamsWithMessage,
   createLogger,
 } from "../../../../utils/logger";
-import { notifyObjectToTeam } from "../../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../../utils/notifyTeam";
 import { UnitOfWorkPerformer } from "../../unit-of-work/ports/UnitOfWorkPerformer";
 import { DomainEvent, EventStatus } from "../events";
 import { EventBus } from "../ports/EventBus";
@@ -36,7 +36,7 @@ export class BasicEventCrawler implements EventCrawler {
       message: `${status} outbox ${count} exceeds ${limit}`,
     };
     logger.error(params);
-    notifyObjectToTeam(params);
+    notifyErrorObjectToTeam(params);
   }
 
   public async processNewEvents(): Promise<void> {
@@ -104,7 +104,7 @@ export class BasicEventCrawler implements EventCrawler {
           message: "Processing event group is taking long",
           events: eventGroup,
         };
-        notifyObjectToTeam(warning);
+        notifyErrorObjectToTeam(warning);
         logger.warn(warning);
       }, 30_000);
 
@@ -135,7 +135,7 @@ export class BasicEventCrawler implements EventCrawler {
         };
 
         logger.error(params);
-        notifyObjectToTeam({
+        notifyErrorObjectToTeam({
           params,
         });
 

--- a/back/src/domains/core/events/adapters/InMemoryEventBus.ts
+++ b/back/src/domains/core/events/adapters/InMemoryEventBus.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/node";
 import { keys, prop } from "ramda";
 import { DateString, errorToString } from "shared";
 import { createLogger } from "../../../../utils/logger";
-import { notifyObjectToTeam } from "../../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../../utils/notifyTeam";
 import { TimeGateway } from "../../time-gateway/ports/TimeGateway";
 import { UnitOfWorkPerformer } from "../../unit-of-work/ports/UnitOfWorkPerformer";
 import {
@@ -118,7 +118,7 @@ export class InMemoryEventBus implements EventBus {
       const message = "Failed too many times, event will be Quarantined";
       logger.error({ events: [event], message });
       const { payload: _, publications: __, ...restEvent } = event;
-      notifyObjectToTeam({
+      notifyErrorObjectToTeam({
         event: {
           ...restEvent,
           lastPublication: getLastPublication(event),

--- a/back/src/domains/establishment/adapters/PgFormEstablishmentRepository.ts
+++ b/back/src/domains/establishment/adapters/PgFormEstablishmentRepository.ts
@@ -13,7 +13,7 @@ import {
   jsonStripNulls,
 } from "../../../config/pg/kysely/kyselyUtils";
 import { createLogger } from "../../../utils/logger";
-import { notifyObjectToTeam } from "../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../utils/notifyTeam";
 import { FormEstablishmentRepository } from "../ports/FormEstablishmentRepository";
 
 const logger = createLogger(__filename);
@@ -58,7 +58,7 @@ export class PgFormEstablishmentRepository
           message: "Cannot save form establishment ",
           error: castedError,
         });
-        notifyObjectToTeam({
+        notifyErrorObjectToTeam({
           _message: `Cannot create form establishment with siret ${formEstablishment.siret}`,
           ...castedError,
         });

--- a/back/src/domains/establishment/use-cases/SuggestEditEstablishment.ts
+++ b/back/src/domains/establishment/use-cases/SuggestEditEstablishment.ts
@@ -6,7 +6,7 @@ import {
   immersionFacileNoReplyEmailSender,
   siretSchema,
 } from "shared";
-import { notifyObjectToTeam } from "../../../utils/notifyTeam";
+import { notifyErrorObjectToTeam } from "../../../utils/notifyTeam";
 import { TransactionalUseCase } from "../../core/UseCase";
 import { makeProvider } from "../../core/authentication/inclusion-connect/port/OAuthGateway";
 import { GenerateEditFormEstablishmentJwt } from "../../core/jwt";
@@ -82,6 +82,6 @@ export class SuggestEditEstablishment extends TransactionalUseCase<SiretDto> {
       followedIds: {
         establishmentSiret: siret,
       },
-    }).catch((error) => notifyObjectToTeam(error));
+    }).catch((error) => notifyErrorObjectToTeam(error));
   }
 }

--- a/back/src/scripts/handleCRONScript.ts
+++ b/back/src/scripts/handleCRONScript.ts
@@ -81,7 +81,9 @@ const onScriptSuccess =
       duration: durationInSeconds,
     });
 
-    return notifyTeam(report).finally(() => process.exit(0));
+    return notifyTeam({ rawContent: report, isError: false }).finally(() =>
+      process.exit(0),
+    );
   };
 
 const onScriptError =
@@ -119,5 +121,7 @@ const onScriptError =
       duration: durationInSeconds,
     });
 
-    return notifyTeam(report).finally(() => process.exit(0));
+    return notifyTeam({ rawContent: report, isError: false }).finally(() =>
+      process.exit(0),
+    );
   };

--- a/back/src/utils/notifyTeam.manual.test.ts
+++ b/back/src/utils/notifyTeam.manual.test.ts
@@ -1,7 +1,10 @@
 // This test need the env var DISCORD_WEBHOOK_URL to be set.
 
 import { DomainEvent } from "../domains/core/events/events";
-import { notifyObjectToTeam, notifyToTeamAndThrowError } from "./notifyTeam";
+import {
+  notifyErrorObjectToTeam,
+  notifyToTeamAndThrowError,
+} from "./notifyTeam";
 
 describe("Notify Team", () => {
   it("Should serialize the thrown Error and notify channel dev-error channel", () => {
@@ -9,7 +12,7 @@ describe("Notify Team", () => {
       throw new SyntaxError("TEST NOTIFICATION - Invalid syntax for action !");
     } catch (e: unknown) {
       expect(e).toBeInstanceOf(SyntaxError);
-      notifyObjectToTeam(e as Error);
+      notifyErrorObjectToTeam(e as Error);
     }
   });
 
@@ -40,7 +43,7 @@ describe("Notify Team", () => {
       topic: "MagicLinkRenewalRequested",
       wasQuarantined: false,
     };
-    notifyObjectToTeam({
+    notifyErrorObjectToTeam({
       event: domainEvent,
       message: "TEST NOTIFICATION - test message with domain event",
     });


### PR DESCRIPTION
## Description

Les notifications Slack, d'information et de succès, sont toujours envoyés au canal d'erreur.
On voudrait pouvoir distinguer le type de notification et renvoyer seulement les erreurs au canal d'erreur.