### PR TITLE
#3523 - Fix affichage du message d'erreur lorsque l'on déclenche un envoi de sms < 24h

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -23,7 +23,7 @@ import {
 import type { JwtKindProps } from "src/app/components/admin/conventions/ConventionManageActions";
 import { Feedback } from "src/app/components/feedback/Feedback";
 import { labelAndSeverityByStatus } from "src/app/contents/convention/labelAndSeverityByStatus";
-import { useFeedbackTopic } from "src/app/hooks/feedback.hooks";
+import { useFeedbackTopics } from "src/app/hooks/feedback.hooks";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { useScrollToTop } from "src/app/hooks/window.hooks";
 import { commonIllustrations } from "src/assets/img/illustrations";
@@ -74,8 +74,7 @@ export const ConventionValidation = ({
     useState<boolean>(false);
 
   useScrollToTop(
-    !!useFeedbackTopic("send-signature-link") ||
-      !!useFeedbackTopic("send-assessment-link"),
+    !!useFeedbackTopics(["send-signature-link", "send-assessment-link"]),
   );
 
   const [signatoryToSendSignatureLink, setSignatoryToSendSignatureLink] =


### PR DESCRIPTION
## 🐛 Problème

Sur la page de pilotage d'une convention, lorsque je déclenche une demande de signature par SMS trop tôt (moins de 24h avant le précédent), j'ai bien un appel api en erreur HTTP 429 mais j'ai un autre écran qui s'affiche au lieu du feedback d'erreur:

![image](https://github.com/user-attachments/assets/c4eb55a2-42a5-463c-bd35-cf02b574624d)
