### PR TITLE
conserver systematiquement l'identifiant FT connect (isJobSeeker n'est pas important), et le transmettre à FT lors de la diffusion

### DIFF
--- a/back/src/domains/core/authentication/ft-connect/dto/FtConnect.dto.ts
+++ b/back/src/domains/core/authentication/ft-connect/dto/FtConnect.dto.ts
@@ -1,10 +1,9 @@
-import {
-  type Beneficiary,
-  type FederatedIdentityProvider,
-  type FtConnectToken,
-  type FtExternalId,
-  type InternshipKind,
-  notJobSeeker,
+import type {
+  Beneficiary,
+  FederatedIdentityProvider,
+  FtConnectToken,
+  FtExternalId,
+  InternshipKind,
 } from "shared";
 import type { EntityFromDto } from "../../../../../utils/EntityFromDto";
 import type { FtConnectImmersionAdvisorDto } from "./FtConnectAdvisor.dto";
@@ -42,8 +41,6 @@ export const toPartialConventionDtoWithFtIdentity = (
   email: ftConnectUserInfo.email || "",
   firstName: ftConnectUserInfo.firstName,
   lastName: ftConnectUserInfo.lastName,
-  fedId: ftConnectUserInfo.isJobseeker
-    ? ftConnectUserInfo.peExternalId
-    : notJobSeeker,
+  fedId: ftConnectUserInfo.peExternalId,
   fedIdProvider: "peConnect",
 });

--- a/back/src/domains/core/authentication/ft-connect/use-cases/LinkFranceTravailAdvisorAndRedirectToConvention.ts
+++ b/back/src/domains/core/authentication/ft-connect/use-cases/LinkFranceTravailAdvisorAndRedirectToConvention.ts
@@ -75,10 +75,9 @@ export class LinkFranceTravailAdvisorAndRedirectToConvention extends Transaction
         : undefined,
     };
 
-    if (peUserAndAdvisor.user.isJobseeker)
-      await uow.conventionFranceTravailAdvisorRepository.openSlotForNextConvention(
-        peUserAndAdvisor,
-      );
+    await uow.conventionFranceTravailAdvisorRepository.openSlotForNextConvention(
+      peUserAndAdvisor,
+    );
 
     return this.#makeRedirectUrl(toPartialConventionDtoWithFtIdentity(user));
   }

--- a/back/src/domains/core/authentication/ft-connect/use-cases/LinkFranceTravailAdvisorAndRedirectToConvention.unit.test.ts
+++ b/back/src/domains/core/authentication/ft-connect/use-cases/LinkFranceTravailAdvisorAndRedirectToConvention.unit.test.ts
@@ -1,4 +1,4 @@
-import { authFailed, expectToEqual, notJobSeeker } from "shared";
+import { authFailed, expectToEqual } from "shared";
 import {
   createInMemoryUow,
   type InMemoryUnitOfWork,
@@ -133,7 +133,7 @@ describe("LinkFranceTravailAdvisorAndRedirectToConvention", () => {
       );
     });
 
