### PR TITLE
#2941 - Fix affichage du titre sur le tableau de bord prescripteur

### DIFF
--- a/front/src/app/components/agency/agency-dashboard/NoActiveAgencyRights.tsx
+++ b/front/src/app/components/agency/agency-dashboard/NoActiveAgencyRights.tsx
@@ -1,6 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useState } from "react";
+import React, { useState } from "react";
 import { AgencyRight, InclusionConnectedUser } from "shared";
 import { RegisterAgenciesForm } from "src/app/components/forms/register-agencies/RegisterAgenciesForm";
 import { commonIllustrations } from "src/assets/img/illustrations";
@@ -17,6 +17,7 @@ export function NoActiveAgencyRights({
     useState<boolean>(false);
   return (
     <>
+      <h1>Demander l'accès à des organismes</h1>
       <h2 className={fr.cx("fr-mt-2w")}>Suivi de mes demandes</h2>
       <div className={fr.cx("fr-grid-row")}>
         <div

--- a/front/src/app/pages/agency-dashboard/AgencyDashboardPage.tsx
+++ b/front/src/app/pages/agency-dashboard/AgencyDashboardPage.tsx
@@ -28,9 +28,6 @@ export const AgencyDashboardPage = ({
 
   return (
     <>
-      <div className={fr.cx("fr-grid-row")}>
-        <h1>Demander l'accès à des organismes</h1>
-      </div>
       {isLoading && <Loader />}
       <Feedback topic="dashboard-agency-register-user" />
 
@@ -44,14 +41,18 @@ export const AgencyDashboardPage = ({
           ({ currentUser }) => {
             if (new Date(currentUser.createdAt) > subMinutes(new Date(), 1))
               return (
-                <Alert
-                  severity="warning"
-                  title="Rattachement à vos organismes en cours"
-                  description="Vous êtes bien connecté. Nous sommes en train de vérifier si vous avez des organismes rattachées à votre compte. Merci de patienter. Ca ne devrait pas prendre plus de 1 minute. Veuillez recharger la page après ce delai."
-                />
+                <>
+                  <h1>Demander l'accès à des organismes</h1>
+                  <Alert
+                    severity="warning"
+                    title="Rattachement à vos organismes en cours"
+                    description="Vous êtes bien connecté. Nous sommes en train de vérifier si vous avez des organismes rattachées à votre compte. Merci de patienter. Ca ne devrait pas prendre plus de 1 minute. Veuillez recharger la page après ce delai."
+                  />
+                </>
               );
             return (
               <>
+                <h1>Demander l'accès à des organismes</h1>
                 <p className={fr.cx("fr-mt-4w")}>
                   Bonjour {currentUser.firstName} {currentUser.lastName},
                   recherchez un organisme afin d'accéder aux conventions et
@@ -72,12 +73,15 @@ export const AgencyDashboardPage = ({
               distinguishAgencyRights(currentUser.agencyRights);
 
             return activeAgencyRights.length ? (
-              <AgencyDashboard
-                route={route}
-                activeAgencyRights={activeAgencyRights}
-                dashboards={currentUser.dashboards}
-                inclusionConnectedJwt={inclusionConnectedJwt}
-              />
+              <>
+                <h1>Bienvenue</h1>
+                <AgencyDashboard
+                  route={route}
+                  activeAgencyRights={activeAgencyRights}
+                  dashboards={currentUser.dashboards}
+                  inclusionConnectedJwt={inclusionConnectedJwt}
+                />
+              </>
             ) : (
               <NoActiveAgencyRights
                 toReviewAgencyRights={toReviewAgencyRights}


### PR DESCRIPTION
## 🐛 Problème

ETQ Prescripteur , je me connecte à mon espace, j'ai le visu suivant

![image (1)](https://github.com/user-attachments/assets/8b468d7a-2ab6-452e-ac58-41c977437867)

## Solution

N'afficher ce titre que sur les pages de rattachement d'agences.
