### PR TITLE
TECH - fix migrations

### DIFF
--- a/back/src/config/pg/migrations/1693581341030_add-status-column-to-outbox.ts
+++ b/back/src/config/pg/migrations/1693581341030_add-status-column-to-outbox.ts
@@ -11,6 +11,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     "published",
     "failed-but-will-retry",
     "failed-to-many-times",
+    "in-process",
   ]);
 
   pgm.addColumn(outboxTable, {

--- a/back/src/config/pg/migrations/1708954107350_add-in-process-to-type-event-status.ts
+++ b/back/src/config/pg/migrations/1708954107350_add-in-process-to-type-event-status.ts
@@ -1,7 +1,8 @@
 import type { MigrationBuilder } from "node-pg-migrate";
 
-export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.addTypeValue("event_status", "in-process", { ifNotExists: true });
+export async function up(_pgm: MigrationBuilder): Promise<void> {
+  // content deleted to created whole enum type in a same transaction
+  // see PR #3323
 }
 
 export async function down(_pgm: MigrationBuilder): Promise<void> {

--- a/back/src/config/pg/migrations/1745336151992_fix-outbox-status-type.ts
+++ b/back/src/config/pg/migrations/1745336151992_fix-outbox-status-type.ts
@@ -1,22 +1,8 @@
 import type { MigrationBuilder } from "node-pg-migrate";
 
-export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.alterColumn("outbox", "status", {
-    type: "varchar(255)",
-  });
-  pgm.dropType("event_status");
-  pgm.createType("event_status", [
-    "never-published",
-    "to-republish",
-    "published",
-    "failed-but-will-retry",
-    "failed-to-many-times",
-    "in-process",
-  ]);
-  pgm.alterColumn("outbox", "status", {
-    type: "event_status",
-    using: "status::event_status",
-  });
+export async function up(_pgm: MigrationBuilder): Promise<void> {
+  // content deleted to created whole enum type in a same transaction
+  // see PR #3323
 }
 
 export async function down(_pgm: MigrationBuilder): Promise<void> {}


### PR DESCRIPTION
## Description

Tous les fichiers de migration sont joués dans une même transaction.
Mais `addTypeValue` (type utilisé pour status de outbox) est joué dans une transaction à part: donc il n'est pas possible de faire un update sur le status. On a ce problème lorsque l'on joue tous les fichiers de migration à la suite.