### PR TITLE
#3167 - ajout de la gestion des anciens format de bilan (y compris dans la page de Bilan, coté front)

### DIFF
--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -646,10 +646,10 @@ interface ImmersionAssessments {
   number_of_hours_actually_made: number | null;
   last_day_of_presence: Timestamp | null;
   number_of_missed_hours: number | null;
-  ended_with_a_job: boolean;
+  ended_with_a_job: boolean | null;
   type_of_contract: string | null;
   contract_start_date: Timestamp | null;
-  establishment_advices: string;
+  establishment_advices: string | null;
   establishment_feedback: string;
   created_at: Generated<Timestamp | null>;
   updated_at: Generated<Timestamp | null>;

--- a/back/src/domains/convention/entities/AssessmentEntity.ts
+++ b/back/src/domains/convention/entities/AssessmentEntity.ts
@@ -2,12 +2,16 @@ import {
   type AssessmentDto,
   type ConventionDto,
   type ConventionStatus,
+  type LegacyAssessmentDto,
   calculateTotalImmersionHoursBetweenDateComplex,
   errors,
 } from "shared";
 import type { EntityFromDto } from "../../../utils/EntityFromDto";
 
-export type AssessmentEntity = EntityFromDto<AssessmentDto, "Assessment"> & {
+export type AssessmentEntity = EntityFromDto<
+  AssessmentDto | LegacyAssessmentDto,
+  "Assessment"
+> & {
   numberOfHoursActuallyMade: number | null;
 };
 
@@ -52,4 +56,4 @@ export const toAssessmentDto = ({
   _entityName,
   numberOfHoursActuallyMade: _,
   ...assessmentEntity
-}: AssessmentEntity): AssessmentDto => assessmentEntity;
+}: AssessmentEntity): AssessmentDto | LegacyAssessmentDto => assessmentEntity;

