### PR TITLE
TECH - faire en sorte de renvoyer un message explicit lorsque l'API de listing de conventions est appelée avec de mauvais paramètres

### DIFF
--- a/back/src/adapters/primary/routers/DtoAndSchemas/v2/input/GetConventionByFiltersQueriesV2.schema.ts
+++ b/back/src/adapters/primary/routers/DtoAndSchemas/v2/input/GetConventionByFiltersQueriesV2.schema.ts
@@ -10,14 +10,16 @@ export type GetConventionsByFiltersQueryParamsV2 = {
 
 const conventionStatusSchema = z.enum(conventionStatuses);
 
-export const getConventionsByFiltersQueryParamsV2Schema = z.object({
-  startDateGreater: z.coerce.date().optional(),
-  startDateLessOrEqual: z.coerce.date().optional(),
-  withStatuses: z
-    .array(conventionStatusSchema)
-    .optional()
-    .or(conventionStatusSchema.optional()),
-});
+export const getConventionsByFiltersQueryParamsV2Schema = z
+  .object({
+    startDateGreater: z.coerce.date().optional(),
+    startDateLessOrEqual: z.coerce.date().optional(),
+    withStatuses: z
+      .array(conventionStatusSchema)
+      .optional()
+      .or(conventionStatusSchema.optional()),
+  })
+  .strict();
 
 export const getConventionsByFiltersV2ToDomain = (
   paramsV2: GetConventionsByFiltersQueryParamsV2,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/conventionPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/conventionPublicV2.e2e.test.ts
@@ -190,6 +190,23 @@ describe("Convention routes", () => {
       });
     });
 
+    it("400 - fails if unknown keys are provided", async () => {
+      const response = await sharedRequest.getConventions({
+        headers: { authorization: "whatever" },
+        queryParams: { someUnknownKey: "yolo" } as any,
+      });
+
+      expectHttpResponseToEqual(response, {
+        status: 400,
+        body: {
+          status: 400,
+          message:
+            "Shared-route schema 'queryParamsSchema' was not respected in adapter 'express'.\nRoute: GET /v2/conventions",
+          issues: [" : Unrecognized key(s) in object: 'someUnknownKey'"],
+        },
+      });
+    });
+
     it("200 - returns the conventions matching agencyIds in scope", async () => {
       inMemoryUow.agencyRepository.agencies = [toAgencyWithRights(agency)];
       inMemoryUow.conventionRepository.setConventions([convention]);


### PR DESCRIPTION
Maintenant que le on reçoit des paramètre inconnu, l'API renvera ceci :

```
{
  "status": 400,
  "message": "Shared-route schema 'queryParamsSchema' was not respected in adapter 'express'.\nRoute: GET /v2/conventions",
  "issues": [" : Unrecognized key(s) in object: 'fieldWithTypo123'"]
}
```