### PR TITLE
#3264 - Traiter les évènements bloqués après une MEP

### DIFF
--- a/back/src/config/bootstrap/createAppDependencies.ts
+++ b/back/src/config/bootstrap/createAppDependencies.ts
@@ -103,7 +103,12 @@ export const createAppDependencies = async (config: AppConfig) => {
     generateApiConsumerJwt,
     generateInclusionConnectJwt,
     eventBus,
-    eventCrawler: createEventCrawler(config, uowPerformer, eventBus),
+    eventCrawler: createEventCrawler(
+      config,
+      uowPerformer,
+      eventBus,
+      gateways.timeGateway,
+    ),
     uuidGenerator,
     inMemoryUow,
     uowPerformer,

--- a/back/src/config/bootstrap/createEventCrawler.ts
+++ b/back/src/config/bootstrap/createEventCrawler.ts
@@ -4,6 +4,7 @@ import {
 } from "../../domains/core/events/adapters/EventCrawlerImplementations";
 import type { EventBus } from "../../domains/core/events/ports/EventBus";
 import type { EventCrawler } from "../../domains/core/events/ports/EventCrawler";
+import type { TimeGateway } from "../../domains/core/time-gateway/ports/TimeGateway";
 import type { UnitOfWorkPerformer } from "../../domains/core/unit-of-work/ports/UnitOfWorkPerformer";
 import type { AppConfig } from "./appConfig";
 
@@ -11,7 +12,13 @@ export const createEventCrawler = (
   config: AppConfig,
   uowPerformer: UnitOfWorkPerformer,
   eventBus: EventBus,
+  timeGateway: TimeGateway,
 ): EventCrawler =>
   config.eventCrawlerPeriodMs > 0
-    ? new RealEventCrawler(uowPerformer, eventBus, config.eventCrawlerPeriodMs)
+    ? new RealEventCrawler(
+        uowPerformer,
+        eventBus,
+        timeGateway,
+        config.eventCrawlerPeriodMs,
+      )
     : new BasicEventCrawler(uowPerformer, eventBus);

--- a/back/src/config/pg/migrations/1745336151992_fix-outbox-status-type.ts
+++ b/back/src/config/pg/migrations/1745336151992_fix-outbox-status-type.ts
@@ -1,0 +1,22 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn("outbox", "status", {
+    type: "varchar(255)",
+  });
+  pgm.dropType("event_status");
+  pgm.createType("event_status", [
+    "never-published",
+    "to-republish",
+    "published",
+    "failed-but-will-retry",
+    "failed-to-many-times",
+    "in-process",
+  ]);
+  pgm.alterColumn("outbox", "status", {
+    type: "event_status",
+    using: "status::event_status",
+  });
+}
+
+export async function down(_pgm: MigrationBuilder): Promise<void> {}

--- a/back/src/config/pg/migrations/1745336151992_mark-old-event-as-failed.ts
+++ b/back/src/config/pg/migrations/1745336151992_mark-old-event-as-failed.ts
@@ -1,0 +1,11 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    UPDATE outbox
+    SET status = 'failed-to-many-times'
+    WHERE status = 'in-process' AND occurred_at < NOW() - INTERVAL '1 day'
+  `);
+}
+
+export async function down(_pgm: MigrationBuilder): Promise<void> {}

--- a/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
+++ b/back/src/domains/core/events/adapters/EventCrawlerImplementations.ts
@@ -155,10 +155,6 @@ export class RealEventCrawler
       message: `RealEventCrawler.startCrawler: processing events at regular intervals (every ${this.crawlingPeriodMs}ms)`,
     });
 
-    // old version :
-    // setInterval(async () => {
-    //   await this.processNewEvents();
-    // }, this.crawlingPeriodMs);
     const processNewEvents = () =>
       setTimeout(() => {
         this.processNewEvents()
@@ -173,11 +169,6 @@ export class RealEventCrawler
       }, this.crawlingPeriodMs);
 
     processNewEvents();
-
-    // old version :
-    // setInterval(async () => {
-    //   await this.retryFailedEvents();
-    // }, retryErrorsPeriodMs);
 
     const retryFailedEvents = () =>
       setTimeout(() => {

--- a/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/InMemoryOutboxRepository.ts
@@ -35,4 +35,20 @@ export class InMemoryOutboxRepository implements OutboxRepository {
       };
     });
   }
+
+  public async markOldInProcessEventsAsToRepublish({
+    eventsBeforeDate,
+  }: { eventsBeforeDate: Date }): Promise<void> {
+    const oldInProcessEvents = this.events.filter(
+      (event) =>
+        event.status === "in-process" &&
+        new Date(event.occurredAt) < eventsBeforeDate,
+    );
+    oldInProcessEvents.forEach((event) => {
+      this._events[event.id] = {
+        ...event,
+        status: "to-republish",
+      };
+    });
+  }
 }

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.ts
@@ -62,6 +62,7 @@ export class PgOutboxRepository implements OutboxRepository {
       .updateTable("outbox")
       .set({ status: "to-republish" })
       .where("status", "=", "in-process")
+      .where("was_quarantined", "=", false)
       .where("occurred_at", "<", eventsBeforeDate)
       .execute();
   }

--- a/back/src/domains/core/events/adapters/PgOutboxRepository.ts
+++ b/back/src/domains/core/events/adapters/PgOutboxRepository.ts
@@ -55,6 +55,17 @@ export class PgOutboxRepository implements OutboxRepository {
         .execute();
   }
 
+  public async markOldInProcessEventsAsToRepublish({
+    eventsBeforeDate,
+  }: { eventsBeforeDate: Date }): Promise<void> {
+    await this.transaction
+      .updateTable("outbox")
+      .set({ status: "to-republish" })
+      .where("status", "=", "in-process")
+      .where("occurred_at", "<", eventsBeforeDate)
+      .execute();
+  }
+
   public async save(event: DomainEvent): Promise<void> {
     const eventInDb =
       await this.#storeEventInOutboxOrRecoverItIfAlreadyThere(event);

--- a/back/src/domains/core/events/ports/OutboxRepository.ts
+++ b/back/src/domains/core/events/ports/OutboxRepository.ts
@@ -4,4 +4,7 @@ export interface OutboxRepository {
   countAllEvents(params: { status: EventStatus }): Promise<number>;
   save: (event: DomainEvent) => Promise<void>;
   markEventsAsInProcess: (events: DomainEvent[]) => Promise<void>;
+  markOldInProcessEventsAsToRepublish: ({
+    eventsBeforeDate,
+  }: { eventsBeforeDate: Date }) => Promise<void>;
 }


### PR DESCRIPTION
### :bug: Le problème

Lorsqu'une MEP est déclenchée, le crawler redémarre et les évènements outbox qui étaient au statut "in-process" le restent et ne sont plus traitées (donc pas d'envois de mails).

### :dart: Solution

Mettre les évènements de plus de 2h au statut "to-republish"

### 💯 Remarque

Les évènements outbox de plus de 1j qui sont en statut "in-process" seront marqué en "failed-too-many-times".