### PR TITLE
#3129 -  Ajout du lien pour déclarer un abandon dans le mail de confirmation final du tuteur de l'immersion

### DIFF
--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -111,6 +111,7 @@ describe("Pg implementation of ConventionQueries", () => {
               emergencyContactInfos: "",
               agencyLogoUrl: "https://super link",
               magicLink: "",
+              assessmentMagicLink: "",
               validatorName: convention.validators?.agencyValidator
                 ? concatValidatorNames(convention.validators?.agencyValidator)
                 : "",

--- a/back/src/domains/convention/use-cases/RenewConventionMagicLink.ts
+++ b/back/src/domains/convention/use-cases/RenewConventionMagicLink.ts
@@ -19,7 +19,7 @@ import { conventionEmailsByRoleForMagicLinkRenewal } from "../../../utils/conven
 import { makeEmailHash } from "../../../utils/jwt";
 import { TransactionalUseCase } from "../../core/UseCase";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
-import { prepareMagicShortLinkMaker } from "../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
@@ -106,7 +106,7 @@ export class RenewConventionMagicLink extends TransactionalUseCase<
       if (!emailHash || makeEmailHash(email) === emailHash) {
         foundHit = true;
 
-        const makeMagicShortLink = prepareMagicShortLinkMaker({
+        const makeMagicShortLink = prepareConventionMagicShortLinkMaker({
           conventionMagicLinkPayload: {
             id: conventionId,
             role,

--- a/back/src/domains/convention/use-cases/SendSignatureLink.ts
+++ b/back/src/domains/convention/use-cases/SendSignatureLink.ts
@@ -19,7 +19,7 @@ import type { GenerateConventionMagicLinkUrl } from "../../../config/bootstrap/m
 import { createTransactionalUseCase } from "../../core/UseCase";
 import type { SaveNotificationAndRelatedEvent } from "../../core/notifications/helpers/Notification";
 import type { NotificationRepository } from "../../core/notifications/ports/NotificationRepository";
-import { prepareMagicShortLinkMaker } from "../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
@@ -160,7 +160,7 @@ const sendSms = async ({
   signatoryPhone: string;
   userId: UserId | undefined;
 }) => {
-  const makeShortMagicLink = prepareMagicShortLinkMaker({
+  const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
     config,
     conventionMagicLinkPayload: conventionMagicLinkPayload,
     generateConventionMagicLinkUrl: generateConventionMagicLinkUrl,

--- a/back/src/domains/convention/use-cases/notifications/NotifyActorThatConventionNeedsModifications.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyActorThatConventionNeedsModifications.ts
@@ -15,7 +15,7 @@ import { TransactionalUseCase } from "../../../core/UseCase";
 import type { ConventionRequiresModificationPayload } from "../../../core/events/eventPayload.dto";
 import { conventionRequiresModificationPayloadSchema } from "../../../core/events/eventPayload.schema";
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -96,7 +96,7 @@ export class NotifyActorThatConventionNeedsModifications extends TransactionalUs
           : {}),
       };
 
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: this.config,
       conventionMagicLinkPayload,
       generateConventionMagicLinkUrl: this.generateConventionMagicLinkUrl,

--- a/back/src/domains/convention/use-cases/notifications/NotifyAllActorsOfFinalConventionValidation.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAllActorsOfFinalConventionValidation.unit.test.ts
@@ -33,6 +33,12 @@ import { UuidV4Generator } from "../../../core/uuid-generator/adapters/UuidGener
 import { NotifyAllActorsOfFinalConventionValidation } from "./NotifyAllActorsOfFinalConventionValidation";
 
 describe("NotifyAllActorsOfFinalApplicationValidation", () => {
+  type ActorForNotification = {
+    role: Role;
+    email: string;
+    conventionShortlinkId: ShortLinkId;
+    assessmentCreationLinkId: ShortLinkId | undefined;
+  };
   const establishmentTutorEmail = "establishment-tutor@mail.com";
   const establishmentRepresentativeEmail =
     "establishment-representativ@gmail.com";
@@ -84,7 +90,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     businessAddress: "Rue des Bouchers 67065 Strasbourg",
   };
 
-  const validConventionWithSameTutorAndRepresentativ =
+  const validConventionWithSameTutorAndRepresentative =
     new ConventionDtoBuilder()
       .withEstablishmentRepresentative(establishmentRepresentative)
       .withEstablishmentTutor({
@@ -95,7 +101,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       .build();
 
   const defaultAgency = AgencyDtoBuilder.create(
-    validConventionWithSameTutorAndRepresentativ.agencyId,
+    validConventionWithSameTutorAndRepresentative.agencyId,
   ).build();
 
   let uow: InMemoryUnitOfWork;
@@ -129,18 +135,13 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
   });
 
   describe("NotifyAllActorsOfFinalApplicationValidation sends confirmation email to all actors", () => {
-    it("Notify Default actors: beneficiary, establishment representative, agency counsellor, agency validator that convention is validate.", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+    it("Notify Default actors: beneficiary, establishment representative, agency counsellor, agency validator that convention is validated.", async () => {
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -174,14 +175,14 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       shortLinkIdGenerator.addMoreShortLinkIds(shortlinkIds);
 
       await notifyAllActorsOfFinalConventionValidation.execute({
-        convention: validConventionWithSameTutorAndRepresentativ,
+        convention: validConventionWithSameTutorAndRepresentative,
       });
 
       const expectedShorlinks = actors.reduce(
         (acc, actor) => ({
           ...acc,
           [actor.conventionShortlinkId]: fakeGenerateMagicLinkUrlFn({
-            id: validConventionWithSameTutorAndRepresentativ.id,
+            id: validConventionWithSameTutorAndRepresentative.id,
             role: actor.role,
             email: actor.email,
             now: timeGateway.now(),
@@ -192,7 +193,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           ...(actor.assessmentCreationLinkId
             ? {
                 [actor.assessmentCreationLinkId]: fakeGenerateMagicLinkUrlFn({
-                  id: validConventionWithSameTutorAndRepresentativ.id,
+                  id: validConventionWithSameTutorAndRepresentative.id,
                   role: actor.role,
                   email: actor.email,
                   now: timeGateway.now(),
@@ -226,7 +227,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           [actor.email],
           emailNotifications[index].templatedContent,
           defaultAgency,
-          validConventionWithSameTutorAndRepresentativ,
+          validConventionWithSameTutorAndRepresentative,
           config,
           actor.conventionShortlinkId,
           actor.assessmentCreationLinkId,
@@ -235,17 +236,12 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     });
 
     it("With beneficiary current employer", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -276,7 +272,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       ];
 
       const conventionWithBeneficiaryCurrentEmployer = new ConventionDtoBuilder(
-        validConventionWithSameTutorAndRepresentativ,
+        validConventionWithSameTutorAndRepresentative,
       )
         .withBeneficiaryCurrentEmployer(currentEmployer)
         .build();
@@ -297,7 +293,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
         (a, actor) => ({
           ...a,
           [actor.conventionShortlinkId]: fakeGenerateMagicLinkUrlFn({
-            id: validConventionWithSameTutorAndRepresentativ.id,
+            id: validConventionWithSameTutorAndRepresentative.id,
             role: actor.role,
             email: actor.email,
             now: timeGateway.now(),
@@ -308,7 +304,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           ...(actor.assessmentCreationLinkId
             ? {
                 [actor.assessmentCreationLinkId]: fakeGenerateMagicLinkUrlFn({
-                  id: validConventionWithSameTutorAndRepresentativ.id,
+                  id: validConventionWithSameTutorAndRepresentative.id,
                   role: actor.role,
                   email: actor.email,
                   now: timeGateway.now(),
@@ -351,17 +347,12 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     });
 
     it("With beneficiary representative", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -392,7 +383,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       ];
 
       const conventionWithBeneficiaryCurrentEmployer = new ConventionDtoBuilder(
-        validConventionWithSameTutorAndRepresentativ,
+        validConventionWithSameTutorAndRepresentative,
       )
         .withBeneficiaryRepresentative(beneficiaryRepresentative)
         .build();
@@ -413,7 +404,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
         (a, actor) => ({
           ...a,
           [actor.conventionShortlinkId]: fakeGenerateMagicLinkUrlFn({
-            id: validConventionWithSameTutorAndRepresentativ.id,
+            id: validConventionWithSameTutorAndRepresentative.id,
             role: actor.role,
             email: actor.email,
             now: timeGateway.now(),
@@ -424,7 +415,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           ...(actor.assessmentCreationLinkId
             ? {
                 [actor.assessmentCreationLinkId]: fakeGenerateMagicLinkUrlFn({
-                  id: validConventionWithSameTutorAndRepresentativ.id,
+                  id: validConventionWithSameTutorAndRepresentative.id,
                   role: actor.role,
                   email: actor.email,
                   now: timeGateway.now(),
@@ -467,17 +458,12 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     });
 
     it("With different establishment tutor and establishment representative", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -516,7 +502,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       shortLinkIdGenerator.addMoreShortLinkIds(shortlinkIds);
 
       const conventionWithDifferentEstablishmentTutorAndEstablishmentRepresentative =
-        new ConventionDtoBuilder(validConventionWithSameTutorAndRepresentativ)
+        new ConventionDtoBuilder(validConventionWithSameTutorAndRepresentative)
           .withEstablishmentTutor(establishmentTutor)
           .build();
 
@@ -583,17 +569,12 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     });
 
     it("With PeConnect Federated identity: beneficiary, establishment representative, agency counsellor & validator, and dedicated advisor", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -632,7 +613,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           type: "CAPEMPLOI",
         },
         peExternalId: userFtExternalId,
-        conventionId: validConventionWithSameTutorAndRepresentativ.id,
+        conventionId: validConventionWithSameTutorAndRepresentative.id,
       };
 
       uow.conventionFranceTravailAdvisorRepository.setConventionFranceTravailUsersAdvisor(
@@ -648,14 +629,14 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       shortLinkIdGenerator.addMoreShortLinkIds(shortlinkIds);
 
       await notifyAllActorsOfFinalConventionValidation.execute({
-        convention: validConventionWithSameTutorAndRepresentativ,
+        convention: validConventionWithSameTutorAndRepresentative,
       });
 
       const expectedShorlinks = actors.reduce(
         (a, actor) => ({
           ...a,
           [actor.conventionShortlinkId]: fakeGenerateMagicLinkUrlFn({
-            id: validConventionWithSameTutorAndRepresentativ.id,
+            id: validConventionWithSameTutorAndRepresentative.id,
             role: actor.role,
             email: actor.email,
             now: timeGateway.now(),
@@ -666,7 +647,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           ...(actor.assessmentCreationLinkId
             ? {
                 [actor.assessmentCreationLinkId]: fakeGenerateMagicLinkUrlFn({
-                  id: validConventionWithSameTutorAndRepresentativ.id,
+                  id: validConventionWithSameTutorAndRepresentative.id,
                   role: actor.role,
                   email: actor.email,
                   now: timeGateway.now(),
@@ -699,7 +680,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           [actor.email],
           emailNotifications[index].templatedContent,
           defaultAgency,
-          validConventionWithSameTutorAndRepresentativ,
+          validConventionWithSameTutorAndRepresentative,
           config,
           actor.conventionShortlinkId,
           actor.assessmentCreationLinkId,
@@ -708,17 +689,12 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
     });
 
     it("With PeConnect Federated identity: beneficiary, establishment tutor, agency counsellor & validator, and no advisor", async () => {
-      const actors: {
-        role: Role;
-        email: string;
-        conventionShortlinkId: ShortLinkId;
-        assessmentCreationLinkId: ShortLinkId | undefined;
-      }[] = [
+      const actors: ActorForNotification[] = [
         {
           role: "beneficiary",
           email:
-            validConventionWithSameTutorAndRepresentativ.signatories.beneficiary
-              .email,
+            validConventionWithSameTutorAndRepresentative.signatories
+              .beneficiary.email,
           conventionShortlinkId: "conventionShortlinkId_0",
           assessmentCreationLinkId: undefined,
         },
@@ -746,7 +722,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
         _entityName: "ConventionFranceTravailAdvisor",
         advisor: undefined,
         peExternalId: userFtExternalId,
-        conventionId: validConventionWithSameTutorAndRepresentativ.id,
+        conventionId: validConventionWithSameTutorAndRepresentative.id,
       };
 
       uow.conventionFranceTravailAdvisorRepository.setConventionFranceTravailUsersAdvisor(
@@ -762,14 +738,14 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
       shortLinkIdGenerator.addMoreShortLinkIds(shortlinkIds);
 
       await notifyAllActorsOfFinalConventionValidation.execute({
-        convention: validConventionWithSameTutorAndRepresentativ,
+        convention: validConventionWithSameTutorAndRepresentative,
       });
 
       const expectedShorlinks = actors.reduce(
         (a, actor) => ({
           ...a,
           [actor.conventionShortlinkId]: fakeGenerateMagicLinkUrlFn({
-            id: validConventionWithSameTutorAndRepresentativ.id,
+            id: validConventionWithSameTutorAndRepresentative.id,
             role: actor.role,
             email: actor.email,
             now: timeGateway.now(),
@@ -780,7 +756,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           ...(actor.assessmentCreationLinkId
             ? {
                 [actor.assessmentCreationLinkId]: fakeGenerateMagicLinkUrlFn({
-                  id: validConventionWithSameTutorAndRepresentativ.id,
+                  id: validConventionWithSameTutorAndRepresentative.id,
                   role: actor.role,
                   email: actor.email,
                   now: timeGateway.now(),
@@ -813,7 +789,7 @@ describe("NotifyAllActorsOfFinalApplicationValidation", () => {
           [actor.email],
           emailNotifications[index].templatedContent,
           defaultAgency,
-          validConventionWithSameTutorAndRepresentativ,
+          validConventionWithSameTutorAndRepresentative,
           config,
           actor.conventionShortlinkId,
           actor.assessmentCreationLinkId,

--- a/back/src/domains/convention/use-cases/notifications/NotifyAllActorsThatConventionTransferred.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAllActorsThatConventionTransferred.ts
@@ -15,7 +15,7 @@ import type { TransferConventionToAgencyPayload } from "../../../core/events/eve
 import { transferConventionToAgencyPayloadSchema } from "../../../core/events/eventPayload.schema";
 
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -148,7 +148,7 @@ const sendAgencyEmails = (
 ) => {
   return agencyRecipientsRoleAndEmail.map(async (emailAndRole) => {
     const { role, email } = emailAndRole;
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: deps.config,
       conventionMagicLinkPayload: {
         id: convention.id,
@@ -209,7 +209,7 @@ const sendSignatoriesEmail = (
 ) => {
   return signatoriesRecipientsRoleAndEmail.map(async (emailAndRole) => {
     const { role, email } = emailAndRole;
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: deps.config,
       conventionMagicLinkPayload: {
         id: convention.id,

--- a/back/src/domains/convention/use-cases/notifications/NotifyConventionReminder.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyConventionReminder.ts
@@ -31,7 +31,7 @@ import type {
   NotificationContentAndFollowedIds,
   SaveNotificationsBatchAndRelatedEvent,
 } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -111,7 +111,7 @@ export class NotifyConventionReminder extends TransactionalUseCase<
     convention: ConventionDto,
     uow: UnitOfWork,
   ): Promise<TemplatedEmail> {
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: this.#config,
       conventionMagicLinkPayload: {
         id: convention.id,
@@ -257,7 +257,7 @@ export class NotifyConventionReminder extends TransactionalUseCase<
     uow: UnitOfWork,
     kind: SignatoriesReminderKind,
   ): Promise<TemplatedSms> {
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: this.#config,
       conventionMagicLinkPayload: {
         id: convention.id,
@@ -289,7 +289,7 @@ export class NotifyConventionReminder extends TransactionalUseCase<
     uow: UnitOfWork,
     kind: AgenciesReminderKind,
   ): Promise<NotificationContentAndFollowedIds> {
-    const makeShortMagicLink = prepareMagicShortLinkMaker({
+    const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
       config: this.#config,
       conventionMagicLinkPayload: {
         id: convention.id,

--- a/back/src/domains/convention/use-cases/notifications/NotifyNewConventionNeedsReview.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyNewConventionNeedsReview.ts
@@ -15,7 +15,7 @@ import { createLogger } from "../../../../utils/logger";
 import { TransactionalUseCase } from "../../../core/UseCase";
 import type { FtConnectImmersionAdvisorDto } from "../../../core/authentication/ft-connect/dto/FtConnectAdvisor.dto";
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -90,7 +90,7 @@ export class NotifyNewConventionNeedsReview extends TransactionalUseCase<WithCon
 
     const emails: TemplatedEmail[] = await Promise.all(
       recipients.map(async (recipient) => {
-        const makeShortMagicLink = prepareMagicShortLinkMaker({
+        const makeShortMagicLink = prepareConventionMagicShortLinkMaker({
           config: this.#config,
           conventionMagicLinkPayload: {
             id: convention.id,

--- a/back/src/domains/convention/use-cases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignature.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignature.ts
@@ -17,7 +17,7 @@ import { agencyWithRightToAgencyDto } from "../../../../utils/agency";
 import { createLogger } from "../../../../utils/logger";
 import { TransactionalUseCase } from "../../../core/UseCase";
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -118,7 +118,7 @@ export class NotifySignatoriesThatConventionSubmittedNeedsSignature extends Tran
         now: this.#timeGateway.now(),
       };
 
-    const makeMagicShortLink = prepareMagicShortLinkMaker({
+    const makeMagicShortLink = prepareConventionMagicShortLinkMaker({
       conventionMagicLinkPayload,
       uow,
       config: this.#config,

--- a/back/src/domains/convention/use-cases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignatureAfterModification.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifySignatoriesThatConventionSubmittedNeedsSignatureAfterModification.ts
@@ -14,7 +14,7 @@ import type { AppConfig } from "../../../../config/bootstrap/appConfig";
 import type { GenerateConventionMagicLinkUrl } from "../../../../config/bootstrap/magicLinkUrl";
 import { TransactionalUseCase } from "../../../core/UseCase";
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -97,7 +97,7 @@ export class NotifySignatoriesThatConventionSubmittedNeedsSignatureAfterModifica
         beneficiaryLastName: convention.signatories.beneficiary.lastName,
         businessName: convention.businessName,
         conventionId: convention.id,
-        conventionSignShortlink: await prepareMagicShortLinkMaker({
+        conventionSignShortlink: await prepareConventionMagicShortLinkMaker({
           conventionMagicLinkPayload: {
             id: convention.id,
             role: signatory.role,

--- a/back/src/domains/convention/use-cases/notifications/NotifyToAgencyConventionSubmitted.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyToAgencyConventionSubmitted.ts
@@ -12,7 +12,7 @@ import type { GenerateConventionMagicLinkUrl } from "../../../../config/bootstra
 import { agencyWithRightToAgencyDto } from "../../../../utils/agency";
 import { TransactionalUseCase } from "../../../core/UseCase";
 import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
-import { prepareMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
+import { prepareConventionMagicShortLinkMaker } from "../../../core/short-link/ShortLink";
 import type { ShortLinkIdGeneratorGateway } from "../../../core/short-link/ports/ShortLinkIdGeneratorGateway";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../../core/unit-of-work/ports/UnitOfWork";
@@ -122,7 +122,7 @@ export class NotifyToAgencyConventionSubmitted extends TransactionalUseCase<
   }) {
     await Promise.all(
       recipients.map(async (email) => {
-        const makeMagicShortLink = prepareMagicShortLinkMaker({
+        const makeMagicShortLink = prepareConventionMagicShortLinkMaker({
           conventionMagicLinkPayload: {
             id: convention.id,
             role,

--- a/back/src/domains/core/notifications/adapters/InMemoryNotificationRepository.ts
+++ b/back/src/domains/core/notifications/adapters/InMemoryNotificationRepository.ts
@@ -196,13 +196,14 @@ export const expectEmailSignatoryConfirmationSignatureRequestMatchingConvention 
     });
   };
 
-export const expectEmailFinalValidationConfirmationMatchingConvention = (
+export const expectEmailFinalValidationConfirmationParamsMatchingConvention = (
   recipients: string[],
   templatedEmails: TemplatedEmail,
   agency: AgencyDto,
   convention: ConventionDto,
   config: AppConfig,
   conventionToSignLinkId: ShortLinkId,
+  assessmentShortlink: ShortLinkId | undefined,
 ) =>
   expectToEqual(templatedEmails, {
     kind: "VALIDATED_CONVENTION_FINAL_CONFIRMATION",
@@ -226,6 +227,9 @@ export const expectEmailFinalValidationConfirmationMatchingConvention = (
       }),
       agencyLogoUrl: agency.logoUrl ?? undefined,
       magicLink: makeShortLinkUrl(config, conventionToSignLinkId),
+      assessmentMagicLink: assessmentShortlink
+        ? makeShortLinkUrl(config, assessmentShortlink)
+        : undefined,
       validatorName: convention.validators?.agencyValidator
         ? concatValidatorNames(convention.validators?.agencyValidator)
         : "",

--- a/back/src/domains/core/short-link/ShortLink.ts
+++ b/back/src/domains/core/short-link/ShortLink.ts
@@ -28,7 +28,7 @@ type ProvidesShortLinkProperties = {
   longLink: AbsoluteUrl;
 };
 
-export const prepareMagicShortLinkMaker =
+export const prepareConventionMagicShortLinkMaker =
   ({
     conventionMagicLinkPayload,
     uow,
@@ -60,10 +60,9 @@ export const makeShortLink = async ({
   config,
   longLink,
 }: ProvidesShortLinkProperties): Promise<AbsoluteUrl> => {
-  const conventionSignShortLinkId: ShortLinkId =
-    shortLinkIdGeneratorGateway.generate();
+  const shortlinkId: ShortLinkId = shortLinkIdGeneratorGateway.generate();
 
-  await uow.shortLinkRepository.save(conventionSignShortLinkId, longLink);
+  await uow.shortLinkRepository.save(shortlinkId, longLink);
 
-  return makeShortLinkUrl(config, conventionSignShortLinkId);
+  return makeShortLinkUrl(config, shortlinkId);
 };

--- a/back/src/utils/assessment.ts
+++ b/back/src/utils/assessment.ts
@@ -9,13 +9,10 @@ import {
   getIcUserRoleForAccessingConvention,
   hasAllowedRoleOnAssessment,
   isEstablishmentTutorIsEstablishmentRepresentative,
-  isSomeEmailMatchingEmailHash,
   legacyAssessmentDtoSchema,
 } from "shared";
 import { z } from "zod";
 import type { AssessmentEntity } from "../domains/convention/entities/AssessmentEntity";
-import type { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
-import { getUserWithRights } from "../domains/inclusion-connected-users/helpers/userRights.helper";
 
 import type { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
 import { getUserWithRights } from "../domains/inclusion-connected-users/helpers/userRights.helper";

--- a/back/src/utils/assessment.ts
+++ b/back/src/utils/assessment.ts
@@ -1,4 +1,3 @@
-import { intersection } from "ramda";
 import {
   type AgencyDto,
   type AssessmentMode,
@@ -6,7 +5,6 @@ import {
   type ConventionRelatedJwtPayload,
   type Role,
   assessmentDtoSchema,
-  assessmentRoles,
   errors,
   getIcUserRoleForAccessingConvention,
   hasAllowedRoleOnAssessment,

--- a/back/src/utils/assessment.ts
+++ b/back/src/utils/assessment.ts
@@ -1,3 +1,4 @@
+import { intersection } from "ramda";
 import {
   type AgencyDto,
   type AssessmentMode,
@@ -5,6 +6,7 @@ import {
   type ConventionRelatedJwtPayload,
   type Role,
   assessmentDtoSchema,
+  assessmentRoles,
   errors,
   getIcUserRoleForAccessingConvention,
   hasAllowedRoleOnAssessment,
@@ -12,6 +14,8 @@ import {
 } from "shared";
 import { z } from "zod";
 import type { AssessmentEntity } from "../domains/convention/entities/AssessmentEntity";
+import type { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
+import { getUserWithRights } from "../domains/inclusion-connected-users/helpers/userRights.helper";
 
 import type { UnitOfWork } from "../domains/core/unit-of-work/ports/UnitOfWork";
 import { getUserWithRights } from "../domains/inclusion-connected-users/helpers/userRights.helper";

--- a/back/src/utils/assessment.ts
+++ b/back/src/utils/assessment.ts
@@ -8,6 +8,8 @@ import {
   errors,
   getIcUserRoleForAccessingConvention,
   hasAllowedRoleOnAssessment,
+  isEstablishmentTutorIsEstablishmentRepresentative,
+  isSomeEmailMatchingEmailHash,
   legacyAssessmentDtoSchema,
 } from "shared";
 import { z } from "zod";
@@ -53,7 +55,7 @@ export const throwForbiddenIfNotAllowedForAssessments = async ({
       convention,
       user,
     );
-    if (!hasAllowedRoleOnAssessment(userRolesOnConvention, mode))
+    if (!hasAllowedRoleOnAssessment(userRolesOnConvention, mode, convention))
       throw errors.assessment.forbidden(mode);
   }
 };
@@ -82,7 +84,9 @@ const assessmentEmailsByRole = (
   "beneficiary-representative": errors.assessment.forbidden(mode),
   "agency-admin": errors.assessment.forbidden(mode),
   "establishment-representative":
-    mode === "GetAssessment"
+    mode === "GetAssessment" ||
+    (mode === "CreateAssessment" &&
+      isEstablishmentTutorIsEstablishmentRepresentative(convention))
       ? [convention.signatories.establishmentRepresentative.email]
       : errors.assessment.forbidden(mode),
   "establishment-tutor": [convention.establishmentTutor.email],

--- a/front/src/app/components/admin/conventions/ConventionManageActions.tsx
+++ b/front/src/app/components/admin/conventions/ConventionManageActions.tsx
@@ -207,7 +207,7 @@ export const ConventionManageActions = ({
     convention.status === "ACCEPTED_BY_VALIDATOR" &&
     isBefore(new Date(convention.dateStart), new Date()) &&
     !assessment &&
-    hasAllowedRoleOnAssessment(roles, "CreateAssessment");
+    hasAllowedRoleOnAssessment(roles, "CreateAssessment", convention);
 
   const shouldShowAssessmentAnbandonAction =
     canAssessmentBeFilled && isConventionEndingInOneDayOrMore;
@@ -216,7 +216,8 @@ export const ConventionManageActions = ({
     canAssessmentBeFilled && !isConventionEndingInOneDayOrMore;
 
   const shouldShowAssessmentDocumentAction =
-    !!assessment && hasAllowedRoleOnAssessment(roles, "GetAssessment");
+    !!assessment &&
+    hasAllowedRoleOnAssessment(roles, "GetAssessment", convention);
 
   const requesterRoles = roles.filter(
     (role): role is ExcludeFromExisting<Role, "agency-admin"> =>

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -677,6 +677,7 @@ export const defaultEmailValueByEmailKind: {
     immersionAppellationLabel: "IMMERSION_APPELLATION_LABEL",
     internshipKind: "immersion",
     magicLink: "MAGIC_LINK",
+    assessmentMagicLink: "ASSESSMENT_MAGIC_LINK",
     validatorName: "VALIDATOR_NAME",
   },
   ESTABLISHMENT_USER_RIGHTS_UPDATED: {

--- a/front/src/app/pages/admin/NotificationsTab.tsx
+++ b/front/src/app/pages/admin/NotificationsTab.tsx
@@ -167,6 +167,7 @@ const Email = ({ email }: { email: EmailNotification }) => (
               "editFrontUrl",
               "assessmentCreationLink",
               "magicLink",
+              "assessmentMagicLink",
               "conventionSignShortlink",
               "unsubscribeToEmailShortLink",
               "registerEstablishmentShortLink",

--- a/front/src/app/pages/immersion-assessment/AssessmentPage.tsx
+++ b/front/src/app/pages/immersion-assessment/AssessmentPage.tsx
@@ -85,7 +85,8 @@ export const AssessmentPage = ({ route }: AssessmentPageProps) => {
   return (
     <HeaderFooterLayout>
       {isLoading && <Loader />}
-      {!hasAllowedRoleOnAssessment(roles, "CreateAssessment") ? (
+      {convention &&
+      !hasAllowedRoleOnAssessment(roles, "CreateAssessment", convention) ? (
         <Alert
           severity="error"
           title="Erreur"

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -466,6 +466,7 @@ export type EmailParamsByEmailType = {
     immersionAppellationLabel: string;
     internshipKind: InternshipKind;
     magicLink: string;
+    assessmentMagicLink: string | undefined;
     validatorName: string;
   };
   TEST_EMAIL: {

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -986,6 +986,7 @@ Ne tardez pas : répondez lui directement en utilisant le bouton ci-dessous : `,
         immersionAppellationLabel,
         internshipKind,
         magicLink,
+        assessmentMagicLink,
         validatorName,
       }) => ({
         subject:
@@ -1030,6 +1031,14 @@ Ne tardez pas : répondez lui directement en utilisant le bouton ci-dessous : `,
           ? `Si la situation l'impose, le contact d'urgence de ${beneficiaryFirstName} ${beneficiaryLastName} : ${emergencyContactInfos}`
           : ""
       }`,
+        highlight: assessmentMagicLink
+          ? {
+              content: `
+              Un imprévu ?
+
+              Si l’immersion ne peut pas aller à son terme (abandon, arrêt anticipé, etc.), merci de nous le signaler dès que possible en <a href="${assessmentMagicLink}">déclarant un abandon</a> , pour assurer un bon suivi.`,
+            }
+          : undefined,
         agencyLogoUrl,
       }),
     },

--- a/shared/src/role/role.dto.ts
+++ b/shared/src/role/role.dto.ts
@@ -50,6 +50,7 @@ export const allowedRolesToCreateAssessment = [
   "establishment-tutor",
   "validator",
   "counsellor",
+  "back-office",
 ] as const;
 
 export const allowedRolesToAccessAssessment = [

--- a/shared/src/role/role.dto.ts
+++ b/shared/src/role/role.dto.ts
@@ -59,13 +59,6 @@ export const allowedRolesToAccessAssessment = [
   "beneficiary",
 ] as const;
 
-export const allowedRolesToAccessAssessment = [
-  ...allowedRolesToCreateAssessment,
-  "back-office",
-  "establishment-representative",
-  "beneficiary",
-] as const;
-
 export const getRequesterRole = (roles: Role[]): Role => {
   if (roles.includes("back-office")) return "back-office";
   if (roles.includes("validator")) return "validator";

--- a/shared/src/role/role.dto.ts
+++ b/shared/src/role/role.dto.ts
@@ -50,7 +50,13 @@ export const allowedRolesToCreateAssessment = [
   "establishment-tutor",
   "validator",
   "counsellor",
+] as const;
+
+export const allowedRolesToAccessAssessment = [
+  ...allowedRolesToCreateAssessment,
   "back-office",
+  "establishment-representative",
+  "beneficiary",
 ] as const;
 
 export const allowedRolesToAccessAssessment = [

--- a/shared/src/role/role.utils.ts
+++ b/shared/src/role/role.utils.ts
@@ -1,5 +1,10 @@
 import { intersection } from "ramda";
-import type { AssessmentMode, Signatories } from "..";
+import {
+  type AssessmentMode,
+  type ConventionDto,
+  type Signatories,
+  isEstablishmentTutorIsEstablishmentRepresentative,
+} from "..";
 import {
   type AgencyModifierRole,
   type Role,
@@ -34,10 +39,16 @@ export const agencyModifierTitleByRole: Record<AgencyModifierRole, string> = {
 export const hasAllowedRoleOnAssessment = (
   userRolesOnConvention: Role[],
   mode: AssessmentMode,
+  convention: ConventionDto,
 ): boolean => {
   const hasAllowedRoleToCreateAssessment =
-    intersection(allowedRolesToCreateAssessment, userRolesOnConvention).length >
-    0;
+    isEstablishmentTutorIsEstablishmentRepresentative(convention)
+      ? intersection(
+          [...allowedRolesToCreateAssessment, "establishment-representative"],
+          userRolesOnConvention,
+        ).length > 0
+      : intersection(allowedRolesToCreateAssessment, userRolesOnConvention)
+          .length > 0;
   const hasAllowedRoleToAccessAssessment =
     intersection(allowedRolesToAccessAssessment, userRolesOnConvention).length >
     0;


### PR DESCRIPTION
- modify get assessment usecase to accept connected user jwt
- modify create assessment usecase to accept connected user jwt
- modify assessment pages to workconnected users
- add buttons to access and fullfill assessment in convention manage action page
- fix wrong message on fetch convention erro in assessment document page
- fix assessment pages with magic link
- do not allow back-office admin to fullfill assessment
- rename prepare magic short link
- add link to assessment page to convention tutor in convention final validation email
