### PR TITLE
#3272 - Fix timeout sur la récupération des conventions pour lesquelles envoyer un bilan

### DIFF
--- a/back/src/utils/notifyTeam.ts
+++ b/back/src/utils/notifyTeam.ts
@@ -72,7 +72,7 @@ const notifySlack = async (rawContent: string, isError: boolean) => {
     });
 };
 
-const getSlackChannelName = (envType: Environment, isError: boolean) => {
+export const getSlackChannelName = (envType: Environment, isError: boolean) => {
   switch (envType) {
     case "production":
       return isError ? "#if-prod-errors" : "#if-prod-notifications";


### PR DESCRIPTION
## 🌈 Description

- si échec du cron -> notification envoyée dans #if-prod-errors ET #if-prod-notifications
- amélioration des perfs de la requête qui récupère
  - les conventions qui finissent dans +/-1 jour mais qui n'ont pas encore reçu de bilan
  - et les conventions qui ont terminés mais ont été validés hier ou aujourd'hui

Ce qui posait problème avec cette requête trop longue :
- on avait parfois des timeout
- difficile de relancer la requête en journée quand la DB est déjà bien sollicitée

## 🤖 Investigation

Dans cette PR je ne tiens compte **que de l'optimisation des clauses WHERE et de jointures de la requête après** `createConventionQueryBuilder`. Il pourrait aussi être recommandé de ne pas utiliser `createConventionQueryBuilder` car elle remonterait des colonnes qui ne nous sont pas nécessaires.

En sql, l'ancienne requête ressemble à:

```sql
SELECT [...]
                 WHERE
                     conventions.status IN ('ACCEPTED_BY_VALIDATOR')
                 AND conventions.date_end <= '2025-04-30'
                 AND NOT EXISTS (SELECT
                                   notifications_email.convention_id
                                 FROM
                                   notifications_email
                                 WHERE
                                     notifications_email.email_kind = 'ASSESSMENT_ESTABLISHMENT_NOTIFICATION'
                                     AND notifications_email.created_at >= '2025-04-25'
                                     AND notifications_email.created_at <= '2025-05-02'
                                 AND conventions.id = notifications_email.convention_id)
                 AND (conventions.date_end >= '2025-04-28' OR EXISTS (SELECT
                                                                        notifications_email.convention_id
                                                                      FROM
                                                                        notifications_email
                                                                      WHERE
                                                                          notifications_email.email_kind
                                                                              = 'VALIDATED_CONVENTION_FINAL_CONFIRMATION'
                                                                      AND notifications_email.created_at >= '2025-04-26'
                                                                      AND notifications_email.created_at <= '2025-05-02'
                                                                      AND conventions.id = notifications_email.convention_id))
```

et maintenant c'est plutôt:

```sql
SELECT [...]
              WHERE c.status = 'ACCEPTED_BY_VALIDATOR'
              AND ((date_end BETWEEN '2025-04-28' AND '2025-04-30') or (updated_at BETWEEN '2025-04-28' AND '2025-04-30' AND date_end <= '2025-04-30'))
              AND EXISTS (
                SELECT 1
                FROM notifications_email ne
                WHERE ne.convention_id = c.id
                AND ne.email_kind = 'VALIDATED_CONVENTION_FINAL_CONFIRMATION'
              )
              AND NOT EXISTS (
                SELECT 1
                FROM notifications_email ne
                WHERE ne.convention_id = c.id
                AND (ne.email_kind = 'ASSESSMENT_ESTABLISHMENT_NOTIFICATION');
```

`EXPLAIN` de la requête avant cette PR:
<img width="1466" alt="Screenshot 2025-04-28 at 15 20 07" src="https://github.com/user-attachments/assets/bae55f7f-3093-43fb-8561-7fef172d171d" />

Puis avec la nouvelle requête:
<img width="1308" alt="Screenshot 2025-04-28 at 16 53 48" src="https://github.com/user-attachments/assets/3ff7e107-b9cf-4075-900a-37519d47ee05" />

**Ce qui change**:
- meilleur temps d'éxécution sur la nightly: ~300ms vs >2000ms
- moins de données extraites (avant on manipulait des millions de lignes)
- on utilise davantage les index scan
