### PR TITLE
#2450 - Envoyer le résultat du bilan au bénéficiaire

### DIFF
--- a/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
+++ b/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   createConventionMagicLinkPayload,
   displayRouteName,
   errors,
+  expectArraysToMatch,
   expectHttpResponseToEqual,
 } from "shared";
 import { HttpClient } from "shared-routes";
@@ -88,7 +89,11 @@ describe("Assessment routes", () => {
 
       await processEventsForEmailToBeSent(eventCrawler);
 
-      expect(gateways.notification.getSentEmails()).toMatchObject([
+      expectArraysToMatch(gateways.notification.getSentEmails(), [
+        {
+          kind: "ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION",
+          recipients: [convention.signatories.beneficiary.email],
+        },
         {
           kind: "ASSESSMENT_CREATED_ESTABLISHMENT_NOTIFICATION",
           recipients: [

--- a/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
+++ b/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
@@ -91,14 +91,14 @@ describe("Assessment routes", () => {
 
       expectArraysToMatch(gateways.notification.getSentEmails(), [
         {
-          kind: "ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION",
-          recipients: [convention.signatories.beneficiary.email],
-        },
-        {
           kind: "ASSESSMENT_CREATED_ESTABLISHMENT_NOTIFICATION",
           recipients: [
             convention.signatories.establishmentRepresentative.email,
           ],
+        },
+        {
+          kind: "ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION",
+          recipients: [convention.signatories.beneficiary.email],
         },
         {
           kind: "ASSESSMENT_CREATED_WITH_STATUS_COMPLETED_AGENCY_NOTIFICATION",

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -43,6 +43,7 @@ import { NotifyAllActorsOfFinalConventionValidation } from "../../domains/conven
 import { NotifyAllActorsThatConventionIsCancelled } from "../../domains/convention/use-cases/notifications/NotifyAllActorsThatConventionIsCancelled";
 import { NotifyAllActorsThatConventionIsDeprecated } from "../../domains/convention/use-cases/notifications/NotifyAllActorsThatConventionIsDeprecated";
 import { NotifyAllActorsThatConventionIsRejected } from "../../domains/convention/use-cases/notifications/NotifyAllActorsThatConventionIsRejected";
+import { makeNotifyBeneficiaryThatAssessmentIsCreated } from "../../domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentIsCreated";
 import { NotifyConventionReminder } from "../../domains/convention/use-cases/notifications/NotifyConventionReminder";
 import { makeNotifyEstablishmentThatAssessmentWasCreated } from "../../domains/convention/use-cases/notifications/NotifyEstablishmentThatAssessmentWasCreated";
 import { NotifyIcUserAgencyRightChanged } from "../../domains/convention/use-cases/notifications/NotifyIcUserAgencyRightChanged";
@@ -668,6 +669,15 @@ export const createUseCases = (
     getAssessmentByConventionId: makeGetAssessmentByConventionId({
       uowPerformer,
     }),
+    notifyBeneficiaryThatAssessmentIsCreated:
+      makeNotifyBeneficiaryThatAssessmentIsCreated({
+        uowPerformer,
+        deps: {
+          saveNotificationAndRelatedEvent,
+          generateConventionMagicLinkUrl: generateConventionLongDurationLinkUrl,
+          timeGateway: gateways.timeGateway,
+        },
+      }),
     listActiveSubscriptions: makeListActiveSubscriptions({
       uowPerformer,
     }),

--- a/back/src/domains/convention/use-cases/CreateAssessment.ts
+++ b/back/src/domains/convention/use-cases/CreateAssessment.ts
@@ -42,6 +42,7 @@ export const makeCreateAssessment = createTransactionalUseCase<
     );
 
     throwForbiddenIfNotAllowedForAssessments(
+      "CreateAssessment",
       convention,
       await agencyWithRightToAgencyDto(uow, agency),
       conventionJwtPayload,

--- a/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
+++ b/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
@@ -160,7 +160,15 @@ describe("CreateAssessment", () => {
       "throws forbidden if the jwt role is '%s'",
       async (role) => {
         await expectPromiseToFailWithError(
-          createAssessment.execute(assessment, { ...tutorPayload, role }),
+          createAssessment.execute(assessment, {
+            applicationId: validatedConvention.id,
+            emailHash: makeHashByRolesForTest(
+              validatedConvention,
+              counsellor,
+              validator,
+            )[role],
+            role,
+          }),
           errors.assessment.forbidden(),
         );
       },

--- a/back/src/domains/convention/use-cases/GetAssessmentByConventionId.ts
+++ b/back/src/domains/convention/use-cases/GetAssessmentByConventionId.ts
@@ -31,6 +31,7 @@ export const makeGetAssessmentByConventionId = createTransactionalUseCase<
     );
 
     throwForbiddenIfNotAllowedForAssessments(
+      "GetAssessment",
       convention,
       await agencyWithRightToAgencyDto(uow, agency),
       currentUser,

--- a/back/src/domains/convention/use-cases/GetAssessmentByConventionId.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetAssessmentByConventionId.unit.test.ts
@@ -50,7 +50,7 @@ describe("GetAssessmentByConventionId", () => {
   };
   const [passingRoles, failingRoles] = splitCasesBetweenPassingAndFailing(
     allRoles,
-    ["establishment-tutor", "validator", "counsellor"],
+    ["establishment-tutor", "validator", "counsellor", "beneficiary"],
   );
 
   let getAssessment: GetAssessmentByConventionId;
@@ -103,7 +103,12 @@ describe("GetAssessmentByConventionId", () => {
           getAssessment.execute(
             { conventionId: convention.id },
             {
-              ...establishmentTutorPayload,
+              applicationId: convention.id,
+              emailHash: makeHashByRolesForTest(
+                convention,
+                counsellor,
+                validator,
+              )[role],
               role,
             },
           ),

--- a/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.ts
@@ -42,7 +42,6 @@ export class NotifyAgencyThatAssessmentIsCreated extends TransactionalUseCase<Wi
         templatedContent: {
           kind: "ASSESSMENT_CREATED_WITH_STATUS_DID_NOT_SHOW_AGENCY_NOTIFICATION",
           recipients,
-          cc: [convention.signatories.beneficiary.email],
           params: {
             beneficiaryFirstName: convention.signatories.beneficiary.firstName,
             beneficiaryLastName: convention.signatories.beneficiary.lastName,
@@ -79,7 +78,6 @@ export class NotifyAgencyThatAssessmentIsCreated extends TransactionalUseCase<Wi
         templatedContent: {
           kind: "ASSESSMENT_CREATED_WITH_STATUS_COMPLETED_AGENCY_NOTIFICATION",
           recipients,
-          cc: [convention.signatories.beneficiary.email],
           params: {
             beneficiaryFirstName: convention.signatories.beneficiary.firstName,
             beneficiaryLastName: convention.signatories.beneficiary.lastName,

--- a/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.unit.test.ts
@@ -134,7 +134,6 @@ describe("NotifyAgencyThatAssessmentIsCreated", () => {
             numberOfHoursMade: "45h",
           },
           recipients: [validator.email, validator2.email],
-          cc: [convention.signatories.beneficiary.email],
         },
       ],
     });
@@ -182,7 +181,6 @@ describe("NotifyAgencyThatAssessmentIsCreated", () => {
               convention.immersionAppellation.appellationLabel,
           },
           recipients: [validator.email, validator2.email],
-          cc: [convention.signatories.beneficiary.email],
         },
       ],
     });

--- a/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentIsCreated.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentIsCreated.ts
@@ -1,0 +1,67 @@
+import {
+  WithAssessmentDto,
+  errors,
+  frontRoutes,
+  withAssessmentSchema,
+} from "shared";
+import { GenerateConventionMagicLinkUrl } from "../../../../config/bootstrap/magicLinkUrl";
+import { createTransactionalUseCase } from "../../../core/UseCase";
+import { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
+import { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
+
+export type NotifyBeneficiaryThatAssessmentIsCreated = ReturnType<
+  typeof makeNotifyBeneficiaryThatAssessmentIsCreated
+>;
+export const makeNotifyBeneficiaryThatAssessmentIsCreated =
+  createTransactionalUseCase<
+    WithAssessmentDto,
+    void,
+    void,
+    {
+      saveNotificationAndRelatedEvent: SaveNotificationAndRelatedEvent;
+      generateConventionMagicLinkUrl: GenerateConventionMagicLinkUrl;
+      timeGateway: TimeGateway;
+    }
+  >(
+    {
+      name: "NotifyBeneficiaryThatAssessmentIsCreated",
+      inputSchema: withAssessmentSchema,
+    },
+    async ({ uow, inputParams, deps }) => {
+      const convention = await uow.conventionRepository.getById(
+        inputParams.assessment.conventionId,
+      );
+
+      if (!convention)
+        throw errors.convention.notFound({
+          conventionId: inputParams.assessment.conventionId,
+        });
+
+      const today = deps.timeGateway.now();
+      await deps.saveNotificationAndRelatedEvent(uow, {
+        kind: "email",
+        templatedContent: {
+          kind: "ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION",
+          recipients: [convention.signatories.beneficiary.email],
+          params: {
+            internshipKind: convention.internshipKind,
+            conventionId: convention.id,
+            beneficiaryLastName: convention.signatories.beneficiary.lastName,
+            beneficiaryFirstName: convention.signatories.beneficiary.firstName,
+            magicLink: deps.generateConventionMagicLinkUrl({
+              id: convention.id,
+              email: convention.signatories.beneficiary.email,
+              role: "beneficiary",
+              targetRoute: frontRoutes.assessmentDocument,
+              now: today,
+            }),
+          },
+        },
+        followedIds: {
+          conventionId: convention.id,
+          agencyId: convention.agencyId,
+          establishmentSiret: convention.siret,
+        },
+      });
+    },
+  );

--- a/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentIsCreated.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentIsCreated.unit.test.ts
@@ -1,0 +1,115 @@
+import {
+  AssessmentDto,
+  AssessmentStatus,
+  ConventionDtoBuilder,
+  ExtractFromExisting,
+  errors,
+  expectPromiseToFailWithError,
+  frontRoutes,
+} from "shared";
+import { fakeGenerateMagicLinkUrlFn } from "../../../../utils/jwtTestHelper";
+import {
+  ExpectSavedNotificationsAndEvents,
+  makeExpectSavedNotificationsAndEvents,
+} from "../../../../utils/makeExpectSavedNotificationAndEvent.helpers";
+import { makeSaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
+import { CustomTimeGateway } from "../../../core/time-gateway/adapters/CustomTimeGateway";
+import { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
+import { InMemoryUowPerformer } from "../../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import {
+  InMemoryUnitOfWork,
+  createInMemoryUow,
+} from "../../../core/unit-of-work/adapters/createInMemoryUow";
+import { UuidV4Generator } from "../../../core/uuid-generator/adapters/UuidGeneratorImplementations";
+import {
+  NotifyBeneficiaryThatAssessmentIsCreated,
+  makeNotifyBeneficiaryThatAssessmentIsCreated,
+} from "./NotifyBeneficiaryThatAssessmentIsCreated";
+
+const convention = new ConventionDtoBuilder().build();
+const assessment: Extract<
+  AssessmentDto,
+  {
+    status: ExtractFromExisting<AssessmentStatus, "PARTIALLY_COMPLETED">;
+  }
+> = {
+  endedWithAJob: false,
+  conventionId: convention.id,
+  status: "PARTIALLY_COMPLETED",
+  lastDayOfPresence: new Date("2025-01-07").toISOString(),
+  numberOfMissedHours: 4,
+  establishmentFeedback: "osef",
+  establishmentAdvices: "osef",
+};
+
+describe("NotifyBeneficiaryThatAssessmentIsCreated", () => {
+  let uow: InMemoryUnitOfWork;
+  let usecase: NotifyBeneficiaryThatAssessmentIsCreated;
+  let expectSavedNotificationsAndEvents: ExpectSavedNotificationsAndEvents;
+  let timeGateway: TimeGateway;
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
+    usecase = makeNotifyBeneficiaryThatAssessmentIsCreated({
+      uowPerformer: new InMemoryUowPerformer(uow),
+      deps: {
+        saveNotificationAndRelatedEvent: makeSaveNotificationAndRelatedEvent(
+          new UuidV4Generator(),
+          new CustomTimeGateway(),
+        ),
+        timeGateway,
+        generateConventionMagicLinkUrl: fakeGenerateMagicLinkUrlFn,
+      },
+    });
+    expectSavedNotificationsAndEvents = makeExpectSavedNotificationsAndEvents(
+      uow.notificationRepository,
+      uow.outboxRepository,
+    );
+  });
+
+  describe("wrong paths", () => {
+    it("Throw when no convention is found", async () => {
+      await expectPromiseToFailWithError(
+        usecase.execute({ assessment }),
+        errors.convention.notFound({ conventionId: assessment.conventionId }),
+      );
+
+      expectSavedNotificationsAndEvents({
+        emails: [],
+      });
+    });
+  });
+
+  describe("right paths", () => {
+    it("Send an email to beneficiary", async () => {
+      const today = timeGateway.now();
+      uow.conventionRepository.setConventions([convention]);
+
+      await usecase.execute({ assessment });
+
+      expectSavedNotificationsAndEvents({
+        emails: [
+          {
+            kind: "ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION",
+            params: {
+              internshipKind: convention.internshipKind,
+              conventionId: convention.id,
+              beneficiaryFirstName:
+                convention.signatories.beneficiary.firstName,
+              beneficiaryLastName: convention.signatories.beneficiary.lastName,
+              magicLink: fakeGenerateMagicLinkUrlFn({
+                id: convention.id,
+                email: convention.signatories.beneficiary.email,
+                role: "beneficiary",
+                targetRoute: frontRoutes.assessmentDocument,
+                now: today,
+              }),
+            },
+            recipients: [convention.signatories.beneficiary.email],
+          },
+        ],
+      });
+    });
+  });
+});

--- a/back/src/domains/core/events/subscribeToEvents.ts
+++ b/back/src/domains/core/events/subscribeToEvents.ts
@@ -149,6 +149,7 @@ const getUseCasesByTopics = (
   AssessmentCreated: [
     useCases.notifyAgencyThatAssessmentIsCreated,
     useCases.notifyEstablishmentThatAssessmentWasCreated,
+    useCases.notifyBeneficiaryThatAssessmentIsCreated,
   ],
   EmailWithLinkToCreateAssessmentSent: [],
   BeneficiaryAssessmentEmailSent: [],

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -508,6 +508,13 @@ export const defaultEmailValueByEmailKind: {
     internshipKind: "immersion",
     immersionAppellationLabel: "APPELLATION_LABEL",
   },
+  ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION: {
+    internshipKind: "immersion",
+    conventionId: "CONVENTION_ID",
+    beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",
+    beneficiaryLastName: "BENEFICIARY_LAST_NAME",
+    magicLink: "http://MAGIC_LINK",
+  },
   NEW_CONVENTION_AGENCY_NOTIFICATION: {
     internshipKind: "immersion",
     conventionId: "CONVENTION_ID",

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -141,6 +141,13 @@ export type EmailParamsByEmailType = {
     internshipKind: InternshipKind;
     immersionAppellationLabel: string;
   };
+  ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION: {
+    internshipKind: InternshipKind;
+    conventionId: ConventionId;
+    beneficiaryFirstName: string;
+    beneficiaryLastName: string;
+    magicLink: string;
+  };
   BENEFICIARY_OR_ESTABLISHMENT_REPRESENTATIVE_ALREADY_SIGNED_NOTIFICATION: {
     agencyLogoUrl: AbsoluteUrl | undefined;
     beneficiaryFirstName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -364,10 +364,47 @@ export const emailTemplatesByName =
         };
       },
     },
+    ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION: {
+      niceName: "Bilan - Bénéficiaire - Bilan complété",
+      tags: ["bilan_créé_bénéficiaire"],
+      createEmailVariables: ({
+        internshipKind,
+        conventionId,
+        beneficiaryFirstName,
+        beneficiaryLastName,
+        magicLink,
+      }) => {
+        return {
+          subject: `Immersion Facilitée - Le bilan de votre ${
+            internshipKind === "immersion" ? "immersion" : "mini-stage"
+          } est disponible ! `,
+          greetings: greetingsWithConventionId(
+            conventionId,
+            `${beneficiaryFirstName} ${beneficiaryLastName}`,
+          ),
+          content: `
+          <strong>Votre entreprise d'accueil a rédigé un avis concernant votre période ${
+            internshipKind === "immersion" ? "d'immersion" : "de mini-stage"
+          }.</strong> Ce retour peut être un atout pour vos futures candidatures en mettant en valeur vos expériences et compétences acquises.
+          
+          Pour consulter cet avis et le conserver dans votre dossier de candidature, vous pouvez le télécharger au format PDF en cliquant sur le bouton ci-dessous. Ce lien a une validité de 6 mois.
+          `,
+          buttons: [{ label: "Consulter mon bilan", url: magicLink }],
+          subContent: `
+          Nous vous encourageons à intégrer ce document dans vos candidatures afin de valoriser votre expérience auprès de vos futurs employeurs.
+          
+          N'hésitez pas à revenir vers nous si vous avez des questions ou besoin d'aide supplémentaire.
+           
+          ${defaultSignature(internshipKind)}
+          `,
+        };
+      },
+    },
     TEST_EMAIL: {
       niceName: "Email de test Immersion Facilitée",
       createEmailVariables: ({ input1, input2, url }) => ({
-        subject: "[Immersion Facilitée] Email transactionel de test",
+        subject:
+          "[Immersion Facilitée] Le bilan de votre immersion est disponible !",
         greetings: "Bonjour,",
         content: `
           Cet email vous a été envoyé dans le cadre d'un test.


### PR DESCRIPTION
## 🌈 Description

Le bénéficiaire reçoit un mail avec un lien vers le bilan une fois que l'entreprise l'a complété.

![Screenshot 2025-02-13 at 10 51 19](https://github.com/user-attachments/assets/e4e75d92-e04f-4d51-984b-f1b757bc9b67)

![Screenshot 2025-02-13 at 10 50 11](https://github.com/user-attachments/assets/66ac8f0a-2984-4988-ab4e-8f7728a832c1)
