### PR TITLE
#3004 - fix du bouton de copie d'id agence sur la page d'agence

### DIFF
--- a/front/src/app/components/agency/CopyAgencyId.tsx
+++ b/front/src/app/components/agency/CopyAgencyId.tsx
@@ -1,24 +1,19 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
-import { Button } from "@codegouvfr/react-dsfr/Button";
 import React from "react";
-import { useCopyButton } from "react-design-system";
+import { CopyButton } from "react-design-system";
 import { AgencyId } from "shared";
 
 export const CopyAgencyId = ({ agencyId }: { agencyId: AgencyId }) => {
-  const { copyButtonIsDisabled, copyButtonLabel, onCopyButtonClick } =
-    useCopyButton("Copier");
-
   return (
     <div>
       Id de l'agence : <Badge severity="success">{agencyId}</Badge>{" "}
-      <Button
-        type="button"
-        disabled={copyButtonIsDisabled}
-        iconId={"fr-icon-clipboard-fill"}
-        onClick={() => onCopyButtonClick(agencyId)}
-      >
-        {copyButtonLabel}
-      </Button>
+      <CopyButton
+        label="Copier"
+        textToCopy={agencyId}
+        withIcon={true}
+        className={fr.cx("fr-ml-1v")}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description

Avant:
![Screenshot 2025-02-17 at 12 15 20](https://github.com/user-attachments/assets/d7bf6839-1d90-4f7a-a57b-fe191e3bae9a)

Après:
![Screenshot 2025-02-17 at 12 10 08](https://github.com/user-attachments/assets/31d80c3e-e5fb-4e92-bf4e-3dfc18cdbd41)
