### PR TITLE
TECH - éviter de voir popper les erreurs open cage dans les notfis slack

### DIFF
--- a/back/src/domains/core/address/adapters/HttpAddressGateway.ts
+++ b/back/src/domains/core/address/adapters/HttpAddressGateway.ts
@@ -119,6 +119,11 @@ export class HttpAddressGateway implements AddressGateway {
             return lookupSearchResultsSchema.parse(
               toLookupSearchResults(response.body),
             );
+          })
+          .catch(() => {
+            // just like for !200 codes: do nothing. We don't need noisy errors.
+            // Errors are logged in data dog anyway. We can configure alert there.
+            return [];
           }),
     })(sanitizedQuery);
   }
@@ -153,6 +158,11 @@ export class HttpAddressGateway implements AddressGateway {
         return response.body.features
           .map((feature) => this.#toAddressAndPosition(feature))
           .filter(filterNotFalsy);
+      })
+      .catch(() => {
+        // just like for !200 codes: do nothing. We don't need noisy errors.
+        // Errors are logged in data dog anyway. We can configure alert there.
+        return [];
       });
   }
 


### PR DESCRIPTION
J'ai bien vérifier, on a pas bien les erreurs dans datadogs. On peut se mettre une alert au dela d'un seuil. 

<img width="1624" height="694" alt="image" src="https://github.com/user-attachments/assets/4cc3291e-e7ab-42cc-a0ce-18ce97621242" />
