### PR TITLE
TECH - optimisations SQL 

### DIFF
--- a/back/src/config/pg/migrations/1742468849412_add-index-in-discussion-for-preformances.ts
+++ b/back/src/config/pg/migrations/1742468849412_add-index-in-discussion-for-preformances.ts
@@ -1,0 +1,14 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex("discussions", "establishment_contact_copy_emails", {
+    name: "idx_establishment_contact_copy_emails",
+    method: "gin",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("discussions", "establishment_contact_copy_emails", {
+    name: "idx_establishment_contact_copy_emails",
+  });
+}

--- a/back/src/config/pg/migrations/1742469808774_add-index-on-actors-email.ts
+++ b/back/src/config/pg/migrations/1742469808774_add-index-on-actors-email.ts
@@ -1,0 +1,9 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex("actors", "email");
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("actors", "email");
+}

--- a/back/src/domains/core/authentication/inclusion-connect/adapters/PgUserRepository.ts
+++ b/back/src/domains/core/authentication/inclusion-connect/adapters/PgUserRepository.ts
@@ -123,7 +123,7 @@ export class PgUserRepository implements UserRepository {
   public async getUsers(filters: GetUsersFilters): Promise<UserOnRepository[]> {
     if (filters.emailContains === "") return [];
     const usersInDb = await this.#getUserQueryBuilder()
-      .where("users.email", "ilike", `%${filters.emailContains}%`)
+      .where("users.email", "like", `%${filters.emailContains.toLowerCase()}%`)
       .execute();
     return usersInDb
       .map((userInDb) => this.#toAuthenticatedUser(userInDb))
@@ -141,7 +141,7 @@ export class PgUserRepository implements UserRepository {
 
   public async findByEmail(email: Email): Promise<User | undefined> {
     const response = await this.#getUserQueryBuilder()
-      .where("users.email", "ilike", email)
+      .where("users.email", "=", email.toLowerCase())
       .executeTakeFirst();
     return this.#toAuthenticatedUser(response);
   }


### PR DESCRIPTION
check de discussion existante pour un email : on passe de 230 ms à moins de 0.2 ms

Cette PR optimize les 3 spans qu'on voit dans cette trace. Qui au passage sont joué 2 fois pour cette query (une fois dans le middleware et une fois dans le usecase). On va donc gagner pratiquement 1 secondes sur toutes ces requêtes.

<img width="1389" alt="image" src="https://github.com/user-attachments/assets/82703b3c-da39-4294-936e-0b95ef10fddc" />

