### PR TITLE
#2157 - Fix typo sur la page de bilan

### DIFF
--- a/front/src/app/pages/convention/AssessmentDocumentPage.tsx
+++ b/front/src/app/pages/convention/AssessmentDocumentPage.tsx
@@ -205,7 +205,7 @@ export const AssessmentDocumentPage = ({
             Ce document a été rédigé dans le cadre{" "}
             {convention.internshipKind === "immersion"
               ? "de l'immersion professionelle réalisée"
-              : "du mini-stage réalisé"}
+              : "du mini-stage réalisé"}{" "}
             par {convention.signatories.beneficiary.firstName}{" "}
             {convention.signatories.beneficiary.lastName} chez{" "}
             {convention.businessName}. Il peut être utilisé comme référence lors


### PR DESCRIPTION
## Description

Fix de typo sur la page de bilan: "réaliséepar" (manque un espace)

![Screenshot 2025-02-11 at 18 01 04](https://github.com/user-attachments/assets/083f73d2-eb8f-454e-91a4-31af18267f6c)