--- a/back/src/domains/convention/use-cases/GetAssessmentByConventionId.ts
+++ b/back/src/domains/convention/use-cases/GetAssessmentByConventionId.ts
@@ -1,6 +1,7 @@
 import {
   type AssessmentDto,
   type ConventionDomainPayload,
+  type LegacyAssessmentDto,
   type WithConventionId,
   errors,
   withConventionIdSchema,
@@ -16,11 +17,11 @@ export type GetAssessmentByConventionId = ReturnType<
 >;
 export const makeGetAssessmentByConventionId = createTransactionalUseCase<
   WithConventionId,
-  AssessmentDto,
+  AssessmentDto | LegacyAssessmentDto,
   ConventionDomainPayload | undefined
 >(
   {
-    name: "GetAssessment",
+    name: "GetAssessmentByConventionId",
     inputSchema: withConventionIdSchema,
   },
   async ({ uow, currentUser, inputParams }) => {

--- a/back/src/utils/assessment.ts
+++ b/back/src/utils/assessment.ts
@@ -6,6 +6,7 @@ import {
   assessmentDtoSchema,
   errors,
   isSomeEmailMatchingEmailHash,
+  legacyAssessmentDtoSchema,
 } from "shared";
 import { z } from "zod";
 import type { AssessmentEntity } from "../domains/convention/entities/AssessmentEntity";
@@ -28,7 +29,7 @@ export const throwForbiddenIfNotAllowedForAssessments = (
 };
 
 export const assessmentEntitySchema: z.Schema<AssessmentEntity> =
-  assessmentDtoSchema.and(
+  assessmentDtoSchema.or(legacyAssessmentDtoSchema).and(
     z.object({
       _entityName: z.literal("Assessment"),
       numberOfHoursActuallyMade: z.number().or(z.null()),

--- a/front/src/core-logic/adapters/AssessmentGateway/HttpAssessmentGateway.ts
+++ b/front/src/core-logic/adapters/AssessmentGateway/HttpAssessmentGateway.ts
@@ -3,6 +3,7 @@ import {
   type AssessmentDto,
   type ConventionId,
   type ConventionMagicLinkRoutes,
+  type LegacyAssessmentDto,
   errors,
 } from "shared";
 import type { HttpClient } from "shared-routes";
@@ -45,7 +46,9 @@ export class HttpAssessmentGateway implements AssessmentGateway {
   public getAssessment$({
     conventionId,
     jwt,
-  }: { conventionId: ConventionId; jwt: string }): Observable<AssessmentDto> {
+  }: { conventionId: ConventionId; jwt: string }): Observable<
+    AssessmentDto | LegacyAssessmentDto
+  > {
     return from(
       this.httpClient
         .getAssessmentByConventionId({

--- a/front/src/core-logic/domain/assessment/assessment.slice.ts
+++ b/front/src/core-logic/domain/assessment/assessment.slice.ts
@@ -1,5 +1,5 @@
 import { type PayloadAction, createSlice } from "@reduxjs/toolkit";
-import type { AssessmentDto, ConventionId } from "shared";
+import type { AssessmentDto, ConventionId, LegacyAssessmentDto } from "shared";
 import type {
   PayloadActionWithFeedbackTopic,
   PayloadActionWithFeedbackTopicError,
@@ -8,7 +8,7 @@ import type { AssessmentAndJwt } from "src/core-logic/ports/AssessmentGateway";
 
 export interface AssessmentState {
   isLoading: boolean;
-  currentAssessment: AssessmentDto | null;
+  currentAssessment: AssessmentDto | LegacyAssessmentDto | null;
 }
 
 const initialState: AssessmentState = {
@@ -43,7 +43,10 @@ export const assessmentSlice = createSlice({
     ) => {
       state.isLoading = true;
     },
-    getAssessmentSucceeded: (state, action: PayloadAction<AssessmentDto>) => {
+    getAssessmentSucceeded: (
+      state,
+      action: PayloadAction<AssessmentDto | LegacyAssessmentDto>,
+    ) => {
       state.isLoading = false;
       state.currentAssessment = action.payload;
     },

--- a/front/src/core-logic/ports/AssessmentGateway.ts
+++ b/front/src/core-logic/ports/AssessmentGateway.ts
@@ -1,5 +1,5 @@
 import type { Observable } from "rxjs";
-import type { AssessmentDto, ConventionId } from "shared";
+import type { AssessmentDto, ConventionId, LegacyAssessmentDto } from "shared";
 
 export type AssessmentAndJwt = {
   assessment: AssessmentDto;
@@ -11,5 +11,5 @@ export interface AssessmentGateway {
   getAssessment$(params: {
     conventionId: ConventionId;
     jwt: string;
-  }): Observable<AssessmentDto>;
+  }): Observable<AssessmentDto | LegacyAssessmentDto>;
 }

--- a/shared/src/assessment/assessment.dto.ts
+++ b/shared/src/assessment/assessment.dto.ts
@@ -63,3 +63,9 @@ export type DateRange = {
   from: Date;
   to: Date;
 };
+
+export type LegacyAssessmentDto = {
+  status: "FINISHED" | "ABANDONED";
+  conventionId: ConventionId;
+  establishmentFeedback: string;
+};

--- a/shared/src/assessment/assessment.schema.ts
+++ b/shared/src/assessment/assessment.schema.ts
@@ -4,6 +4,7 @@ import { localization, zEnumValidation, zStringMinLength1 } from "../zodUtils";
 import {
   type AssessmentDto,
   type DateRange,
+  type LegacyAssessmentDto,
   type WithAssessmentDto,
   type WithEndedWithAJob,
   type WithEstablishmentComments,
@@ -77,3 +78,10 @@ export const withDateRangeSchema: z.Schema<DateRange> = z
     ({ from, to }) => from < to,
     "La date de fin doit être après la date de début.",
   );
+
+export const legacyAssessmentDtoSchema: z.Schema<LegacyAssessmentDto> =
+  z.object({
+    status: z.enum(["FINISHED", "ABANDONED"]),
+    conventionId: z.string(),
+    establishmentFeedback: zStringMinLength1,
+  });

--- a/shared/src/convention/convention.routes.ts
+++ b/shared/src/convention/convention.routes.ts
@@ -1,7 +1,10 @@
 import { defineRoute, defineRoutes } from "shared-routes";
 import { shareLinkByEmailSchema } from "../ShareLinkByEmailDto";
 import { apiConsumerReadSchema } from "../apiConsumer/apiConsumer.schema";
-import { assessmentDtoSchema } from "../assessment/assessment.schema";
+import {
+  assessmentDtoSchema,
+  legacyAssessmentDtoSchema,
+} from "../assessment/assessment.schema";
 import { dashboardUrlAndNameSchema } from "../dashboard/dashboard.schema";
 import { withAuthorizationHeaders } from "../headers";
 import { httpErrorSchema } from "../httpClient/httpErrors.schema";
@@ -42,7 +45,7 @@ export const conventionMagicLinkRoutes = defineRoutes({
     method: "get",
     ...withAuthorizationHeaders,
     responses: {
-      200: assessmentDtoSchema,
+      200: assessmentDtoSchema.or(legacyAssessmentDtoSchema),
       400: httpErrorSchema,
       401: httpErrorSchema,
       403: httpErrorSchema,


### PR DESCRIPTION
- **handle legacy assessments**
- **fix front to handle LegacyAssessments**

Ça donne ça :

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/57938d1e-fd72-4b2c-ac24-0c87699d8602" />

