### PR TITLE
3622 longueur max dépassée dans le replyto de brevo

### DIFF
--- a/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.unit.test.ts
@@ -326,7 +326,7 @@ describe("SendExchangeToRecipient", () => {
             },
             recipients: [discussion.establishmentContact.email],
             replyTo: {
-              email: `e-ric_el-ah-e-truc__${discussion.id}_b@reply.my-domain.com`,
+              email: `e-ric_el-ah-e-tru__${discussion.id}_b@reply.my-domain.com`,
               name: `${discussion.potentialBeneficiary.firstName} ${discussion.potentialBeneficiary.lastName}`,
             },
             sender: immersionFacileNoReplyEmailSender,

--- a/shared/src/inboundEmailParsing/inboundEmailParsing.unit.test.ts
+++ b/shared/src/inboundEmailParsing/inboundEmailParsing.unit.test.ts
@@ -1,7 +1,7 @@
 import { createOpaqueEmail } from "./inboundEmailParsing.utils";
 
 describe("inboundEmailParsing", () => {
-  it("should create opaque email with long fullname truncated", () => {
+  it("should create opaque email with long fullname truncated and keep firstname and lastname part", () => {
     const opaqueEmail = createOpaqueEmail({
       discussionId: "ab5ca3ad-d348-43b7-bdd6-5eddbbb0a274",
       replyDomain: "reply.immersion-facile.beta.gouv.fr",
@@ -15,7 +15,7 @@ describe("inboundEmailParsing", () => {
     expect(opaqueEmail.split("@")[0].length).toBeLessThanOrEqual(64);
 
     expect(opaqueEmail).toBe(
-      "fulgence-antoinette_pour__ab5ca3ad-d348-43b7-bdd6-5eddbbb0a274_e@reply.immersion-facile.beta.gouv.fr",
+      "fulgence-an_pourroy-de__ab5ca3ad-d348-43b7-bdd6-5eddbbb0a274_e@reply.immersion-facile.beta.gouv.fr",
     );
   });
 

--- a/shared/src/inboundEmailParsing/inboundEmailParsing.utils.ts
+++ b/shared/src/inboundEmailParsing/inboundEmailParsing.utils.ts
@@ -42,7 +42,11 @@ const makeFullnameWithSeparator = (
   separator: string,
   limit: number,
 ) => {
-  const fullname = `${firstname}_${lastname}`;
-  const fullnameTruncated = fullname.slice(0, limit);
-  return `${fullnameTruncated}${separator}`;
+  const limitForParts = Math.ceil(limit / 2) - 1;
+  const truncatedFirstname = firstname
+    .slice(0, limitForParts)
+    .replace(/-$/, "");
+  const truncatedLastname = lastname.slice(0, limitForParts).replace(/-$/, "");
+  const fullname = `${truncatedFirstname}_${truncatedLastname}`;
+  return `${fullname}${separator}`;
 };


### PR DESCRIPTION
- **truncate fullname if it's loo long on createOpaqueEmail**
- **truncate emails in inbound parsing from what left from local part**
- **firstname and lastname truncated, remove trailing dash**
