### PR TITLE
Fix - Retirer le wording en doublon dans la tab de convention a synchroniser dans l'espace prescripteur

### DIFF
--- a/front/src/app/components/agency/agency-dashboard/tabs/ErroredConventionTabContent.tsx
+++ b/front/src/app/components/agency/agency-dashboard/tabs/ErroredConventionTabContent.tsx
@@ -57,16 +57,6 @@ export const ErroredConventionTabContent = ({
               </p>
 
               <h3 className={fr.cx("fr-h6")}>
-                Identifiant National DE trouvé mais écart sur la date de
-                naissance
-              </h3>
-              <p>
-                Action → Modifier la date de naissance dans la demande pour
-                correspondre à l'information présente dans le dossier du
-                Demandeur d'emploi
-              </p>
-
-              <h3 className={fr.cx("fr-h6")}>
                 Identifiant National DE non trouvé
               </h3>
               <p>


### PR DESCRIPTION
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/be97a469-7c57-4add-a082-23e53c1d5eac" />
J'ai retiré le wording en doublon présent sur l'image ci-dessus