### PR TITLE
#3435 - Envois des mails de liens de complétion de bilan 1h plus tôt

### DIFF
--- a/back/scalingo/cron.json
+++ b/back/scalingo/cron.json
@@ -13,11 +13,11 @@
       "size": "M"
     },
     {
-      "command": "00 6 * * * pnpm back run trigger-establishment-leads-reminders",
+      "command": "30 05 * * * pnpm back run trigger-sending-assessment-needed-notifications",
       "size": "M"
     },
     {
-      "command": "30 06 * * * pnpm back run trigger-sending-assessment-needed-notifications",
+      "command": "00 6 * * * pnpm back run trigger-establishment-leads-reminders",
       "size": "M"
     },
     {


### PR DESCRIPTION
## 🌈 Description

Actuellement, les mails partent entre 8h30 et 9h.
Puisque nous avons des problèmes de requêtes SQL sur la table convention en timeout, on avance l'heure d'envois des mails à un moment où la table serait moins sollicitée.