### PR TITLE
FIX - Noms et Prénoms des conseillers/valideurs moins restrictifs 

### DIFF
--- a/front/src/app/contents/admin/types.ts
+++ b/front/src/app/contents/admin/types.ts
@@ -6,13 +6,13 @@ import type {
   ConventionReadDto,
   EstablishmentRepresentative,
   EstablishmentTutor,
-  WithFirstnameAndLastname,
+  WithOptionalFirstnameAndLastname,
 } from "shared";
 
 export type ConventionField =
   | keyof ConventionReadDto
   | `agencyRefersTo.${keyof AgencyRefersToInConvention}`
-  | `agencyReferent.${keyof WithFirstnameAndLastname}`
+  | `agencyReferent.${keyof WithOptionalFirstnameAndLastname}`
   | `establishmentTutor.${keyof EstablishmentTutor}`
   | `signatories.beneficiary.${keyof Beneficiary<"immersion">}`
   | `signatories.beneficiary.${keyof Beneficiary<"mini-stage-cci">}`

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -24,7 +24,7 @@ import {
   type ImmersionObjective,
   type InternshipKind,
   type Renewed,
-  type WithFirstnameAndLastname,
+  type WithOptionalFirstnameAndLastname,
   isBeneficiary,
   isBeneficiaryStudent,
 } from "./convention.dto";
@@ -715,7 +715,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   }
 
   public withValidator(
-    agencyValidator: WithFirstnameAndLastname,
+    agencyValidator: WithOptionalFirstnameAndLastname,
   ): ConventionDtoBuilder {
     return new ConventionDtoBuilder({
       ...this.dto,
@@ -727,7 +727,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   }
 
   public withCounsellor(
-    agencyCounsellor: WithFirstnameAndLastname,
+    agencyCounsellor: WithOptionalFirstnameAndLastname,
   ): ConventionDtoBuilder {
     return new ConventionDtoBuilder({
       ...this.dto,
@@ -739,7 +739,7 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
   }
 
   public withAgencyReferent(
-    agencyReferent: WithFirstnameAndLastname,
+    agencyReferent: WithOptionalFirstnameAndLastname,
   ): ConventionDtoBuilder {
     return new ConventionDtoBuilder({
       ...this.dto,

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -181,7 +181,7 @@ export type ConventionCommon = {
   establishmentNumberEmployeesRange?: NumberEmployeesRange;
   establishmentTutor: EstablishmentTutor;
   validators?: ConventionValidatorInputNames;
-  agencyReferent?: WithFirstnameAndLastname;
+  agencyReferent?: WithOptionalFirstnameAndLastname;
 } & Partial<WithRenewed> &
   WithAcquisition;
 
@@ -197,11 +197,11 @@ export type WithRenewed = {
 };
 
 export type ConventionValidatorInputNames = {
-  agencyCounsellor?: WithFirstnameAndLastname;
-  agencyValidator?: WithFirstnameAndLastname;
+  agencyCounsellor?: WithOptionalFirstnameAndLastname;
+  agencyValidator?: WithOptionalFirstnameAndLastname;
 };
 
-export type WithFirstnameAndLastname = {
+export type WithOptionalFirstnameAndLastname = {
   firstname?: string;
   lastname?: string;
 };

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -214,10 +214,15 @@ const withFirstnameAndLastnameSchema: z.Schema<WithFirstnameAndLastname> =
     lastname: personNameSchema.optional(),
   });
 
+const conventionValidatorSchema: z.Schema<WithFirstnameAndLastname> = z.object({
+  firstname: z.string().optional(),
+  lastname: z.string().optional(),
+});
+
 const conventionValidatorsSchema: z.Schema<ConventionValidatorInputNames> =
   z.object({
-    agencyCounsellor: withFirstnameAndLastnameSchema.optional(),
-    agencyValidator: withFirstnameAndLastnameSchema.optional(),
+    agencyCounsellor: conventionValidatorSchema.optional(),
+    agencyValidator: conventionValidatorSchema.optional(),
   });
 
 const renewedSchema = z.object({

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -92,7 +92,7 @@ import {
   type WithConventionDto,
   type WithConventionId,
   type WithConventionIdLegacy,
-  type WithFirstnameAndLastname,
+  type WithOptionalFirstnameAndLastname,
   conventionObjectiveOptions,
   conventionStatuses,
   conventionStatusesWithJustification,
@@ -208,16 +208,17 @@ export const immersionObjectiveSchema: z.Schema<ImmersionObjective> =
     localization.invalidImmersionObjective,
   );
 
-const withFirstnameAndLastnameSchema: z.Schema<WithFirstnameAndLastname> =
+const withOptionalFirstnameAndLastnameSchema: z.Schema<WithOptionalFirstnameAndLastname> =
   z.object({
     firstname: personNameSchema.optional(),
     lastname: personNameSchema.optional(),
   });
 
-const conventionValidatorSchema: z.Schema<WithFirstnameAndLastname> = z.object({
-  firstname: z.string().optional(),
-  lastname: z.string().optional(),
-});
+const conventionValidatorSchema: z.Schema<WithOptionalFirstnameAndLastname> =
+  z.object({
+    firstname: z.string().optional(),
+    lastname: z.string().optional(),
+  });
 
 const conventionValidatorsSchema: z.Schema<ConventionValidatorInputNames> =
   z.object({
@@ -262,7 +263,7 @@ const conventionCommonSchema: z.Schema<ConventionCommon> = z
     immersionSkills: zStringPossiblyEmptyWithMax(2000),
     establishmentTutor: establishmentTutorSchema,
     validators: conventionValidatorsSchema.optional(),
-    agencyReferent: withFirstnameAndLastnameSchema.optional(),
+    agencyReferent: withOptionalFirstnameAndLastnameSchema.optional(),
     renewed: renewedSchema.optional(),
     establishmentNumberEmployeesRange: numberOfEmployeesRangeSchema.optional(),
   })

--- a/shared/src/convention/convention.ts
+++ b/shared/src/convention/convention.ts
@@ -16,11 +16,11 @@ import type {
   GetConventionsForAgencyUserParams,
   Signatories,
   Signatory,
-  WithFirstnameAndLastname,
+  WithOptionalFirstnameAndLastname,
 } from "./convention.dto";
 
 export const concatValidatorNames = (
-  validator: WithFirstnameAndLastname,
+  validator: WithOptionalFirstnameAndLastname,
 ): string => [validator.firstname, validator.lastname].join(" ").trim();
 
 export const allSignatoriesSigned = (signatories: Signatories) =>


### PR DESCRIPTION
## 🐛 Problème

On avait appliqué le type `personNameSchema` à la fois:
- à agencyReferent (nom et prénom du conseiller dans le form de convention)
- à agencyCounsellor (nom et prénom du conseiller qui pré-valide la convention)
- à agencyValidator (nom et prénom du valideur qui valide la convention)

Or, pour agencyCounsellor et agencyValidator nous avons déjà en DB des données qui ressemble à:
- "lastname": "firstname.lastname@francetravail.fr", "firstname": "firstname.lastname@francetravail.fr"
- "lastname": "Avenir Actif", "firstname": "Conseil St Brieuc / Plérin"

Problème: avec le type personNameSchema, les / et ponctuation ne sont pas acceptés.

## 💯 Solution

Vu avec Gaël: on veut garder l'état des données actuelle en DB. Donc pour agencyCounsellor et agencyValidator, on ne met qu'un typage string.