### PR TITLE
#3049 - Script d'insertion des agences et utilisateurs depuis un fichiers CSV

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -32,6 +32,7 @@
     "test:manual": "jest --runInBand --watchAll --testRegex=.manual.test.ts",
     "test:unit": "jest --watchAll --testRegex=.unit.test.ts",
     "test": "NODE_OPTIONS='--max_old_space_size=4096' jest --testRegex='^((?!(integration|manual)).)*.test.ts$'",
+    "trigger-add-agencies-and-users": "ts-node src/scripts/triggerAddAgenciesAndUsers.ts",
     "trigger-convention-reminder": "ts-node src/scripts/triggerConventionReminder.ts",
     "trigger-contact-request-reminder-3d": "ts-node src/scripts/triggerContactRequestReminder3Days.ts",
     "trigger-contact-request-reminder-7d": "ts-node src/scripts/triggerContactRequestReminder7Days.ts",

--- a/back/src/config/bootstrap/createGateways.ts
+++ b/back/src/config/bootstrap/createGateways.ts
@@ -122,6 +122,28 @@ export type Gateways = ReturnType<typeof createGateways> extends Promise<
   ? T
   : never;
 
+export const createFetchHttpClientForExternalAPIs = <
+  R extends Record<string, UnknownSharedRoute>,
+>({
+  routes,
+  partnerName,
+  logInputCbOnSuccess,
+  config,
+}: {
+  routes: R;
+  partnerName: string;
+  logInputCbOnSuccess?: LogInputCbOnSuccess;
+  config: AppConfig;
+}) =>
+  createFetchSharedClient(routes, fetch, {
+    timeout: config.externalAxiosTimeout,
+    skipResponseValidation: true,
+    onResponseSideEffect: logPartnerResponses({
+      partnerName: partnerName,
+      logInputCbOnSuccess,
+    }),
+  });
+
 export const createGateways = async (
   config: AppConfig,
   uuidGenerator: UuidGenerator,
@@ -136,26 +158,6 @@ export const createGateways = async (
       apiAddress: config.apiAddress,
     },
   });
-
-  const createFetchHttpClientForExternalAPIs = <
-    R extends Record<string, UnknownSharedRoute>,
-  >({
-    routes,
-    partnerName,
-    logInputCbOnSuccess,
-  }: {
-    routes: R;
-    partnerName: string;
-    logInputCbOnSuccess?: LogInputCbOnSuccess;
-  }) =>
-    createFetchSharedClient(routes, fetch, {
-      timeout: config.externalAxiosTimeout,
-      skipResponseValidation: true,
-      onResponseSideEffect: logPartnerResponses({
-        partnerName: partnerName,
-        logInputCbOnSuccess,
-      }),
-    });
 
   const createLegacyAxiosHttpClientForExternalAPIs = <
     R extends Record<string, UnknownSharedRoute>,
