### PR TITLE
#3080 - Fix: afficher un message d'erreur correct

### DIFF
--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -10,11 +10,14 @@ import {
 } from "react-design-system";
 import { useDispatch } from "react-redux";
 import {
+  AgencyModifierRole,
   ConventionId,
   ConventionReadDto,
+  SignatoryRole,
   addressDtoToString,
   convertLocaleDateToUtcTimezoneDate,
   domElementIds,
+  errors,
   isConventionRenewed,
   isStringDate,
   makeSiretDescriptionLink,
@@ -35,8 +38,21 @@ import { Route } from "type-route";
 import logoIf from "/assets/img/logo-if.svg";
 import logoRf from "/assets/img/logo-rf.svg";
 
-const throwOnMissingSignDate = (signedAt: string | undefined): string => {
-  if (!signedAt) throw new Error("Signature date is missing.");
+const throwOnMissingSignDate = (
+  actor: SignatoryRole,
+  signedAt: string | undefined,
+): string => {
+  if (!signedAt)
+    throw errors.convention.missingSignatorySignature({ role: actor });
+  return signedAt;
+};
+
+const throwOnMissingApprovalOrValidationDate = (
+  actor: AgencyModifierRole,
+  signedAt: string | undefined,
+): string => {
+  if (!signedAt)
+    throw errors.convention.missingAgencyApprovalOrValidation({ role: actor });
   return signedAt;
 };
 
@@ -530,7 +546,9 @@ export const ConventionDocumentPage = ({
               (signé le{" "}
               {toDisplayedDate({
                 date: convertLocaleDateToUtcTimezoneDate(
-                  new Date(throwOnMissingSignDate(beneficiary.signedAt)),
+                  new Date(
+                    throwOnMissingSignDate("beneficiary", beneficiary.signedAt),
+                  ),
                 ),
                 withHours: true,
                 showGMT: true,
@@ -549,6 +567,7 @@ export const ConventionDocumentPage = ({
                   date: convertLocaleDateToUtcTimezoneDate(
                     new Date(
                       throwOnMissingSignDate(
+                        "beneficiary-representative",
                         beneficiaryRepresentative.signedAt,
                       ),
                     ),
@@ -572,6 +591,7 @@ export const ConventionDocumentPage = ({
                   date: convertLocaleDateToUtcTimezoneDate(
                     new Date(
                       throwOnMissingSignDate(
+                        "beneficiary-current-employer",
                         beneficiaryCurrentEmployer.signedAt,
                       ),
                     ),
@@ -591,6 +611,7 @@ export const ConventionDocumentPage = ({
                 date: convertLocaleDateToUtcTimezoneDate(
                   new Date(
                     throwOnMissingSignDate(
+                      "establishment-representative",
                       establishmentRepresentative.signedAt,
                     ),
                   ),
@@ -607,7 +628,12 @@ export const ConventionDocumentPage = ({
                 , <strong>{convention.agencyName}</strong> (validé le{" "}
                 {toDisplayedDate({
                   date: convertLocaleDateToUtcTimezoneDate(
-                    new Date(throwOnMissingSignDate(convention.dateValidation)),
+                    new Date(
+                      throwOnMissingApprovalOrValidationDate(
+                        "validator",
+                        convention.dateValidation,
+                      ),
+                    ),
                   ),
                 })}
                 )
@@ -624,7 +650,10 @@ export const ConventionDocumentPage = ({
                   {toDisplayedDate({
                     date: convertLocaleDateToUtcTimezoneDate(
                       new Date(
-                        throwOnMissingSignDate(convention.dateValidation),
+                        throwOnMissingApprovalOrValidationDate(
+                          "validator",
+                          convention.dateValidation,
+                        ),
                       ),
                     ),
                   })}
@@ -635,7 +664,12 @@ export const ConventionDocumentPage = ({
                   <strong>{convention.agencyName}</strong> (validé le{" "}
                   {toDisplayedDate({
                     date: convertLocaleDateToUtcTimezoneDate(
-                      new Date(throwOnMissingSignDate(convention.dateApproval)),
+                      new Date(
+                        throwOnMissingApprovalOrValidationDate(
+                          "counsellor",
+                          convention.dateApproval,
+                        ),
+                      ),
                     ),
                   })}
                   ).

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -29,7 +29,11 @@ import {
   NotificationId,
   NotificationKind,
 } from "../notifications/notifications.dto";
-import { Role } from "../role/role.dto";
+import { AgencyModifierRole, Role, SignatoryRole } from "../role/role.dto";
+import {
+  agencyModifierTitleByRole,
+  signatoryTitleByRole,
+} from "../role/role.utils";
 import { AppellationCode } from "../romeAndAppellationDtos/romeAndAppellation.dto";
 import { ShortLinkId } from "../shortLink/shortLink.dto";
 import { SiretDto } from "../siret/siret";
@@ -178,6 +182,16 @@ export const errors = {
       role,
     }: { conventionId: ConventionId; role: Role }) =>
       new BadRequestError(`There is no ${role} on convention ${conventionId}.`),
+    missingSignatorySignature: ({ role }: { role: SignatoryRole }) =>
+      new BadRequestError(
+        `Signature manquante pour ${signatoryTitleByRole[role]}.`,
+      ),
+    missingAgencyApprovalOrValidation: ({
+      role,
+    }: { role: AgencyModifierRole }) =>
+      new BadRequestError(
+        `Validation manquante par le ${agencyModifierTitleByRole[role]}.`,
+      ),
     unsupportedRoleRenewMagicLink: ({ role }: { role: Role }) =>
       new BadRequestError(
         `Le rôle ${role} n'est pas supporté pour le renouvellement de lien magique.`,

--- a/shared/src/role/role.utils.ts
+++ b/shared/src/role/role.utils.ts
@@ -1,4 +1,4 @@
-import { SignatoryRole } from "./role.dto";
+import { AgencyModifierRole, SignatoryRole } from "./role.dto";
 
 export const signatoryTitleByRole: Record<SignatoryRole, string> = {
   beneficiary: "Le bénéficiaire",
@@ -6,4 +6,9 @@ export const signatoryTitleByRole: Record<SignatoryRole, string> = {
   "establishment-representative": "Le représentant de l'entreprise",
   "beneficiary-current-employer":
     "Le représentant de l'entreprise actuelle du candidat",
+};
+
+export const agencyModifierTitleByRole: Record<AgencyModifierRole, string> = {
+  counsellor: "conseiller",
+  validator: "valideur",
 };


### PR DESCRIPTION
## 🐛 Problème

Certaines conventions ont été validées sans conseiller alors qu'elles sont rattachées à une structure d'accompagnement.
On a alors ce message d'erreur sur le document de convention:

![Image](https://github.com/user-attachments/assets/3b9902c7-602d-4ec2-8551-b424f2d63a26)