### PR TITLE
#2955 - fix affichage des champs du représentant légal du bénéficiaire

### DIFF
--- a/shared/src/convention/convention.ts
+++ b/shared/src/convention/convention.ts
@@ -1,4 +1,4 @@
-import { differenceInCalendarISOWeekYears } from "date-fns";
+import { differenceInISOWeekYears } from "date-fns";
 import { keys, mapObjIndexed, values } from "ramda";
 import { Role, SignatoryRole, allSignatoryRoles } from "../role/role.dto";
 import { DotNestedKeys } from "../utils";
@@ -115,7 +115,7 @@ export const isBeneficiaryMinorAccordingToAge = (
   conventionDateStart: DateString,
   beneficiaryBirthdate: string,
 ): boolean => {
-  const age = differenceInCalendarISOWeekYears(
+  const age = differenceInISOWeekYears(
     new Date(conventionDateStart),
     new Date(beneficiaryBirthdate),
   );


### PR DESCRIPTION
## 🐛 Problème

Les champs du représentant légal du bénéficiaire ne s'affiche plus lorsque le candidat a 18 ans l'année de l'immersion.

## 🤖 Pour reproduire le bug

1. Sur le formulaire de convention, saisir 30/11/2007 comme date de naissance du candidat
2. Constater que les champs du représentant légal du bénéficiaire ne s'affichent pas

 ## 💯 Solution

Utiliser `differenceInISOWeekYears` au lieu de `differenceInCalendarISOWeekYears` de date-fns, qui permet de considérer la progression dans l'année et pas juste l'année.