### PR TITLE
Fix - Retirer le feedback en doublon de la page de signature et le rajouter dans la page de signature depuis l'espace entreprise

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -74,8 +74,11 @@ export const ConventionValidation = ({
     useState<boolean>(false);
 
   useScrollToTop(
-    useFeedbackTopics(["send-signature-link", "send-assessment-link"]).length >
-      0,
+    useFeedbackTopics([
+      "send-signature-link",
+      "send-assessment-link",
+      "convention-action-sign",
+    ]).length > 0,
   );
 
   const [signatoryToSendSignatureLink, setSignatoryToSendSignatureLink] =
@@ -183,7 +186,12 @@ export const ConventionValidation = ({
         <p>Justification : {convention.statusJustification}</p>
       )}
       <Feedback
-        topics={["send-signature-link", "send-assessment-link"]}
+        topics={[
+          "send-signature-link",
+          "send-assessment-link",
+          "convention-action-sign",
+        ]}
+        closable
         className={fr.cx("fr-my-4w")}
       />
       {isConventionRenewed(convention) && (

--- a/front/src/app/components/forms/convention/ConventionSignForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionSignForm.tsx
@@ -145,10 +145,7 @@ export const ConventionSignForm = ({
 
   return (
     <>
-      <Feedback
-        topics={["convention-action-sign", "send-signature-link"]}
-        closable
-      />
+      <Feedback topics={["send-signature-link"]} closable />
       {alreadySigned ? (
         <>
           <Alert

--- a/playwright/utils/convention.ts
+++ b/playwright/utils/convention.ts
@@ -214,7 +214,7 @@ export const signConvention = async (
   await expect(
     page
       .locator(".fr-alert--success")
-      .getByRole("heading", { name: "La convention a bien été signée" }),
+      .getByRole("heading", { name: "Vous avez signé cette convention." }),
   ).toBeVisible();
 };
 


### PR DESCRIPTION
J'ai retiré le feedback en doublon de la page de signature et j'ai rajouté ce feedback qui était manquant lorsqu'on signe la convention depuis l'espace entreprise