-    it("On FtConnected and is not jobseeker should not open slot and provide convention url with notJobSeeker peConnect mode", async () => {
+    it("On FtConnected and is not jobseeker should still open slot", async () => {
       ftConnectGateway.setAccessToken(accessToken);
       ftConnectGateway.setUser(ftNotJobseekerUser);
 
@@ -141,12 +141,20 @@ describe("LinkFranceTravailAdvisorAndRedirectToConvention", () => {
         await linkFtAdvisorAndRedirectToConvention.execute(authorizationCode);
 
       expect(urlWithQueryParams).toBe(
-        `${baseurl}/demande-immersion?email=john.doe@gmail.com&firstName=John&lastName=Doe&fedId=${notJobSeeker}&fedIdProvider=peConnect`,
+        `${baseurl}/demande-immersion?email=john.doe@gmail.com&firstName=John&lastName=Doe&fedId=${ftNotJobseekerUser.peExternalId}&fedIdProvider=peConnect`,
       );
       expectToEqual(
         uow.conventionFranceTravailAdvisorRepository
           .conventionFranceTravailUsersAdvisors,
-        [],
+        [
+          conventionFranceTravailUserAdvisorFromDto(
+            {
+              user: ftNotJobseekerUser,
+              advisor: undefined,
+            },
+            CONVENTION_ID_DEFAULT_UUID,
+          ),
+        ],
       );
     });
   });

--- a/back/src/utils/emailHash.ts
+++ b/back/src/utils/emailHash.ts
@@ -86,7 +86,7 @@ export const isHashMatchPeAdvisorEmail = ({
   beneficiary: Beneficiary<"immersion" | "mini-stage-cci">;
   emailHash: EmailHash;
 }) => {
-  const peAdvisorEmail = beneficiary.federatedIdentity?.payload?.advisor.email;
+  const peAdvisorEmail = beneficiary.federatedIdentity?.payload?.advisor?.email;
 
   return peAdvisorEmail
     ? isSomeEmailMatchingEmailHash([peAdvisorEmail], emailHash)

--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -46,7 +46,6 @@ import {
   isFtConnectIdentity,
   keys,
   makeListAgencyOptionsKindFilter,
-  notJobSeeker,
 } from "shared";
 import { AddressAutocompleteWithCountrySelect } from "src/app/components/forms/autocomplete/AddressAutocompleteWithCountrySelect";
 import {
@@ -165,7 +164,7 @@ export const ConventionForm = ({
         federatedIdentity,
       ),
     },
-    ...(federatedIdentity?.payload && mode === "create-from-scratch"
+    ...(federatedIdentity?.payload?.advisor && mode === "create-from-scratch"
       ? {
           agencyReferentFirstName: federatedIdentity.payload.advisor.firstName,
           agencyReferentLastName: federatedIdentity.payload.advisor.lastName,
@@ -725,9 +724,7 @@ const makeInitialBenefiaryForm = (
 
   return {
     ...beneficiaryOtherProperties,
-    ...(federatedIdentityValue?.token !== notJobSeeker && {
-      federatedIdentity: federatedIdentityValue,
-    }),
+    federatedIdentity: federatedIdentityValue,
   };
 };
 

--- a/front/src/app/pages/convention/ConventionDocumentPage.tsx
+++ b/front/src/app/pages/convention/ConventionDocumentPage.tsx
@@ -362,10 +362,10 @@ export const ConventionDocumentPage = ({
                   {getFormattedFirstnameAndLastname({
                     firstname:
                       convention.signatories.beneficiary.federatedIdentity
-                        .payload.advisor.firstName,
+                        .payload.advisor?.firstName,
                     lastname:
                       convention.signatories.beneficiary.federatedIdentity
-                        .payload.advisor.lastName,
+                        .payload.advisor?.lastName,
                   })}
                 </strong>
               </li>

--- a/shared/src/federatedIdentities/federatedIdentity.dto.ts
+++ b/shared/src/federatedIdentities/federatedIdentity.dto.ts
@@ -34,7 +34,6 @@ type GenericFederatedIdentity<
     };
 
 export const authFailed = "AuthFailed";
-export const notJobSeeker = "NotJobSeeker";
 
 export type FtExternalId = Flavor<string, "FtExternalId">;
 
@@ -47,10 +46,7 @@ type FtConnectAdvisorForBeneficiary = {
   };
 };
 
-export type FtConnectToken =
-  | FtExternalId
-  | typeof authFailed
-  | typeof notJobSeeker;
+export type FtConnectToken = FtExternalId | typeof authFailed;
 
 export type FtConnectIdentity = GenericFederatedIdentity<
   "peConnect",

--- a/shared/src/federatedIdentities/federatedIdentity.dto.ts
+++ b/shared/src/federatedIdentities/federatedIdentity.dto.ts
@@ -38,7 +38,7 @@ export const authFailed = "AuthFailed";
 export type FtExternalId = Flavor<string, "FtExternalId">;
 
 type FtConnectAdvisorForBeneficiary = {
-  advisor: {
+  advisor?: {
     email: string;
     firstName: string;
     lastName: string;

--- a/shared/src/federatedIdentities/federatedIdentity.schema.ts
+++ b/shared/src/federatedIdentities/federatedIdentity.schema.ts
@@ -6,12 +6,14 @@ export const peConnectIdentitySchema: z.Schema<FtConnectIdentity> = z.object({
   token: z.string(),
   payload: z
     .object({
-      advisor: z.object({
-        email: z.string(),
-        firstName: z.string(),
-        lastName: z.string(),
-        type: z.enum(["PLACEMENT", "CAPEMPLOI", "INDEMNISATION"]),
-      }),
+      advisor: z
+        .object({
+          email: z.string(),
+          firstName: z.string(),
+          lastName: z.string(),
+          type: z.enum(["PLACEMENT", "CAPEMPLOI", "INDEMNISATION"]),
+        })
+        .optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
- **remove condition to open slot when FT connected**
- **make advisor optional when Ft connected**
