### PR TITLE
TECH - Fix déploiement de review-app

### DIFF
--- a/.github/workflows/review-app-trigger.yml
+++ b/.github/workflows/review-app-trigger.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/review-app-deploy.yml
     with:
       pull_request_id: ${{ inputs.pull_request_number }}
-      run_number: ${{ github.run_number }}
+      run_number: "${{ github.run_number }}"
     secrets:
       SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
 


### PR DESCRIPTION
## 🐛 Problème

Dans le script `review-app-deploy.yml`, le paramètre d'entrée `run_number` est de type string.
Mais dans son appel dans `review-app-trigger.yml`, on passe run_number de type number.