### PR TITLE
TECH - Modification de l'heure du cron d'envoi de lien de formulaire bilan

### DIFF
--- a/back/scalingo/cron.json
+++ b/back/scalingo/cron.json
@@ -17,6 +17,10 @@
       "size": "M"
     },
     {
+      "command": "30 06 * * * pnpm back run trigger-sending-assessment-needed-notifications",
+      "size": "M"
+    },
+    {
       "command": "15 07 * * * pnpm back run trigger-convention-reminder",
       "size": "M"
     },
@@ -26,10 +30,6 @@
     },
     {
       "command": "30 08 * * * pnpm back run trigger-contact-request-reminder-7d",
-      "size": "M"
-    },
-    {
-      "command": "49 20 * * * pnpm back run trigger-sending-assessment-needed-notifications",
       "size": "M"
     },
     {


### PR DESCRIPTION
## 🌈 Description

Vu que nous avons des soucis d'envoi de mails de bilan le jeudi en raison de la quantité de conventions concernées, nous pouvons mettre le cron en matinée pour prévoir de le rejouer en fin d'aprem si jamais il a planté.

Un autre ticket https://github.com/gip-inclusion/immersion-facile/issues/3272 est prévu pour corriger le problème.