### PR TITLE
#2918 - fix timezone pour signature de la convention

### DIFF
--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -501,7 +501,8 @@ export const isSundayInSchedule = (complexSchedule: DailyScheduleDto[]) => {
   const sunday = 0;
   return complexSchedule.some(
     (week) =>
-      getDay(parseISO(week.date)) === sunday && week.timePeriods.length > 0,
+      getDay(convertLocaleDateToUtcTimezoneDate(parseISO(week.date))) ===
+        sunday && week.timePeriods.length > 0,
   );
 };
 


### PR DESCRIPTION
## 🐛 Problème

Le signataire ne peut pas accéder à la convention pour la signer car il obtient l’erreur: “Le mini-stage ne peut pas se dérouler un dimanche” alors que son emploi du temps est correct.