### PR TITLE
#3551 - Gérer les retours de liens magiques invalides

### DIFF
--- a/back/src/config/bootstrap/authMiddleware.ts
+++ b/back/src/config/bootstrap/authMiddleware.ts
@@ -9,6 +9,7 @@ import {
   errors,
   expiredMagicLinkErrorMessage,
   type PayloadKind,
+  unsupportedMagicLinkErrorMessage,
 } from "shared";
 import type { GetApiConsumerById } from "../../domains/core/api-consumer/ports/ApiConsumerRepository";
 import { type JwtKind, makeVerifyJwtES256 } from "../../domains/core/jwt";
@@ -128,7 +129,7 @@ const sendNeedsRenewedLinkError = (res: Response, error: Error) => {
         message:
           error.message === "jwt expired"
             ? expiredMagicLinkErrorMessage
-            : error.message,
+            : unsupportedMagicLinkErrorMessage,
         needsNewMagicLink: true,
       })
     : res.json({ message: JSON.stringify(error), needsNewMagicLink: true });

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -31,6 +31,7 @@ import type { NumberEmployeesRange, SiretDto } from "../siret/siret";
 import type {
   AppSupportedJwt,
   expiredMagicLinkErrorMessage,
+  unsupportedMagicLinkErrorMessage,
 } from "../tokens/jwt.dto";
 import type { Flavor } from "../typeFlavors";
 import type {
@@ -400,7 +401,9 @@ export type RenewMagicLinkRequestDto = {
 };
 
 export type RenewMagicLinkResponse = {
-  message: typeof expiredMagicLinkErrorMessage;
+  message:
+    | typeof expiredMagicLinkErrorMessage
+    | typeof unsupportedMagicLinkErrorMessage;
   needsNewMagicLink: boolean;
 };
 

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -40,7 +40,10 @@ import {
   numberOfEmployeesRangeSchema,
   siretSchema,
 } from "../siret/siret.schema";
-import { expiredMagicLinkErrorMessage } from "../tokens/jwt.dto";
+import {
+  expiredMagicLinkErrorMessage,
+  unsupportedMagicLinkErrorMessage,
+} from "../tokens/jwt.dto";
 import type { OmitFromExistingKeys } from "../utils";
 import type { DateString } from "../utils/date";
 import { addressWithPostalCodeSchema } from "../utils/postalCode";
@@ -633,7 +636,9 @@ export const renewMagicLinkRequestSchema: ZodSchemaWithInputMatchingOutput<Renew
 
 export const renewMagicLinkResponseSchema: ZodSchemaWithInputMatchingOutput<RenewMagicLinkResponse> =
   z.object({
-    message: z.literal(expiredMagicLinkErrorMessage),
+    message: z
+      .literal(expiredMagicLinkErrorMessage)
+      .or(z.literal(unsupportedMagicLinkErrorMessage)),
     needsNewMagicLink: z.boolean(),
   });
 

--- a/shared/src/tokens/jwt.dto.ts
+++ b/shared/src/tokens/jwt.dto.ts
@@ -25,3 +25,5 @@ export type JwtDto = {
 };
 
 export const expiredMagicLinkErrorMessage = "Le lien magique est périmé";
+export const unsupportedMagicLinkErrorMessage =
+  "Le lien magique est n'est pas valide";


### PR DESCRIPTION
## 🐛 Problème

On a un cas d'erreur non géré sur un lien magique invalide.
<img width="2022" height="890" alt="image" src="https://github.com/user-attachments/assets/f1502f1d-83e8-4d31-bb79-6addc0ef694c" />

## 💯 Solution

<img width="883" height="313" alt="Screenshot 2025-10-30 at 14 31 36" src="https://github.com/user-attachments/assets/f6f3ea6f-ca86-4bda-bd91-05bb0048bb1b" />
