### PR TITLE
#3053 - Fix id du formulaire de convention

### DIFF
--- a/back/src/domains/convention/use-cases/notifications/NotifyActorThatConventionNeedsModifications.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyActorThatConventionNeedsModifications.ts
@@ -118,7 +118,10 @@ export class NotifyActorThatConventionNeedsModifications extends TransactionalUs
         justification,
         signature: agency.signature,
         magicLink: await makeShortMagicLink({
-          targetRoute: frontRoutes.conventionImmersionRoute,
+          targetRoute:
+            convention.internshipKind === "immersion"
+              ? frontRoutes.conventionImmersionRoute
+              : frontRoutes.conventionMiniStageRoute,
           lifetime: "short",
         }),
         agencyLogoUrl: agency.logoUrl ?? undefined,


### PR DESCRIPTION
## 🐛 Problème

Lors d'une modification d'un mini-stage, on est sur la page d'immersion /demande-immersion.

Puisque l'on est pas sur la bonne route, l'id du form de convention est "im-convention-immersion-form--edit" au lieu de "im-convention-mini-stage-cci-form--edit".

## 💯 Solution

Créer le lien magique sur la bonne route.
A noter que sur la route de demande-mini-stage, on a plus de header et footer du site IF.
