### PR TITLE
#3053 - Distinguer les différents modes et types de formulaire de convention pour le tracking

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -25,6 +25,7 @@ import {
   Beneficiary,
   ConventionReadDto,
   DepartmentCode,
+  ExcludeFromExisting,
   FederatedIdentity,
   InternshipKind,
   addressDtoToString,
@@ -71,6 +72,7 @@ import { errors as errorMessage } from "shared";
 import {
   ConventionFormMode,
   SupportedConventionRoutes,
+  creationFormModes,
 } from "src/app/components/forms/convention/ConventionFormWrapper";
 import { useUpdateConventionValuesInUrl } from "src/app/components/forms/convention/useUpdateConventionValuesInUrl";
 import { useGetAcquisitionParams } from "src/app/hooks/acquisition.hooks";
@@ -160,8 +162,11 @@ export const ConventionForm = ({
 
   const reduxFormUiReady =
     useWaitForReduxFormUiReadyBeforeInitialisation(initialValues);
-  const defaultValues =
-    mode === "create" ? initialValues : fetchedConvention || initialValues;
+  const defaultValues = creationFormModes.includes(
+    mode as ExcludeFromExisting<ConventionFormMode, "edit">,
+  )
+    ? initialValues
+    : fetchedConvention || initialValues;
 
   const methods = useForm<Required<ConventionPresentation>>({
     defaultValues,
@@ -350,7 +355,7 @@ export const ConventionForm = ({
   }, [dispatch]);
 
   useEffect(() => {
-    if (mode !== "create") {
+    if (mode === "edit") {
       validateSteps("clearAllErrors");
     }
   }, [conventionValues.id]);

--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -386,9 +386,13 @@ export const ConventionForm = ({
             </p>
 
             <form
-              id={domElementIds.conventionImmersionRoute.form({ mode })}
+              id={domElementIds.conventionImmersionRoute.form({
+                mode,
+                internshipKind,
+              })}
               data-matomo-name={domElementIds.conventionImmersionRoute.form({
                 mode,
+                internshipKind,
               })}
             >
               <>

--- a/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
+++ b/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
@@ -9,6 +9,7 @@ import { useDispatch } from "react-redux";
 import {
   ConventionId,
   ConventionJwtPayload,
+  ExcludeFromExisting,
   InternshipKind,
   decodeMagicLinkJwtWithoutSignatureCheck,
   domElementIds,
@@ -38,7 +39,12 @@ const {
   isOpenedByDefault: false,
 });
 
-export type ConventionFormMode = "create" | "edit";
+export const creationFormModes = [
+  "create-from-scratch",
+  "create-from-shared",
+] as const;
+const allConventionFormModes = [...creationFormModes, "edit"] as const;
+export type ConventionFormMode = (typeof allConventionFormModes)[number];
 
 type ConventionFormWrapperProps = {
   internshipKind: InternshipKind;
@@ -66,7 +72,11 @@ export const ConventionFormWrapper = ({
   useScrollToTop(formSuccessfullySubmitted);
 
   useEffect(() => {
-    if (mode === "create") {
+    if (
+      creationFormModes.includes(
+        mode as ExcludeFromExisting<ConventionFormMode, "edit">,
+      )
+    ) {
       dispatch(conventionSlice.actions.clearFetchedConvention());
       dispatch(
         conventionSlice.actions.showSummaryChangeRequested({

--- a/front/src/app/pages/convention/ConventionImmersionPage.tsx
+++ b/front/src/app/pages/convention/ConventionImmersionPage.tsx
@@ -119,18 +119,25 @@ export const ConventionImmersionPage = ({
 
 const PageContent = ({ route }: ConventionImmersionPageProps) => {
   const { isLoading } = useFeatureFlags();
+  const initialRouteParams = useRef(route.params).current;
   const {
     jwt: _,
     mtm_campaign: __,
     mtm_kwd: ____,
     ...routeParamsWithoutJwtAndTrackers
-  } = route.params;
-  const isNewOrSharedConvention = useMemo(
+  } = initialRouteParams;
+  const isSharedConvention = useMemo(
     () => keys(routeParamsWithoutJwtAndTrackers).length > 0,
     [routeParamsWithoutJwtAndTrackers],
   );
 
-  const mode: ConventionFormMode = "jwt" in route.params ? "edit" : "create";
+  const getMode = (): ConventionFormMode => {
+    if ("jwt" in initialRouteParams) return "edit";
+    if (isSharedConvention) return "create-from-shared";
+    return "create-from-scratch";
+  };
+
+  const mode = getMode();
 
   return match({
     isLoading,
@@ -138,10 +145,7 @@ const PageContent = ({ route }: ConventionImmersionPageProps) => {
   })
     .with({ isLoading: true }, () => <Loader />)
     .with({ isLoading: false }, () => (
-      <ConventionFormWrapper
-        internshipKind="immersion"
-        mode={isNewOrSharedConvention ? "create" : mode}
-      />
+      <ConventionFormWrapper internshipKind="immersion" mode={mode} />
     ))
     .exhaustive();
 };

--- a/front/src/app/pages/convention/ConventionImmersionPage.tsx
+++ b/front/src/app/pages/convention/ConventionImmersionPage.tsx
@@ -125,7 +125,7 @@ const PageContent = ({ route }: ConventionImmersionPageProps) => {
     mtm_kwd: ____,
     ...routeParamsWithoutJwtAndTrackers
   } = route.params;
-  const isSharedConvention = useMemo(
+  const isNewOrSharedConvention = useMemo(
     () => keys(routeParamsWithoutJwtAndTrackers).length > 0,
     [routeParamsWithoutJwtAndTrackers],
   );
@@ -140,7 +140,7 @@ const PageContent = ({ route }: ConventionImmersionPageProps) => {
     .with({ isLoading: false }, () => (
       <ConventionFormWrapper
         internshipKind="immersion"
-        mode={isSharedConvention ? "edit" : mode}
+        mode={isNewOrSharedConvention ? "create" : mode}
       />
     ))
     .exhaustive();

--- a/front/src/app/pages/convention/ConventionMiniStagePage.tsx
+++ b/front/src/app/pages/convention/ConventionMiniStagePage.tsx
@@ -1,7 +1,10 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useRef } from "react";
 import { MainWrapper, PageHeader } from "react-design-system";
 import { keys } from "shared";
-import { ConventionFormWrapper } from "src/app/components/forms/convention/ConventionFormWrapper";
+import {
+  ConventionFormMode,
+  ConventionFormWrapper,
+} from "src/app/components/forms/convention/ConventionFormWrapper";
 import { useConventionTexts } from "src/app/contents/forms/convention/textSetup";
 import { routes } from "src/app/routes/routes";
 import { Route } from "type-route";
@@ -18,11 +21,20 @@ export const ConventionMiniStagePage = ({
   route,
 }: ConventionMiniStagePageProps) => {
   const t = useConventionTexts("mini-stage-cci");
-  const { jwt: _, ...routeParamsWithoutJwt } = route.params;
+  const initialRouteParams = useRef(route.params).current;
+  const { jwt: _, ...routeParamsWithoutJwt } = initialRouteParams;
   const isSharedConvention = useMemo(
     () => keys(routeParamsWithoutJwt).length > 0,
     [routeParamsWithoutJwt],
   );
+
+  const getMode = (): ConventionFormMode => {
+    if ("jwt" in initialRouteParams) return "edit";
+    if (isSharedConvention) return "create-from-shared";
+    return "create-from-scratch";
+  };
+  const mode = getMode();
+
   return (
     <MainWrapper
       layout={"default"}
@@ -33,10 +45,7 @@ export const ConventionMiniStagePage = ({
         </PageHeader>
       }
     >
-      <ConventionFormWrapper
-        internshipKind="mini-stage-cci"
-        mode={isSharedConvention ? "edit" : "create"}
-      />
+      <ConventionFormWrapper internshipKind="mini-stage-cci" mode={mode} />
     </MainWrapper>
   );
 };

--- a/front/src/app/pages/convention/ConventionPageForExternals.tsx
+++ b/front/src/app/pages/convention/ConventionPageForExternals.tsx
@@ -32,11 +32,17 @@ export const ConventionPageForExternals = ({
   }
 
   return externalConsumer.isIframe ? (
-    <ConventionFormWrapper internshipKind="immersion" mode="create" />
+    <ConventionFormWrapper
+      internshipKind="immersion"
+      mode="create-from-scratch"
+    />
   ) : (
     <HeaderFooterLayout>
       <MainWrapper layout="default">
-        <ConventionFormWrapper internshipKind="immersion" mode="create" />
+        <ConventionFormWrapper
+          internshipKind="immersion"
+          mode="create-from-scratch"
+        />
       </MainWrapper>
     </HeaderFooterLayout>
   );

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -4,6 +4,7 @@ type FrontRoutesKeys = keyof typeof frontRoutes | "home" | "header" | "footer";
 
 type FrontRouteParametrizedKeys =
   | "mode"
+  | "internshipKind"
   | "currentStep"
   | "rightName"
   | "apiConsumerId";
@@ -211,7 +212,8 @@ export const domElementIds = {
   },
 
   conventionImmersionRoute: {
-    form: (params) => `im-convention-immersion-form--${params.mode}`,
+    form: (params) =>
+      `im-convention-${params.internshipKind}-form--${params.mode}`,
     shareForm: "im-convention-form__share-form",
     shareFormSubmitButton: "im-convention-form__share-form-submit-button",
     copyLinkButton: "im-convention-form__copy-link-button",


### PR DESCRIPTION
## 🌈 Description

On veut pouvoir distinguer dans nos trackings:
- les accès au formulaire en immersion vs mini-stage
- la création d'une modification de convention
- si c’est une création suite à un partage de convention

## 🤖 Solution

Les ids possibles sur le formulaire de convention seront:

Pour le mini-stage
- im-convention-mini-stage-cci-form--edit
- im-convention-mini-stage-cci-form--create-from-shared
- im-convention-mini-stage-cci-form--create-from-scratch

Pour l'immersion
- im-convention-immersion-form--edit
- im-convention-immersion-form--create-from-shared
- im-convention-immersion-form--create-from-scratch