### PR TITLE
#3717 - Ne plus envoyer la première notification de bilan à l’agence mais la notifier si le tuteur n’a pas encore compléter le bilan à J+3 et J+10

### DIFF
--- a/back/src/domains/establishment/use-cases/AssessmentReminder.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.ts
@@ -316,6 +316,7 @@ const sendAgencyAssessmentReminder = async ({
             businessName: convention.businessName,
             agencyLogoUrl: agency.logoUrl ?? undefined,
             assessmentCreationLink,
+            tutorEmail: convention.establishmentTutor.email,
           },
         },
         followedIds: {

--- a/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
@@ -227,6 +227,7 @@ describe("AssessmentReminder", () => {
               ),
               businessName: convention.businessName,
               agencyLogoUrl: agency.logoUrl ?? undefined,
+              tutorEmail: convention.establishmentTutor.email,
             },
             recipients: [validator.email],
             sender: {
@@ -302,6 +303,7 @@ describe("AssessmentReminder", () => {
               ),
               businessName: convention.businessName,
               agencyLogoUrl: agency.logoUrl ?? undefined,
+              tutorEmail: convention.establishmentTutor.email,
             },
             recipients: [validator.email],
             sender: {
@@ -393,6 +395,7 @@ describe("AssessmentReminder", () => {
               ),
               businessName: convention.businessName,
               agencyLogoUrl: agency.logoUrl ?? undefined,
+              tutorEmail: convention.establishmentTutor.email,
             },
             recipients: [advisorEmail],
             sender: {

--- a/back/src/scripts/triggerAssessmentReminder.ts
+++ b/back/src/scripts/triggerAssessmentReminder.ts
@@ -34,7 +34,7 @@ const triggerAssessmentReminder = async () => {
     notificationRepository: new PgNotificationRepository(kyselyDb),
   };
 
-  const { numberOfReminders: numberOfFirstReminders } =
+  const { numberOfConventionsReminded: numberOfFirstReminders } =
     await makeAssessmentReminder({
       uowPerformer: createUowPerformer(config, createGetPgPoolFn(config))
         .uowPerformer,
@@ -54,7 +54,7 @@ const triggerAssessmentReminder = async () => {
       },
     }).execute({ mode: "3daysAfterInitialAssessmentEmail" });
 
-  const { numberOfReminders: numberOfSecondReminders } =
+  const { numberOfConventionsReminded: numberOfSecondReminders } =
     await makeAssessmentReminder({
       uowPerformer: createUowPerformer(config, createGetPgPoolFn(config))
         .uowPerformer,

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -289,6 +289,7 @@ export const defaultEmailValueByEmailKind: {
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",
     beneficiaryLastName: "BENEFICIARY_LAST_NAME",
     businessName: "BUSINESS_NAME",
+    tutorEmail: "TUTOR_EMAIL",
     conventionId: "CONVENTION_ID",
     internshipKind: "immersion",
   },

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -83,6 +83,7 @@ export type EmailParamsByEmailType = {
     assessmentCreationLink: string;
     beneficiaryFirstName: string;
     beneficiaryLastName: string;
+    tutorEmail: string;
     businessName: string;
     conventionId: ConventionId;
     internshipKind: InternshipKind;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -113,6 +113,7 @@ export const emailTemplatesByName =
         assessmentCreationLink,
         beneficiaryFirstName,
         beneficiaryLastName,
+        tutorEmail,
         businessName,
         conventionId,
         internshipKind,
@@ -120,13 +121,16 @@ export const emailTemplatesByName =
         subject: `Immersion Facilitée - Bilan disponible pour l'immersion de ${beneficiaryFirstName} ${beneficiaryLastName}`,
         greetings: greetingsWithConventionId(conventionId),
         content: `
-      ${
-        internshipKind === "immersion"
-          ? "L'immersion professionnelle"
-          : "Le mini stage"
-      } de ${beneficiaryFirstName} ${beneficiaryLastName} au sein de l’entreprise ${businessName} est en passe de s'achever.
-
-      Nous venons d’envoyer le bilan de l’immersion à l’entreprise. Vous pouvez, si vous le souhaitez, les contacter par téléphone pour les accompagner dans la saisie du bilan.
+        Nous constatons que le bilan ${
+          internshipKind === "immersion"
+            ? " de l'immersion professionnelle"
+            : " du mini stage"
+        } de ${beneficiaryFirstName} ${beneficiaryLastName} n'a pas encore été complété par l’entreprise ${businessName}.
+      
+      Afin de clôturer cette étape, vous pouvez:
+      
+      1. <a href="mailto:${tutorEmail}" target="_blank">Relancer directement l'entreprise</a> pour qu'elle remplisse le bilan en ligne.
+      2. Les contacter par téléphone pour les accompagner dans la saisie du bilan.
       `,
         buttons: [
           {
@@ -135,7 +139,6 @@ export const emailTemplatesByName =
           },
         ],
         subContent: `
-      Ces informations sont importantes pour la suite du parcours professionnel de ${beneficiaryFirstName} ${beneficiaryLastName}.    
       ${
         agencyReferentName &&
         `


### PR DESCRIPTION
## 🌈 Description

Les conseillers et valideurs reçoivent trop de mails.

Cette PR :
- supprime l'envoi au conseiller/valideur lors de l'envoi du mail initial au tuteur
- envoie le mail au conseiller/valideurs en même temps que le reminder au tuteur à J+3 et J+10