### PR TITLE
#3004 - page de récap de convention: remettre les boutons de copie sans labels + sans bordures

### DIFF
--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -99,6 +99,7 @@ const makeSignatoriesSubsections = (
             <CopyButton
               withIcon={true}
               textToCopy={convention.signatories.beneficiary.email}
+              priority="tertiary no outline"
             />
           ),
         },

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -94,6 +94,7 @@ export const ConventionSummary = ({
               textToCopy={conventionId}
               withIcon={true}
               className={fr.cx("fr-my-2v")}
+              priority="tertiary"
             />
           </div>
         </section>

--- a/libs/react-design-system/src/immersionFacile/components/copy-button/CopyButton.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/copy-button/CopyButton.tsx
@@ -23,7 +23,7 @@ export const CopyButton = (props: CopyButtonProperties) => {
       disabled={copyButtonIsDisabled}
       onClick={() => onCopyButtonClick(props.textToCopy)}
       size="small"
-      priority="tertiary"
+      priority={props.priority ?? "tertiary no outline"}
       className={cx(
         fr.cx(
           "fr-py-0",

--- a/libs/react-design-system/src/immersionFacile/components/copy-button/useCopyButton.ts
+++ b/libs/react-design-system/src/immersionFacile/components/copy-button/useCopyButton.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-export const useCopyButton = (defaultLabel = "Copier cet ID") => {
+export const useCopyButton = (label = "") => {
   const [isCopied, setIsCopied] = useState(false);
 
   const onCopyButtonClick = (stringToCopy: string) => {
@@ -18,7 +18,7 @@ export const useCopyButton = (defaultLabel = "Copier cet ID") => {
 
   const copyButtonIsDisabled = isCopied;
 
-  const copyButtonLabel = isCopied ? "Copié !" : defaultLabel;
+  const copyButtonLabel = isCopied ? "Copié !" : label;
 
   return { onCopyButtonClick, copyButtonLabel, copyButtonIsDisabled, isCopied };
 };


### PR DESCRIPTION
## Description

Remettre le bouton de copie possiblement sans label et sans bordure sur la page de récap de convention

![Screenshot 2025-02-14 at 12 05 03](https://github.com/user-attachments/assets/cafceefd-6ddf-4c24-8542-3ae4433846d2)

