### PR TITLE
#3230 - Fix accès à la convention mini-stage

### DIFF
--- a/shared/src/schedule/ScheduleUtils.ts
+++ b/shared/src/schedule/ScheduleUtils.ts
@@ -502,11 +502,12 @@ export const calculateScheduleTotalDurationInDays = (
 
 export const isSundayInSchedule = (complexSchedule: DailyScheduleDto[]) => {
   const sunday = 0;
-  return complexSchedule.some(
-    (week) =>
-      getDay(convertLocaleDateToUtcTimezoneDate(parseISO(week.date))) ===
-        sunday && week.timePeriods.length > 0,
-  );
+  return complexSchedule.some((week) => {
+    return (
+      convertLocaleDateToUtcTimezoneDate(parseISO(week.date)).getUTCDay() ===
+        sunday && week.timePeriods.length > 0
+    );
+  });
 };
 
 const makeWeeklyPrettyPrint = (


### PR DESCRIPTION
## 🐛 Problème

Lorsque le mini-stage commence un lundi, on a l'erreur suivante:

![Screenshot 2025-04-03 at 14 14 44](https://github.com/user-attachments/assets/9c423ece-9148-49a2-80cc-a2de3537f54a)

## 💯 Remarque

En résolvant ce problème, je découvre que les dates affichées ne sont pas correctes 😭 

Le mini-stage ci-dessous devrait se dérouler du 17/02 au 20/02 !

<img width="591" alt="Screenshot 2025-04-03 at 14 18 29" src="https://github.com/user-attachments/assets/5da401d9-76b3-4a4c-a470-4bddadbb8249" />

C'est peut-être lié à ce ticket de bug: https://github.com/gip-inclusion/immersion-facile/issues/3232