@@ -251,6 +253,7 @@ export const createGateways = async (
           createFetchHttpClientForExternalAPIs({
             partnerName: partnerNames.emailable,
             routes: emailableValidationRoutes,
+            config,
           }),
           config.emailableApiKey,
           withCache,
@@ -265,6 +268,7 @@ export const createGateways = async (
           createFetchHttpClientForExternalAPIs({
             partnerName: partnerNames.diagoriente,
             routes: diagorienteAppellationsRoutes,
+            config,
           }),
           new InMemoryCachingGateway<DiagorienteAccessTokenResponse>(
             timeGateway,
@@ -285,6 +289,7 @@ export const createGateways = async (
         createFetchHttpClientForExternalAPIs({
           partnerName: partnerNames.openCageData,
           routes: addressesExternalRoutes,
+          config,
         }),
         config.apiKeyOpenCageDataGeocoding,
         config.apiKeyOpenCageDataGeosearch,
@@ -304,6 +309,7 @@ export const createGateways = async (
         httpClient: createFetchHttpClientForExternalAPIs({
           partnerName: partnerNames.brevoNotifications,
           routes: brevoNotificationGatewayRoutes,
+          config,
         }),
         defaultSender: immersionFacileNoReplyEmailSender,
         emailAllowListPredicate: makeEmailAllowListPredicate({
@@ -367,6 +373,7 @@ export const createGateways = async (
             partnerName: partnerNames.annuaireDesEntreprises,
             routes: annuaireDesEntreprisesSiretRoutes,
             logInputCbOnSuccess: logQwhenExists,
+            config,
           }),
           createInseeSiretGateway(),
         ),
@@ -433,6 +440,7 @@ export const createGateways = async (
             createFetchHttpClientForExternalAPIs({
               partnerName: partnerNames.laBonneBoite,
               routes: createLbbRoutes(config.ftApiUrl),
+              config,
             }),
             franceTravailGateway,
             config.franceTravailClientId,

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -639,6 +639,7 @@ export const createUseCases = ({
       deps: {
         uuidGenerator,
         timeGateway: gateways.timeGateway,
+        addressGateway: gateways.addressApi,
       },
     }),
 

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -8,6 +8,7 @@ import {
   type ShortLinkId,
   type SiretDto,
 } from "shared";
+import { makeAddAgenciesAndUsers } from "../../domains/agency/use-cases/AddAgenciesAndUsers";
 import { makeAddAgency } from "../../domains/agency/use-cases/AddAgency";
 import { makeGetAgencyById } from "../../domains/agency/use-cases/GetAgencyById";
 import { makeListAgencyOptionsByFilter } from "../../domains/agency/use-cases/ListAgenciesByFilter";
@@ -631,6 +632,14 @@ export const createUseCases = ({
           similarConventionIds:
             await uow.conventionQueries.findSimilarConventions(params),
         })),
+    }),
+
+    addAgenciesAndUsers: makeAddAgenciesAndUsers({
+      uowPerformer,
+      deps: {
+        uuidGenerator,
+        timeGateway: gateways.timeGateway,
+      },
     }),
 
     updateUserForAgency: makeUpdateUserForAgency({

--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -7,6 +7,7 @@ import {
   type AgencyPositionFilter,
   type AgencyStatus,
   type AgencyWithUsersRights,
+  activeAgencyStatuses,
   type DepartmentCode,
   errors,
   type GeoPositionDto,
@@ -206,6 +207,18 @@ export class InMemoryAgencyRepository implements AgencyRepository {
         agency.status !== "rejected" &&
         agency.id !== idToIgnore,
     );
+  }
+
+  public async getExistingActiveSirets(
+    sirets: SiretDto[],
+  ): Promise<SiretDto[]> {
+    return this.agencies
+      .filter(
+        (agency) =>
+          activeAgencyStatuses.includes(agency.status) &&
+          sirets.includes(agency.agencySiret),
+      )
+      .map((agency) => agency.agencySiret);
   }
 }
 

--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -122,7 +122,7 @@ export class InMemoryAgencyRepository implements AgencyRepository {
             agencyIsOfKind(agency, filters?.kinds),
             agencyIsOfPosition(agency, filters?.position),
             agencyIsOfStatus(agency, filters?.status),
-            agencyHasSiret(agency, filters?.sirets),
+            agencyHasSirets(agency, filters?.sirets),
             agencyDoesNotReferToOtherAgency(
               agency,
               filters?.doesNotReferToOtherAgency,
@@ -247,7 +247,7 @@ const agencyHasName = (
   return agency.name.toLowerCase().includes(name.toLowerCase());
 };
 
-const agencyHasSiret = (
+const agencyHasSirets = (
   agency: AgencyWithUsersRights,
   sirets?: SiretDto[],
 ): boolean => {

--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -122,7 +122,7 @@ export class InMemoryAgencyRepository implements AgencyRepository {
             agencyIsOfKind(agency, filters?.kinds),
             agencyIsOfPosition(agency, filters?.position),
             agencyIsOfStatus(agency, filters?.status),
-            agencyHasSiret(agency, filters?.siret),
+            agencyHasSiret(agency, filters?.sirets),
             agencyDoesNotReferToOtherAgency(
               agency,
               filters?.doesNotReferToOtherAgency,
@@ -249,10 +249,10 @@ const agencyHasName = (
 
 const agencyHasSiret = (
   agency: AgencyWithUsersRights,
-  siret?: SiretDto,
+  sirets?: SiretDto[],
 ): boolean => {
-  if (!siret) return true;
-  return agency.agencySiret === siret;
+  if (!sirets || sirets.length === 0) return true;
+  return sirets.includes(agency.agencySiret);
 };
 
 const agencyDoesNotReferToOtherAgency = (

--- a/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
@@ -642,7 +642,7 @@ describe("PgAgencyRepository", () => {
       });
     });
 
-    describe("filter siret", () => {
+    describe("filter sirets", () => {
       beforeEach(async () => {
         await Promise.all([
           agencyRepository.insert(agency1PEVitrySurSeine),
@@ -650,19 +650,27 @@ describe("PgAgencyRepository", () => {
         ]);
       });
 
-      it("returns all agencies filtered by siret", async () => {
+      it("returns all agencies filtered by sirets", async () => {
         expect(
           await agencyRepository.getAgencies({
-            filters: { siret: agency1PEVitrySurSeine.agencySiret },
+            filters: { sirets: [agency1PEVitrySurSeine.agencySiret] },
           }),
         ).toEqual([agency1PEVitrySurSeine]);
       });
-      it("returns nothing on missing siret", async () => {
+      it("returns nothing on missing sirets", async () => {
         expect(
           await agencyRepository.getAgencies({
-            filters: { siret: "00000000000000" },
+            filters: { sirets: ["00000000000000"] },
           }),
         ).toEqual([]);
+      });
+
+      it("returns all on empty sirets", async () => {
+        expect(
+          await agencyRepository.getAgencies({
+            filters: { sirets: [] },
+          }),
+        ).toEqual([agency1PEVitrySurSeine, agency2PEVitryLeFrancois]);
       });
     });
 

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -10,6 +10,7 @@ import {
   type AgencyStatus,
   type AgencyUsersRights,
   type AgencyWithUsersRights,
+  activeAgencyStatuses,
   ConflictError,
   type DepartmentCode,
   errors,
@@ -17,6 +18,7 @@ import {
   isWithAgencyRole,
   type OmitFromExistingKeys,
   pipeWithValue,
+  type SiretDto,
   type UserId,
   type WithUserFilters,
 } from "shared";
@@ -453,6 +455,17 @@ export class PgAgencyRepository implements AgencyRepository {
       .insertInto("users__agencies")
       .values(newRights)
       .execute();
+  }
+
+  async getExistingActiveSirets(sirets: SiretDto[]): Promise<SiretDto[]> {
+    const results = await this.transaction
+      .selectFrom("agencies")
+      .select("agency_siret")
+      .where("agency_siret", "in", sirets)
+      .where("status", "in", activeAgencyStatuses)
+      .execute();
+
+    return results.map(({ agency_siret }) => agency_siret);
   }
 }
 

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -180,7 +180,7 @@ export class PgAgencyRepository implements AgencyRepository {
       doesNotReferToOtherAgency,
       nameIncludes,
       position,
-      siret,
+      sirets,
       status,
     } = filters;
 
@@ -204,7 +204,7 @@ export class PgAgencyRepository implements AgencyRepository {
         doesNotReferToOtherAgency
           ? b.where("agencies.refers_to_agency_id", "is", null)
           : b,
-      (b) => (siret ? b.where("agencies.agency_siret", "=", siret) : b),
+      (b) => (sirets && sirets.length > 0 ? b.where("agencies.agency_siret", "in", sirets) : b),
       (b) =>
         position
           ? b.where(

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -204,7 +204,10 @@ export class PgAgencyRepository implements AgencyRepository {
         doesNotReferToOtherAgency
           ? b.where("agencies.refers_to_agency_id", "is", null)
           : b,
-      (b) => (sirets && sirets.length > 0 ? b.where("agencies.agency_siret", "in", sirets) : b),
+      (b) =>
+        sirets && sirets.length > 0
+          ? b.where("agencies.agency_siret", "in", sirets)
+          : b,
       (b) =>
         position
           ? b.where(

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -62,6 +62,7 @@ export interface AgencyRepository {
     kind: AgencyKind;
     idToIgnore: AgencyId;
   }): Promise<boolean>;
+  getExistingActiveSirets(sirets: SiretDto[]): Promise<SiretDto[]>;
 }
 
 export const updateAgencyRightsForUser = async (

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -22,7 +22,7 @@ export type GetAgenciesFilters = {
   departmentCode?: DepartmentCode;
   kinds?: AgencyKind[];
   status?: AgencyStatus[];
-  siret?: SiretDto;
+  sirets?: SiretDto[];
   doesNotReferToOtherAgency?: true;
 };
 

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
@@ -1,0 +1,171 @@
+import { splitEvery, uniq } from "ramda";
+import { type AgencyWithUsersRights, type Phone, phoneSchema } from "shared";
+import { z } from "zod";
+import type { UserRepository } from "../../core/authentication/connected-user/port/UserRepository";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
+import { useCaseBuilder } from "../../core/useCaseBuilder";
+import type { UuidGenerator } from "../../core/uuid-generator/ports/UuidGenerator";
+import type { AgencyRepository } from "../ports/AgencyRepository";
+
+export type ImportedAgencyAndUserRow = {
+  ID: string;
+  SIRET: string;
+  "Type structure": string;
+  "Nom structure": string;
+  "E-mail authentification": string;
+  "Adresse ligne 1": string;
+  "Adresse ligne 2": string;
+  Ville: string;
+  Téléphone: Phone;
+};
+
+export const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> =
+  z.object({
+    ID: z.string(),
+    SIRET: z.string(),
+    "Type structure": z.string(),
+    "Nom structure": z.string(),
+    "E-mail authentification": z.string(),
+    "Adresse ligne 1": z.string(),
+    "Adresse ligne 2": z.string(),
+    Ville: z.string(),
+    Téléphone: phoneSchema,
+  });
+
+export type AddAgenciesAndUsers = ReturnType<typeof makeAddAgenciesAndUsers>;
+export const makeAddAgenciesAndUsers = useCaseBuilder("AddAgenciesAndUsers")
+  .withInput<ImportedAgencyAndUserRow[]>(
+    z.array(importedAgencyAndUserRowSchema),
+  )
+  .withOutput<{
+    createdAgenciesCount: number;
+    createdUsersCount: number;
+    updatedUsersCount: number;
+  }>()
+  .withDeps<{
+    uuidGenerator: UuidGenerator;
+    timeGateway: TimeGateway;
+  }>()
+  .build(async ({ inputParams, uow, deps }) => {
+    const chunkSize = 500;
+    const chunks = splitEvery(chunkSize, inputParams);
+    const results = await Promise.all(
+      chunks.map(async (importedAgencies) => {
+        const existingAgencies = await uow.agencyRepository.getAgencies({
+          filters: {
+            sirets: importedAgencies.map(
+              (importedAgency) => importedAgency.SIRET,
+            ),
+          },
+        });
+
+        const { createdUsersCount, updatedUsersCount } =
+          await addOrUpdateAgencyUsers({
+            agenciesIF: existingAgencies,
+            importedAgencyAndUserRows: importedAgencies,
+            agencyRepository: uow.agencyRepository,
+            userRepository: uow.userRepository,
+            deps,
+          });
+
+        return {
+          createdUsersCount,
+          updatedUsersCount,
+        };
+      }),
+    );
+
+    return {
+      createdAgenciesCount: 0,
+      createdUsersCount: results.reduce(
+        (acc, curr) => acc + curr.createdUsersCount,
+        0,
+      ),
+      updatedUsersCount: results.reduce(
+        (acc, curr) => acc + curr.updatedUsersCount,
+        0,
+      ),
+    };
+  });
+
+const addOrUpdateAgencyUsers = async ({
+  agenciesIF,
+  importedAgencyAndUserRows,
+  agencyRepository,
+  userRepository,
+  deps,
+}: {
+  agenciesIF: AgencyWithUsersRights[];
+  importedAgencyAndUserRows: ImportedAgencyAndUserRow[];
+  agencyRepository: AgencyRepository;
+  userRepository: UserRepository;
+  deps: { uuidGenerator: UuidGenerator; timeGateway: TimeGateway };
+}) => {
+  const siretsInIF = agenciesIF.map((agency) => agency.agencySiret);
+  const rowsWithSiretAlreadyInIF = importedAgencyAndUserRows.filter((row) =>
+    siretsInIF.includes(row.SIRET),
+  );
+
+  const results = (
+    await Promise.all(
+      rowsWithSiretAlreadyInIF.map(async (row) => {
+        const agencyIF = agenciesIF.find(
+          (agencyIF) => agencyIF.agencySiret === row.SIRET,
+        );
+        if (!agencyIF)
+          throw new Error(
+            `Should not happen: Agency ${row.SIRET} not found in IF`,
+          );
+
+        const user = await userRepository.findByEmail(
+          row["E-mail authentification"],
+        );
+        const userWithRoles = user ? agencyIF.usersRights[user.id] : undefined;
+        const newUserUUid = deps.uuidGenerator.new();
+
+        if (!user) {
+          await userRepository.save({
+            id: newUserUUid,
+            email: row["E-mail authentification"],
+            firstName: "",
+            lastName: "",
+            createdAt: deps.timeGateway.now().toISOString(),
+            proConnect: null,
+            isBackofficeAdmin: false,
+          });
+        }
+
+        await agencyRepository.update({
+          id: agencyIF.id,
+          usersRights: {
+            ...agencyIF.usersRights,
+            [user ? user.id : newUserUUid]: {
+              roles: uniq([
+                ...(userWithRoles ? userWithRoles.roles : []),
+                "agency-admin",
+                "validator",
+              ]),
+              isNotifiedByEmail: userWithRoles?.isNotifiedByEmail ?? true,
+            },
+          },
+        });
+
+        return {
+          createdUsers: user ? 0 : 1,
+          updatedUser: user ? [row["E-mail authentification"]] : [],
+        };
+      }),
+    )
+  ).reduce(
+    (acc, curr) => ({
+      createdUsersCount: acc.createdUsersCount + curr.createdUsers,
+      updatedUsers: [...acc.updatedUsers, ...curr.updatedUser],
+    }),
+    { createdUsersCount: 0, updatedUsers: [] as string[] },
+  );
+
+  return {
+    createdUsersCount: results.createdUsersCount,
+    updatedUsersCount: uniq(results.updatedUsers).length,
+  };
+};

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
@@ -4,8 +4,8 @@ import {
   errors,
   type GeoPositionDto,
   geoPositionSchema,
-  type Phone,
-  phoneSchema,
+  type PhoneNumber,
+  phoneNumberSchema,
 } from "shared";
 import { z } from "zod";
 import { getUserByEmailAndCreateIfMissing } from "../../connected-users/helpers/connectedUser.helper";
@@ -26,7 +26,7 @@ export type ImportedAgencyAndUserRow = {
   Ville: string;
   "Code postal": string;
   Coordonées: GeoPositionDto;
-  Téléphone: Phone;
+  Téléphone: PhoneNumber;
 };
 
 export const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> =
@@ -50,7 +50,7 @@ export const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> 
       return val;
     }, geoPositionSchema) as z.ZodType<GeoPositionDto>,
     "Code postal": z.string(),
-    Téléphone: phoneSchema,
+    Téléphone: phoneNumberSchema,
   });
 
 export type AddAgenciesAndUsers = ReturnType<typeof makeAddAgenciesAndUsers>;

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
@@ -1,6 +1,14 @@
-import { splitEvery, uniq } from "ramda";
-import { type AgencyWithUsersRights, type Phone, phoneSchema } from "shared";
+import { splitEvery, uniq, values } from "ramda";
+import {
+  type AgencyWithUsersRights,
+  errors,
+  type GeoPositionDto,
+  geoPositionSchema,
+  type Phone,
+  phoneSchema,
+} from "shared";
 import { z } from "zod";
+import { getUserByEmailAndCreateIfMissing } from "../../connected-users/helpers/connectedUser.helper";
 import type { UserRepository } from "../../core/authentication/connected-user/port/UserRepository";
 import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
@@ -16,6 +24,8 @@ export type ImportedAgencyAndUserRow = {
   "Adresse ligne 1": string;
   "Adresse ligne 2": string;
   Ville: string;
+  "Code postal": string;
+  Coordonées: GeoPositionDto;
   Téléphone: Phone;
 };
 
@@ -29,6 +39,17 @@ export const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> 
     "Adresse ligne 1": z.string(),
     "Adresse ligne 2": z.string(),
     Ville: z.string(),
+    Coordonées: z.preprocess((val) => {
+      if (typeof val === "string") {
+        const [lat, lon] = val.replace("(", "").replace(")", "").split(", ");
+        return {
+          lat: Number.parseFloat(lat),
+          lon: Number.parseFloat(lon),
+        } as GeoPositionDto;
+      }
+      return val;
+    }, geoPositionSchema) as z.ZodType<GeoPositionDto>,
+    "Code postal": z.string(),
     Téléphone: phoneSchema,
   });
 
@@ -51,41 +72,67 @@ export const makeAddAgenciesAndUsers = useCaseBuilder("AddAgenciesAndUsers")
     const chunks = splitEvery(chunkSize, inputParams);
     const results = await Promise.all(
       chunks.map(async (importedAgencies) => {
+        const formattedImportedAgencies =
+          formatImportedAgencyAndUserRow(importedAgencies);
         const existingAgencies = await uow.agencyRepository.getAgencies({
           filters: {
-            sirets: importedAgencies.map(
+            sirets: formattedImportedAgencies.map(
               (importedAgency) => importedAgency.SIRET,
             ),
           },
         });
+        const siretsInIF = existingAgencies.map((agency) => agency.agencySiret);
+        const rowsNotInIF = formattedImportedAgencies.filter(
+          (importedAgency) => !siretsInIF.includes(importedAgency.SIRET),
+        );
+        const { rowsWithDuplicates, uniqRows } =
+          findDuplicatesInImportedRows(rowsNotInIF);
 
         const { createdUsersCount, updatedUsersCount } =
-          await addOrUpdateAgencyUsers({
-            agenciesIF: existingAgencies,
-            importedAgencyAndUserRows: importedAgencies,
-            agencyRepository: uow.agencyRepository,
+          await createOrUpdateUsers({
+            emails: formattedImportedAgencies.map(
+              (importedAgency) => importedAgency["E-mail authentification"],
+            ),
             userRepository: uow.userRepository,
-            deps,
+            timeGateway: deps.timeGateway,
+            uuidGenerator: deps.uuidGenerator,
           });
 
+        await addOrUpdateAgencyUsers({
+          agenciesIF: existingAgencies,
+          importedAgencyAndUserRows: formattedImportedAgencies,
+          agencyRepository: uow.agencyRepository,
+          userRepository: uow.userRepository,
+        });
+
+        await createNewAgencies({
+          importedAgencyAndUserRows: rowsWithDuplicates,
+          agencyRepository: uow.agencyRepository,
+          userRepository: uow.userRepository,
+          deps,
+        });
+
         return {
-          createdUsersCount,
-          updatedUsersCount,
+          createdAgenciesCount: rowsWithDuplicates.length + uniqRows.length,
+          createdUsersCount: createdUsersCount,
+          updatedUsersCount: updatedUsersCount,
         };
       }),
     );
 
-    return {
-      createdAgenciesCount: 0,
-      createdUsersCount: results.reduce(
-        (acc, curr) => acc + curr.createdUsersCount,
-        0,
-      ),
-      updatedUsersCount: results.reduce(
-        (acc, curr) => acc + curr.updatedUsersCount,
-        0,
-      ),
-    };
+    return results.reduce(
+      (acc, curr) => ({
+        createdAgenciesCount:
+          acc.createdAgenciesCount + curr.createdAgenciesCount,
+        createdUsersCount: acc.createdUsersCount + curr.createdUsersCount,
+        updatedUsersCount: acc.updatedUsersCount + curr.updatedUsersCount,
+      }),
+      {
+        createdAgenciesCount: 0,
+        createdUsersCount: 0,
+        updatedUsersCount: 0,
+      },
+    );
   });
 
 const addOrUpdateAgencyUsers = async ({
@@ -93,53 +140,47 @@ const addOrUpdateAgencyUsers = async ({
   importedAgencyAndUserRows,
   agencyRepository,
   userRepository,
-  deps,
 }: {
   agenciesIF: AgencyWithUsersRights[];
   importedAgencyAndUserRows: ImportedAgencyAndUserRow[];
   agencyRepository: AgencyRepository;
   userRepository: UserRepository;
-  deps: { uuidGenerator: UuidGenerator; timeGateway: TimeGateway };
-}) => {
+}): Promise<void> => {
   const siretsInIF = agenciesIF.map((agency) => agency.agencySiret);
   const rowsWithSiretAlreadyInIF = importedAgencyAndUserRows.filter((row) =>
     siretsInIF.includes(row.SIRET),
   );
 
-  const results = (
-    await Promise.all(
-      rowsWithSiretAlreadyInIF.map(async (row) => {
-        const agencyIF = agenciesIF.find(
-          (agencyIF) => agencyIF.agencySiret === row.SIRET,
+  await Promise.all(
+    rowsWithSiretAlreadyInIF.map(async (row) => {
+      const agencyIF = agenciesIF.find(
+        (agencyIF) => agencyIF.agencySiret === row.SIRET,
+      );
+      if (!agencyIF)
+        throw new Error(
+          `Should not happen: Agency ${row.SIRET} not found in IF`,
         );
-        if (!agencyIF)
-          throw new Error(
-            `Should not happen: Agency ${row.SIRET} not found in IF`,
-          );
 
-        const user = await userRepository.findByEmail(
-          row["E-mail authentification"],
-        );
-        const userWithRoles = user ? agencyIF.usersRights[user.id] : undefined;
-        const newUserUUid = deps.uuidGenerator.new();
+      const user = await userRepository.findByEmail(
+        row["E-mail authentification"],
+      );
+      if (!user)
+        throw errors.user.notFoundByEmail({
+          email: row["E-mail authentification"],
+        });
 
-        if (!user) {
-          await userRepository.save({
-            id: newUserUUid,
-            email: row["E-mail authentification"],
-            firstName: "",
-            lastName: "",
-            createdAt: deps.timeGateway.now().toISOString(),
-            proConnect: null,
-            isBackofficeAdmin: false,
-          });
-        }
+      const userWithRoles = agencyIF.usersRights[user.id] ?? undefined;
 
+      if (
+        !userWithRoles ||
+        !userWithRoles.roles.includes("agency-admin") ||
+        !userWithRoles.roles.includes("validator")
+      ) {
         await agencyRepository.update({
           id: agencyIF.id,
           usersRights: {
             ...agencyIF.usersRights,
-            [user ? user.id : newUserUUid]: {
+            [user.id]: {
               roles: uniq([
                 ...(userWithRoles ? userWithRoles.roles : []),
                 "agency-admin",
@@ -149,23 +190,166 @@ const addOrUpdateAgencyUsers = async ({
             },
           },
         });
-
-        return {
-          createdUsers: user ? 0 : 1,
-          updatedUser: user ? [row["E-mail authentification"]] : [],
-        };
-      }),
-    )
-  ).reduce(
-    (acc, curr) => ({
-      createdUsersCount: acc.createdUsersCount + curr.createdUsers,
-      updatedUsers: [...acc.updatedUsers, ...curr.updatedUser],
+      }
     }),
-    { createdUsersCount: 0, updatedUsers: [] as string[] },
+  );
+};
+
+const formatImportedAgencyAndUserRow = (
+  importedAgencyAndUserRow: ImportedAgencyAndUserRow[],
+) => {
+  const removeSpaces = (str: string) => str.replace(/\s/g, "");
+  const capitalizeFirstLetter = (str: string) =>
+    str
+      .toLowerCase()
+      .split(/\s+/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+
+  return importedAgencyAndUserRow.map((row) => ({
+    ...row,
+    "Type structure": row["Type structure"].toUpperCase(),
+    "Nom structure": capitalizeFirstLetter(row["Nom structure"]),
+    "E-mail authentification": row["E-mail authentification"].toLowerCase(),
+    "Adresse ligne 1": row["Adresse ligne 1"].toLowerCase(),
+    "Adresse ligne 2": row["Adresse ligne 2"].toLowerCase(),
+    Ville: capitalizeFirstLetter(row.Ville),
+    Téléphone: removeSpaces(row.Téléphone),
+  }));
+};
+
+const createNewAgencies = async ({
+  importedAgencyAndUserRows,
+  agencyRepository,
+  userRepository,
+  deps,
+}: {
+  importedAgencyAndUserRows: ImportedAgencyAndUserRow[];
+  agencyRepository: AgencyRepository;
+  userRepository: UserRepository;
+  deps: { uuidGenerator: UuidGenerator; timeGateway: TimeGateway };
+}) => {
+  await Promise.all(
+    await importedAgencyAndUserRows.map(async (row) => {
+      const user = await userRepository.findByEmail(
+        row["E-mail authentification"],
+      );
+      if (!user)
+        throw errors.user.notFoundByEmail({
+          email: row["E-mail authentification"],
+        });
+
+      const agencyDepartmentCode = row["Code postal"].slice(0, 2);
+      const agency: AgencyWithUsersRights = {
+        id: deps.uuidGenerator.new(),
+        status: "active",
+        agencySiret: row.SIRET,
+        name: row["Nom structure"],
+        address: {
+          streetNumberAndAddress: row["Adresse ligne 1"],
+          postcode: row["Code postal"],
+          city: row.Ville,
+          departmentCode: agencyDepartmentCode,
+        },
+        position: {
+          lat: row.Coordonées.lat,
+          lon: row.Coordonées.lon,
+        },
+        kind: "structure-IAE",
+        coveredDepartments: [agencyDepartmentCode],
+        logoUrl: null,
+        signature: "L'équipe",
+        refersToAgencyId: null,
+        refersToAgencyName: null,
+        phoneNumber: row.Téléphone,
+        usersRights: {
+          [user.id]: {
+            roles: ["agency-admin", "validator"],
+            isNotifiedByEmail: true,
+          },
+        },
+        codeSafir: null,
+        rejectionJustification: null,
+      };
+
+      await agencyRepository.insert(agency);
+    }),
+  );
+};
+
+// duplicas si même siret + nom structure + e-mail authentification + adresse ligne 1 + code postal + ville + téléphone
+function findDuplicatesInImportedRows(
+  rows: ImportedAgencyAndUserRow[],
+): Record<string, ImportedAgencyAndUserRow[]> {
+  const groupedRows = rows.reduce(
+    (acc, row) => {
+      const key = [
+        row.SIRET,
+        row["Nom structure"],
+        row["E-mail authentification"],
+        row["Adresse ligne 1"],
+        row["Code postal"],
+        row.Ville,
+        row.Téléphone,
+      ].join("||");
+
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(row);
+
+      return acc;
+    },
+    {} as Record<string, ImportedAgencyAndUserRow[]>,
   );
 
+  return values(groupedRows).reduce(
+    (acc, curr) => {
+      if (curr.length > 1) {
+        acc.rowsWithDuplicates.push(curr[0]);
+      } else {
+        acc.uniqRows.push(curr[0]);
+      }
+      return acc;
+    },
+    {
+      rowsWithDuplicates: [] as ImportedAgencyAndUserRow[],
+      uniqRows: [] as ImportedAgencyAndUserRow[],
+    },
+  );
+}
+
+const createOrUpdateUsers = async ({
+  emails,
+  userRepository,
+  timeGateway,
+  uuidGenerator,
+}: {
+  emails: string[];
+  userRepository: UserRepository;
+  timeGateway: TimeGateway;
+  uuidGenerator: UuidGenerator;
+}) => {
+  const uniqEmails = uniq(emails);
+
+  const newUsersCount = (
+    await Promise.all(
+      uniqEmails.map(async (email) => {
+        const newUserUUid = uuidGenerator.new();
+        const user = await getUserByEmailAndCreateIfMissing({
+          userRepository,
+          timeGateway: timeGateway,
+          userIdIfNew: newUserUUid,
+          userEmail: email,
+        });
+
+        return user.id === newUserUUid;
+      }),
+    )
+  ).filter(Boolean).length;
+
   return {
-    createdUsersCount: results.createdUsersCount,
-    updatedUsersCount: uniq(results.updatedUsers).length,
+    createdUsersCount: newUsersCount,
+    updatedUsersCount: uniqEmails.length - newUsersCount,
   };
 };

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
@@ -1,0 +1,139 @@
+import { AgencyDtoBuilder, ConnectedUserBuilder } from "shared";
+import { toAgencyWithRights } from "../../../utils/agency";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
+import {
+  createInMemoryUow,
+  type InMemoryUnitOfWork,
+} from "../../core/unit-of-work/adapters/createInMemoryUow";
+import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
+import {
+  type AddAgenciesAndUsers,
+  type ImportedAgencyAndUserRow,
+  makeAddAgenciesAndUsers,
+} from "./AddAgenciesAndUsers";
+
+describe("AddAgenciesAndUsers", () => {
+  const siret1 = "12345678901111";
+  const siret2 = "12345678902222";
+  const user1Email = "user1@test.com";
+  const user2Email = "user2@test.com";
+  const rows: ImportedAgencyAndUserRow[] = [
+    {
+      ID: "1",
+      SIRET: siret1,
+      "Type structure": "AI",
+      "Nom structure": "Structure avec user existant sur IF",
+      "E-mail authentification": user1Email,
+      "Adresse ligne 1": "Adresse ligne 1",
+      "Adresse ligne 2": "Adresse ligne 2",
+      Ville: "Ville",
+      Téléphone: "+33600000000",
+    },
+    {
+      ID: "2",
+      SIRET: siret2,
+      "Type structure": "EI",
+      "Nom structure": "Structure avec user non existant sur IF",
+      "E-mail authentification": user2Email,
+      "Adresse ligne 1": "Adresse ligne 1",
+      "Adresse ligne 2": "Adresse ligne 2",
+      Ville: "Ville",
+      Téléphone: "+33600000000",
+    },
+  ];
+
+  let uuidGenerator: TestUuidGenerator;
+  let uow: InMemoryUnitOfWork;
+  let timeGateway: CustomTimeGateway;
+  let addAgenciesAndUsers: AddAgenciesAndUsers;
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    uow.agencyRepository.agencies = [];
+    uow.userRepository.users = [];
+    timeGateway = new CustomTimeGateway();
+    uuidGenerator = new TestUuidGenerator();
+    addAgenciesAndUsers = makeAddAgenciesAndUsers({
+      uowPerformer: new InMemoryUowPerformer(uow),
+      deps: {
+        timeGateway,
+        uuidGenerator,
+      },
+    });
+  });
+
+  describe("sirets already in IF", () => {
+    it("should add and update users with role agency-admin and validator", async () => {
+      const user1 = new ConnectedUserBuilder()
+        .withId("10000000-0000-0000-0000-000000000021")
+        .withEmail(user1Email)
+        .buildUser();
+      const agency1 = toAgencyWithRights(
+        new AgencyDtoBuilder()
+          .withId("10000000-0000-0000-0000-000000000011")
+          .withAgencySiret(siret1)
+          .build(),
+        {
+          [user1.id]: { isNotifiedByEmail: false, roles: ["counsellor"] },
+        },
+      );
+      const agency2 = toAgencyWithRights(
+        new AgencyDtoBuilder()
+          .withId("10000000-0000-0000-0000-0000000000012")
+          .withAgencySiret(siret2)
+          .build(),
+        {
+          [user1.id]: { isNotifiedByEmail: true, roles: ["counsellor"] },
+        },
+      );
+
+      await uow.userRepository.save(user1);
+      await uow.agencyRepository.insert(agency1);
+      await uow.agencyRepository.insert(agency2);
+
+      const newUserId = "10000000-0000-0000-0000-000000000022";
+      uuidGenerator.setNextUuids([newUserId, newUserId]);
+      const result = await addAgenciesAndUsers.execute(rows);
+
+      expect(result).toEqual({
+        createdAgenciesCount: 0,
+        createdUsersCount: 1,
+        updatedUsersCount: 1,
+      });
+      expect(uow.agencyRepository.agencies).toEqual([
+        {
+          ...agency1,
+          usersRights: {
+            [user1.id]: {
+              isNotifiedByEmail: false,
+              roles: ["counsellor", "agency-admin", "validator"],
+            },
+          },
+        },
+        {
+          ...agency2,
+          usersRights: {
+            ...agency2.usersRights,
+            [newUserId]: {
+              isNotifiedByEmail: true,
+              roles: ["agency-admin", "validator"],
+            },
+          },
+        },
+      ]);
+      expect(uow.userRepository.users).toEqual([
+        user1,
+        new ConnectedUserBuilder()
+          .withId(newUserId)
+          .withFirstName("")
+          .withLastName("")
+          .withEmail(user2Email)
+          .withCreatedAt(timeGateway.now())
+          .withProConnectInfos(null)
+          .withEstablishments(undefined)
+          .buildUser(),
+      ]);
+    });
+  });
+});

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
@@ -119,6 +119,7 @@ describe("AddAgenciesAndUsers", () => {
         createdAgenciesCount: 0,
         createdUsersCount: 1,
         usersAlreadyInIFCount: 1,
+        usecaseErrors: {},
       });
       expect(uow.agencyRepository.agencies).toEqual([
         {
@@ -198,6 +199,7 @@ describe("AddAgenciesAndUsers", () => {
         createdAgenciesCount: 1,
         createdUsersCount: 1,
         usersAlreadyInIFCount: 0,
+        usecaseErrors: {},
       });
       expect(uow.userRepository.users).toEqual([
         {
@@ -298,6 +300,7 @@ describe("AddAgenciesAndUsers", () => {
         createdAgenciesCount: 2,
         createdUsersCount: 1,
         usersAlreadyInIFCount: 0,
+        usecaseErrors: {},
       });
       expectArraysToMatch(uow.agencyRepository.agencies, [
         {

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
@@ -4,6 +4,7 @@ import {
   expectArraysToMatch,
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
+import { InMemoryAddressGateway } from "../../core/address/adapters/InMemoryAddressGateway";
 import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
@@ -39,6 +40,7 @@ describe("AddAgenciesAndUsers", () => {
       deps: {
         timeGateway,
         uuidGenerator,
+        addressGateway: new InMemoryAddressGateway(),
       },
     });
   });

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
@@ -113,9 +113,10 @@ describe("AddAgenciesAndUsers", () => {
       const result = await addAgenciesAndUsers.execute(rows);
 
       expect(result).toEqual({
+        siretAlreadyInIFCount: 2,
         createdAgenciesCount: 0,
         createdUsersCount: 1,
-        updatedUsersCount: 1,
+        usersAlreadyInIFCount: 1,
       });
       expect(uow.agencyRepository.agencies).toEqual([
         {
@@ -191,9 +192,10 @@ describe("AddAgenciesAndUsers", () => {
       const result = await addAgenciesAndUsers.execute(rowsWithDuplicates);
 
       expect(result).toEqual({
+        siretAlreadyInIFCount: 0,
         createdAgenciesCount: 1,
         createdUsersCount: 1,
-        updatedUsersCount: 0,
+        usersAlreadyInIFCount: 0,
       });
       expect(uow.userRepository.users).toEqual([
         {
@@ -290,9 +292,10 @@ describe("AddAgenciesAndUsers", () => {
         },
       );
       expect(result).toEqual({
+        siretAlreadyInIFCount: 0,
         createdAgenciesCount: 2,
         createdUsersCount: 1,
-        updatedUsersCount: 0,
+        usersAlreadyInIFCount: 0,
       });
       expectArraysToMatch(uow.agencyRepository.agencies, [
         {

--- a/back/src/domains/agency/use-cases/ListAgenciesByFilter.ts
+++ b/back/src/domains/agency/use-cases/ListAgenciesByFilter.ts
@@ -29,7 +29,7 @@ export const makeListAgencyOptionsByFilter = useCaseBuilder(
         nameIncludes,
         departmentCode,
         status: status ? status : activeAgencyStatuses,
-        siret: siret ? removeSpaces(siret) : undefined,
+        sirets: siret ? [removeSpaces(siret)] : undefined,
         ...extraFilters,
       },
     });

--- a/back/src/domains/connected-users/use-cases/CreateUserForAgency.ts
+++ b/back/src/domains/connected-users/use-cases/CreateUserForAgency.ts
@@ -40,7 +40,7 @@ export const makeCreateUserForAgency = useCaseBuilder("CreateUserForAgency")
     const user = await getUserByEmailAndCreateIfMissing({
       userRepository: uow.userRepository,
       timeGateway: deps.timeGateway,
-      userIdIfNew: inputParams.userId,
+      userIdIfNew: inputParams.userId, //Cet id provient du front. Comment le front le génère? Pourquoi on le gènere pas dans le back vu qu'on check l'existence par email?
       userEmail: inputParams.email,
     });
 

--- a/back/src/scripts/triggerAddAgenciesAndUsers.ts
+++ b/back/src/scripts/triggerAddAgenciesAndUsers.ts
@@ -1,14 +1,19 @@
 import { readFile } from "node:fs/promises";
 import Papa from "papaparse";
+import { keys } from "ramda";
+import { z } from "zod";
 import { AppConfig } from "../config/bootstrap/appConfig";
+import { createGetPgPoolFn } from "../config/bootstrap/createGateways";
+import {
+  type ImportedAgencyAndUserRow,
+  importedAgencyAndUserRowSchema,
+  makeAddAgenciesAndUsers,
+} from "../domains/agency/use-cases/AddAgenciesAndUsers";
+import { RealTimeGateway } from "../domains/core/time-gateway/adapters/RealTimeGateway";
+import { createUowPerformer } from "../domains/core/unit-of-work/adapters/createUowPerformer";
+import { UuidV4Generator } from "../domains/core/uuid-generator/adapters/UuidGeneratorImplementations";
 import { createLogger } from "../utils/logger";
 import { handleCRONScript } from "./handleCRONScript";
-import { z } from "zod";
-import { keys } from "ramda";
-import { Phone, phoneSchema } from "shared";
-import { makeAddAgenciesAndUsers } from "../domains/agency/use-cases/AddAgenciesAndUsers";
-import { createUowPerformer } from "../domains/core/unit-of-work/adapters/createUowPerformer";
-import { createGetPgPoolFn } from "../config/bootstrap/createGateways";
 
 // Upload a file to the one-off container (target is /tmp/uploads)
 // scalingo --app my-app run --file ./dump.sql <command>
@@ -18,30 +23,6 @@ import { createGetPgPoolFn } from "../config/bootstrap/createGateways";
 
 const logger = createLogger(__filename);
 const config = AppConfig.createFromEnv();
-
-type ImportedAgencyAndUserRow = {
-  "ID": string;
-  "SIRET": string;
-  "Type structure": string;
-  "Nom structure": string;
-  "E-mail authentification": string;
-  "Adresse ligne 1": string;
-  "Adresse ligne 2": string;
-  "Ville": string;
-  "Téléphone": Phone;
-};
-
-const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> = z.object({
-  "ID": z.string(),
-  "SIRET": z.string(),
-  "Type structure": z.string(),
-  "Nom structure": z.string(),
-  "E-mail authentification": z.string(),
-  "Adresse ligne 1": z.string(),
-  "Adresse ligne 2": z.string(),
-  "Ville": z.string(),
-  "Téléphone": phoneSchema.or(z.string().length(0)),
-});
 
 const triggerAddAgenciesAndUsers = async () => {
   logger.info({ message: "Starting to add agencies and users" });
@@ -66,32 +47,44 @@ const triggerAddAgenciesAndUsers = async () => {
 
   const parsedErrors: Record<number, string> = {};
   const skipLines = 2; //1 for index that starts at 0 + 1 for header
-  const validatedRows: ImportedAgencyAndUserRow[] = result.data.map((row, index) => {
-    try {
-      const importedRow = importedAgencyAndUserRowSchema.parse(row);
-      return importedRow;
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        parsedErrors[index+skipLines] = JSON.stringify(error);
+  const validatedRows: ImportedAgencyAndUserRow[] = result.data
+    .map((row, index) => {
+      try {
+        const importedRow = importedAgencyAndUserRowSchema.parse(row);
+        return importedRow;
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          parsedErrors[index + skipLines] = JSON.stringify(error);
+        }
       }
-    }
-    return null;
-  }).filter((row) => row !== null);
+      return null;
+    })
+    .filter((row) => row !== null);
 
   logger.info({ message: `Ready to import ${validatedRows.length} lines` });
 
-
-  const { alreadyExistingAgencies, createdAgencies, alreadyExistingUsers, createdUsers } = await makeAddAgenciesAndUsers({
-    uowPerformer: createUowPerformer(config, createGetPgPoolFn(config)).uowPerformer,
-    deps: {},
-  }).execute(validatedRows);
+  const { createdAgenciesCount, createdUsersCount, updatedUsersCount } =
+    await makeAddAgenciesAndUsers({
+      uowPerformer: createUowPerformer(config, createGetPgPoolFn(config))
+        .uowPerformer,
+      deps: {
+        timeGateway: new RealTimeGateway(),
+        uuidGenerator: new UuidV4Generator(),
+      },
+    }).execute(validatedRows);
 
   return {
-    alreadyExistingAgencies,
-    createdAgencies,
-    alreadyExistingUsers,
-    createdUsers,
-    errors: keys(parsedErrors).length !== 0 ? `${keys(parsedErrors).length} error(s) during CSV parsing: ${keys(parsedErrors).map((key) => `line ${key}: ${parsedErrors[key]}`).join("\n")}` : 0,
+    createdAgenciesCount,
+    createdUsersCount,
+    updatedUsersCount,
+    errors:
+      keys(parsedErrors).length !== 0
+        ? `${keys(parsedErrors).length} error(s) during CSV parsing: ${keys(
+            parsedErrors,
+          )
+            .map((key) => `line ${key}: ${parsedErrors[key]}`)
+            .join("\n")}`
+        : 0,
   };
 };
 
@@ -99,18 +92,12 @@ handleCRONScript(
   "addAgenciesAndUsers",
   config,
   triggerAddAgenciesAndUsers,
-  ({
-    alreadyExistingAgencies,
-    createdAgencies,
-    alreadyExistingUsers,
-    createdUsers,
-    errors,
-  }) =>
+  ({ createdAgenciesCount, createdUsersCount, updatedUsersCount, errors }) =>
     [
-      `Already existing agencies: ${alreadyExistingAgencies}`,
-      `Created agencies: ${createdAgencies}`,
-      `Already existing users: ${alreadyExistingUsers}`,
-      `Created users: ${createdUsers}`,
+      //`Already existing agencies: ${alreadyExistingAgencies}`,
+      `Created agencies: ${createdAgenciesCount}`,
+      `Already existing users: ${updatedUsersCount}`,
+      `Created users: ${createdUsersCount}`,
       `Errors: ${errors}`,
     ].join("\n"),
   logger,

--- a/back/src/scripts/triggerAddAgenciesAndUsers.ts
+++ b/back/src/scripts/triggerAddAgenciesAndUsers.ts
@@ -1,0 +1,117 @@
+import { readFile } from "node:fs/promises";
+import Papa from "papaparse";
+import { AppConfig } from "../config/bootstrap/appConfig";
+import { createLogger } from "../utils/logger";
+import { handleCRONScript } from "./handleCRONScript";
+import { z } from "zod";
+import { keys } from "ramda";
+import { Phone, phoneSchema } from "shared";
+import { makeAddAgenciesAndUsers } from "../domains/agency/use-cases/AddAgenciesAndUsers";
+import { createUowPerformer } from "../domains/core/unit-of-work/adapters/createUowPerformer";
+import { createGetPgPoolFn } from "../config/bootstrap/createGateways";
+
+// Upload a file to the one-off container (target is /tmp/uploads)
+// scalingo --app my-app run --file ./dump.sql <command>
+
+// Then run this file with:
+// pnpm back trigger-add-agencies-and-users /tmp/uploads/export.csv
+
+const logger = createLogger(__filename);
+const config = AppConfig.createFromEnv();
+
+type ImportedAgencyAndUserRow = {
+  "ID": string;
+  "SIRET": string;
+  "Type structure": string;
+  "Nom structure": string;
+  "E-mail authentification": string;
+  "Adresse ligne 1": string;
+  "Adresse ligne 2": string;
+  "Ville": string;
+  "Téléphone": Phone;
+};
+
+const importedAgencyAndUserRowSchema: z.Schema<ImportedAgencyAndUserRow> = z.object({
+  "ID": z.string(),
+  "SIRET": z.string(),
+  "Type structure": z.string(),
+  "Nom structure": z.string(),
+  "E-mail authentification": z.string(),
+  "Adresse ligne 1": z.string(),
+  "Adresse ligne 2": z.string(),
+  "Ville": z.string(),
+  "Téléphone": phoneSchema.or(z.string().length(0)),
+});
+
+const triggerAddAgenciesAndUsers = async () => {
+  logger.info({ message: "Starting to add agencies and users" });
+
+  const path = process.argv.slice(2)[0];
+  if (!path.endsWith(".csv")) {
+    logger.error({ message: "Le fichier n'est pas un CSV" });
+    throw new Error("Le fichier n'est pas un CSV");
+  }
+
+  const fileContent = await readFile(path, "utf-8");
+  const result = Papa.parse(fileContent, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  if (result.errors.length > 0) {
+    throw new Error(
+      `Erreur(s) lors du parsing CSV: ${JSON.stringify(result.errors)}`,
+    );
+  }
+
+  const parsedErrors: Record<number, string> = {};
+  const skipLines = 2; //1 for index that starts at 0 + 1 for header
+  const validatedRows: ImportedAgencyAndUserRow[] = result.data.map((row, index) => {
+    try {
+      const importedRow = importedAgencyAndUserRowSchema.parse(row);
+      return importedRow;
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        parsedErrors[index+skipLines] = JSON.stringify(error);
+      }
+    }
+    return null;
+  }).filter((row) => row !== null);
+
+  logger.info({ message: `Ready to import ${validatedRows.length} lines` });
+
+
+  const { alreadyExistingAgencies, createdAgencies, alreadyExistingUsers, createdUsers } = await makeAddAgenciesAndUsers({
+    uowPerformer: createUowPerformer(config, createGetPgPoolFn(config)).uowPerformer,
+    deps: {},
+  }).execute(validatedRows);
+
+  return {
+    alreadyExistingAgencies,
+    createdAgencies,
+    alreadyExistingUsers,
+    createdUsers,
+    errors: keys(parsedErrors).length !== 0 ? `${keys(parsedErrors).length} error(s) during CSV parsing: ${keys(parsedErrors).map((key) => `line ${key}: ${parsedErrors[key]}`).join("\n")}` : 0,
+  };
+};
+
+handleCRONScript(
+  "addAgenciesAndUsers",
+  config,
+  triggerAddAgenciesAndUsers,
+  ({
+    alreadyExistingAgencies,
+    createdAgencies,
+    alreadyExistingUsers,
+    createdUsers,
+    errors,
+  }) =>
+    [
+      `Already existing agencies: ${alreadyExistingAgencies}`,
+      `Created agencies: ${createdAgencies}`,
+      `Already existing users: ${alreadyExistingUsers}`,
+      `Created users: ${createdUsers}`,
+      `Errors: ${errors}`,
+    ].join("\n"),
+  logger,
+);

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -595,6 +595,8 @@ export const errors = {
       new BadRequestError(
         `Vous devez taper au moins ${minLength} caractères pour faire une recherche.`,
       ),
+    notFound: ({ address }: { address: string }) =>
+      new NotFoundError(`Aucune adresse trouvée pour l'adresse ${address}.`),
   },
   agencies: {
     notFound: ({


### PR DESCRIPTION
## 🌈 Description

Insertions des agences à partir d'un fichier CSV:

- pour les agences dont le siret est présent sur IF: créer ou mettre à jour les utilisateurs avec les rôles "agency-admin" et "validator"
- pour les agences avec un duplica dans ce même fichier (même siret + nom structure + e-mail authentification + adresse ligne 1 + code postal + ville + téléphone): créer 1 seule agence chez IF + créer/mettre à jour un utilisateur
- pour les agences restantes:
  - dont le siret est déjà dans ce fichier, suffixer le nom avec le type de stucture
  - sinon créer 1 seule agence chez IF + créer/mettre à jour un utilisateur