### PR TITLE
#3049 - Import siae : prise en compte des retours

### DIFF
--- a/back/src/scripts/triggerAddAgenciesAndUsers.ts
+++ b/back/src/scripts/triggerAddAgenciesAndUsers.ts
@@ -22,7 +22,10 @@ import { createLogger } from "../utils/logger";
 import { handleCRONScript } from "./handleCRONScript";
 
 // Upload a file to the one-off container (target is /tmp/uploads)
-// scalingo --app my-app run --file ./dump.sql <command>
+// scalingo --app my-app --region my-region run --file "/path/to/file.csv" bash
+
+// confirm that file is on the container
+// ls /tmp/uploads
 
 // Then run this file with:
 // pnpm back trigger-add-agencies-and-users /tmp/uploads/export.csv


### PR DESCRIPTION
## 🐛 Retours suite aux tests manuels avec Gael

1. Les données étaient formatés pour faciliter la comparaison et détection de doublon au sein même du fichier. Or au moment de la sauvegarde en DB, on ne veut pas sauvegarder la donnée formatée mais la donnée brute du CSV
2. On avait une erreur de duplicate key userId et agencyId sur la table de jointure `users_agencies`. Cela est du qu'en bouclant sur le tableau de lignes du CSV, on peut rencontrer plusieurs la même agence et donc modifier ses utilisateurs plusieurs fois de suite sans que ça reste consistent avec la précédente modification.