### PR TITLE
#3047 - ajout des liens d'accès à pages.immersion-facile.beta.gouv.fr dans le footer et dans la partie prescripteur (menu et accueil)

### DIFF
--- a/front/src/app/components/layout/LayoutFooter.tsx
+++ b/front/src/app/components/layout/LayoutFooter.tsx
@@ -206,10 +206,9 @@ const bottomsLinks: (NavLink | typeof headerFooterDisplayItem)[] = [
     },
   },
   {
-    label: "Kit de communication",
-    href: "https://inclusion.beta.gouv.fr/kits-de-communication/immersion-facilitée/",
-    id: bottomsLinksIds.communicationKit,
-    target: "_blank",
+    label: "Ressources et webinaires",
+    href: "https://pages.immersion-facile.beta.gouv.fr/",
+    id: bottomsLinksIds.resourcesAndWebinars,
   },
   headerFooterDisplayItem,
 ];

--- a/front/src/app/components/layout/LayoutHeader.tsx
+++ b/front/src/app/components/layout/LayoutHeader.tsx
@@ -276,6 +276,14 @@ export const LayoutHeader = () => {
             id: agencyIds.dashboard,
           },
         },
+        {
+          text: "Ressources et webinaires",
+          isActive: false,
+          linkProps: {
+            href: "https://pages.immersion-facile.beta.gouv.fr/",
+            id: agencyIds.resourcesAndWebinars,
+          },
+        },
       ],
     },
   ];

--- a/front/src/app/contents/home/content.ts
+++ b/front/src/app/contents/home/content.ts
@@ -202,6 +202,15 @@ export const heroHeaderNavCards: (
         alternateTitle:
           "Mon espace : espace personnel nominatif où retrouver mes conventions et statistiques.",
       },
+      {
+        title: "Ressources et webinaires",
+        icon: "fr-icon-book-2-line",
+        type: "agency",
+        id: domElementIds.home.heroHeader.resourcesAndWebinars,
+        link: { href: "https://pages.immersion-facile.beta.gouv.fr" },
+        alternateTitle:
+          "Ressources et webinaires : découvrez nos ressources dédiées pour guider et être guidé.",
+      },
     ],
   };
 };

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -60,6 +60,9 @@ export const domElementIds = {
         addAgencyForm: buildHeaderNavLinkId("agency-form"),
         formConvention: buildHeaderNavLinkId("agency-form-convention"),
         dashboard: buildHeaderNavLinkId("agency-my-dashboard"),
+        resourcesAndWebinars: buildHeaderNavLinkId(
+          "agency-resources-and-webinars",
+        ),
       },
       admin: {
         backOffice: buildHeaderNavLinkId("admin-home"),
@@ -113,7 +116,7 @@ export const domElementIds = {
       sitemap: buildFooterNavLinkId("sitemap"),
       budget: buildFooterNavLinkId("budget"),
       apiDocumentation: buildFooterNavLinkId("api-documentation"),
-      communicationKit: buildFooterNavLinkId("communication-kit"),
+      resourcesAndWebinars: buildFooterNavLinkId("resources-and-webinars"),
     },
   },
 
@@ -122,6 +125,7 @@ export const domElementIds = {
       candidate: buildHeroHeaderId("home-candidate"),
       establishment: buildHeroHeaderId("home-establishment"),
       agency: buildHeroHeaderId("home-agency"),
+      resourcesAndWebinars: buildHeroHeaderId("home-resources-and-webinars"),
     },
   },
 


### PR DESCRIPTION
Ça donne ça (+ un lien dans le footer) : 
<img width="1316" alt="image" src="https://github.com/user-attachments/assets/acdd0ab6-ad0a-4207-81f6-42bf2cec3f77" />
