### PR TITLE
TECH - Ne récupérer que les agences actives lors de la recherche des agences par code safir à lier aux conseillers

### DIFF
--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -73,12 +73,16 @@ export class InMemoryAgencyRepository implements AgencyRepository {
     return this.#agencies[id];
   }
 
-  public async getBySafir(
+  public async getBySafirAndActiveStatus(
     safirCode: string,
   ): Promise<AgencyWithUsersRights | undefined> {
     return values(this.#agencies)
       .filter(isTruthy)
-      .find((agency) => agency.codeSafir === safirCode);
+      .find(
+        (agency) =>
+          agency.codeSafir === safirCode &&
+          activeAgencyStatuses.includes(agency.status),
+      );
   }
 
   public async getByIds(ids: AgencyId[]): Promise<AgencyWithUsersRights[]> {

--- a/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
@@ -341,7 +341,7 @@ describe("PgAgencyRepository", () => {
     });
   });
 
-  describe("getBySafir()", () => {
+  describe("getBySafirAndActiveStatus()", () => {
     const agency1WithSafir = toAgencyWithRights(
       agency1builder.withCodeSafir(safirCode).build(),
       {
@@ -350,14 +350,27 @@ describe("PgAgencyRepository", () => {
     );
 
     it("returns undefined when no agency found", async () => {
-      expect(await agencyRepository.getBySafir(safirCode)).toBeUndefined();
+      expect(
+        await agencyRepository.getBySafirAndActiveStatus(safirCode),
+      ).toBeUndefined();
     });
 
     it("returns existing agency", async () => {
       await agencyRepository.insert(agency1WithSafir);
       expectToEqual(
-        await agencyRepository.getBySafir(safirCode),
+        await agencyRepository.getBySafirAndActiveStatus(safirCode),
         agency1WithSafir,
+      );
+    });
+
+    it("returns undefined when agency is not active", async () => {
+      await agencyRepository.insert({
+        ...agency1WithSafir,
+        status: "closed",
+      });
+      expectToEqual(
+        await agencyRepository.getBySafirAndActiveStatus(safirCode),
+        undefined,
       );
     });
 
@@ -373,7 +386,7 @@ describe("PgAgencyRepository", () => {
       await agencyRepository.insert(agency2WithSafir);
 
       await expectPromiseToFailWithError(
-        agencyRepository.getBySafir(safirCode),
+        agencyRepository.getBySafirAndActiveStatus(safirCode),
         new ConflictError(
           safirConflictErrorMessage(safirCode, [
             agency1WithSafir,

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -130,11 +130,12 @@ export class PgAgencyRepository implements AgencyRepository {
     return this.#pgAgencyToAgencyWithRights(result?.agency);
   }
 
-  public async getBySafir(
+  public async getBySafirAndActiveStatus(
     safirCode: string,
   ): Promise<AgencyWithUsersRights | undefined> {
     const results = await this.#getAgencyWithJsonBuiltQueryBuilder()
       .where("agencies.code_safir", "=", safirCode)
+      .where("agencies.status", "in", activeAgencyStatuses)
       .execute();
 
     //TODO: On ne fait pas de unique sur le code safir en base

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -43,7 +43,9 @@ export interface AgencyRepository {
   update(partialAgency: PartialAgencyWithUsersRights): Promise<void>;
 
   getById(id: AgencyId): Promise<AgencyWithUsersRights | undefined>;
-  getBySafir(safirCode: string): Promise<AgencyWithUsersRights | undefined>;
+  getBySafirAndActiveStatus(
+    safirCode: string,
+  ): Promise<AgencyWithUsersRights | undefined>;
   getByIds(ids: AgencyId[]): Promise<AgencyWithUsersRights[]>;
   getAgencies(props: {
     filters?: GetAgenciesFilters;

--- a/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.ts
+++ b/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.ts
@@ -46,11 +46,10 @@ export const makeLinkFranceTravailUsersToTheirAgencies = useCaseBuilder(
     const user = await getUserWithRights(uow, userId);
     if (isIcUserAlreadyHasValidRight(user, codeSafir)) return;
 
-    const agencyWithSafir = await uow.agencyRepository.getBySafir(codeSafir);
-    if (
-      agencyWithSafir &&
-      activeAgencyStatuses.includes(agencyWithSafir.status)
-    )
+    const agencyWithSafir =
+      await uow.agencyRepository.getBySafirAndActiveStatus(codeSafir);
+
+    if (agencyWithSafir)
       return updateActiveAgencyWithSafir(
         uow,
         agencyWithSafir,


### PR DESCRIPTION
## 🐛 Problème

Nous avons ce type d'erreur en prod :
> Multiple agencies were found with safir code \"17063\": a84512cd-27b5-444a-8deb-813e883aa4af,fe6a22c4-8556-44e3-a8a5-a1cc736e78a4


Il y a deux raisons :
1. Lors de la récupération des agences par code Safir, la méthode du repository ne filtre pas par statut d'agence mais déclenche l'erreur ci-dessus si plusieurs agences sont retournées. 
 **Solution**: Cette PR modifie la méthode du repository pour ne récupérer que les agences actives.
2. Nous avons récemment nettoyé les codes safir en DB en reprenant ceux fournit par Corinne et Loic de chez FT. Or, nous nous basions sur le siret pour associer le code safir, mais en BD nous pouvons avoir plusieurs agences actives avec le même siret.
**Solution** ([ticket](https://github.com/gip-inclusion/immersion-facile/issues/3937)): Il y a 24 agences qui ont des mêmes code safir en DB. Reprendre le fichier de correspondance des sirets/code safir et se baser aussi sur le nom de l'agence pour faire la correction manuelle des code Safir. Partager à Corinne et Loic les agences qui se retrouvent alors sans code safir