### PR TITLE
#3112 - Fix création de convention sur une date où le bénéficiaire devient majeur le 26/03

### DIFF
--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -949,6 +949,30 @@ describe("conventionDtoSchema", () => {
       });
     });
 
+    describe("accepts when beneficiary is major", () => {
+      it("from immersion start date", () => {
+        const convention = new ConventionDtoBuilder()
+          .withBeneficiaryBirthdate("2007-03-26")
+          .withDateStart("2025-03-26")
+          .withDateEnd("2025-03-28")
+          .withSchedule(reasonableSchedule)
+          .build();
+
+        expectConventionDtoToBeValid(convention);
+      });
+
+      it("before immersion start date", () => {
+        const convention = new ConventionDtoBuilder()
+          .withBeneficiaryBirthdate("2000-10-05")
+          .withDateStart("2025-10-05")
+          .withDateEnd("2025-10-10")
+          .withSchedule(reasonableSchedule)
+          .build();
+
+        expectConventionDtoToBeValid(convention);
+      });
+    });
+
     describe("convention with no beneficiary representative for a beneficiary under 18", () => {
       it("rejects when beneficiary is minor (when immersion starts) and no beneficiary representative was provided", () => {
         const immersionStartDate = new Date("2023-11-01");

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -1,3 +1,4 @@
+import { differenceInYears, startOfDay } from "date-fns";
 import { keys } from "ramda";
 import { WithAcquisition } from "../acquisition.dto";
 import { AddressDto, Postcode } from "../address/address.dto";
@@ -427,3 +428,10 @@ export const userHasEnoughRightsOnConvention = (
       agencyRight.agency.id === convention.agencyId &&
       agencyRight.roles.some((role) => allowedRoles.includes(role)),
   ) || !!user.isBackofficeAdmin;
+
+export const getExactAge = ({
+  birthDate,
+  referenceDate,
+}: { birthDate: Date; referenceDate: Date }): number => {
+  return differenceInYears(startOfDay(referenceDate), startOfDay(birthDate));
+};

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -90,6 +90,7 @@ import {
   conventionStatusesWithJustificationWithoutModifierRole,
   conventionStatusesWithValidator,
   conventionStatusesWithoutJustificationNorValidator,
+  getExactAge,
   internshipKinds,
   levelsOfEducation,
 } from "./convention.dto";
@@ -295,10 +296,10 @@ export const conventionSchema: z.Schema<ConventionDto> = conventionCommonSchema
   .refine(
     minorBeneficiaryHasRepresentative,
     ({ dateStart, signatories: { beneficiary } }) => {
-      const beneficiaryAgeAtConventionStart = differenceInYears(
-        new Date(dateStart),
-        new Date(beneficiary.birthdate),
-      );
+      const beneficiaryAgeAtConventionStart = getExactAge({
+        birthDate: new Date(beneficiary.birthdate),
+        referenceDate: new Date(dateStart),
+      });
       return {
         message: `Les bénéficiaires mineurs doivent renseigner un représentant légal. Le bénéficiaire aurait ${beneficiaryAgeAtConventionStart} ans au démarrage de la convention.`,
         path: [getConventionFieldName("signatories.beneficiaryRepresentative")],

--- a/shared/src/convention/conventionRefinements.ts
+++ b/shared/src/convention/conventionRefinements.ts
@@ -1,4 +1,3 @@
-import { differenceInYears } from "date-fns";
 import differenceInDays from "date-fns/differenceInDays";
 import { addressSchema } from "../address/address.schema";
 import { DateString } from "../utils/date";
@@ -9,6 +8,7 @@ import {
   EstablishmentTutor,
   InternshipKind,
   Signatories,
+  getExactAge,
   maximumCalendarDayByInternshipKind,
 } from "./convention.dto";
 
@@ -61,10 +61,10 @@ export const minorBeneficiaryHasRepresentative = ({
   signatories,
   dateSubmission,
 }: ConventionDto) => {
-  const beneficiaryAgeAtConventionStart = differenceInYears(
-    new Date(dateStart),
-    new Date(signatories.beneficiary.birthdate),
-  );
+  const beneficiaryAgeAtConventionStart = getExactAge({
+    birthDate: new Date(signatories.beneficiary.birthdate),
+    referenceDate: new Date(dateStart),
+  });
 
   const ruleAppliesFrom = new Date("2023-10-28");
   const conventionWasSubmittedBeforeRuleApplies =

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -389,7 +389,7 @@ export const emailTemplatesByName =
         return {
           subject: `Immersion Facilitée - Le bilan de votre ${
             internshipKind === "immersion" ? "immersion" : "mini-stage"
-          } est disponible ! `,
+          } est disponible !`,
           greetings: greetingsWithConventionId(
             conventionId,
             `${beneficiaryFirstName} ${beneficiaryLastName}`,


### PR DESCRIPTION
## 🐛 Problème

On utilise `differenceInYears` pour calculer l'âge du candidat.
Or le calcul ne retourne pas toujours l'âge comme on s'y attendrait:

- differenceInYears(new Date("2025-04-07"), new Date("2007-04-07")) // retourne 18 -> OK
- differenceInYears(new Date("2025-03-26"), new Date("2007-03-26")) // retourne 17 -> ??

--> C'est parce que quand on crée une date avec new Date("YYYY-MM-DD"), elle est interprétée en UTC, ce qui peut entrainer des différences d'horaires

## 🤖 Solution

Comparer les dates au début du jour avec `startOfDay`: 
`differenceInYears(new Date("2025-04-07"), new Date("2007-04-07"))`.

## 💯 Pour tester

Créer une convention avec ces exactes dates:

- date de naissance : 26/03/2007
- date de démarrage : 26/03/2025
