### PR TITLE
#3344 - utiliser plusieurs adresses mail dexpédition (bilan, mise-en-relation), pour améliorer la délivrabilité et éviter de dérouter les utilsateurs hésitant à répondre

### DIFF
--- a/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
+++ b/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
@@ -2,6 +2,7 @@ import { partition, uniqBy } from "ramda";
 import {
   type AbsoluteUrl,
   type AgencyWithUsersRights,
+  assessmentEmailSender,
   type ConventionDto,
   type ConventionId,
   calculateDurationInSecondsFrom,
@@ -11,7 +12,6 @@ import {
   executeInSequence,
   frontRoutes,
   getFormattedFirstnameAndLastname,
-  immersionFacileBilanEmailSender,
   immersionFacileNoReplyEmailSender,
   validatedConventionStatuses,
   withDateRangeSchema,
@@ -341,7 +341,7 @@ export class SendAssessmentNeededNotifications extends UseCase<
       templatedContent: {
         kind: "ASSESSMENT_ESTABLISHMENT_NOTIFICATION",
         recipients: [convention.establishmentTutor.email],
-        sender: immersionFacileBilanEmailSender,
+        sender: assessmentEmailSender,
         params: {
           agencyLogoUrl: agency.logoUrl ?? undefined,
           beneficiaryFirstName: getFormattedFirstnameAndLastname({

--- a/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.unit.test.ts
@@ -2,6 +2,7 @@ import { addDays, subDays } from "date-fns";
 import {
   AgencyDtoBuilder,
   AssessmentDtoBuilder,
+  assessmentEmailSender,
   ConnectedUserBuilder,
   ConventionDtoBuilder,
   errors,
@@ -9,6 +10,7 @@ import {
   expectObjectInArrayToMatch,
   expectToEqual,
   getFormattedFirstnameAndLastname,
+  immersionFacileNoReplyEmailSender,
   type Notification,
   type TemplatedEmail,
 } from "shared";
@@ -186,10 +188,7 @@ describe("SendAssessmentNeededNotifications", () => {
               internshipKind: conventionEndingTomorrow.internshipKind,
             },
             recipients: [conventionEndingTomorrow.establishmentTutor.email],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: assessmentEmailSender,
           },
           {
             kind: "ASSESSMENT_BENEFICIARY_NOTIFICATION",
@@ -211,10 +210,7 @@ describe("SendAssessmentNeededNotifications", () => {
             recipients: [
               conventionEndingTomorrow.signatories.beneficiary.email,
             ],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: immersionFacileNoReplyEmailSender,
           },
         ],
       });
@@ -301,10 +297,7 @@ describe("SendAssessmentNeededNotifications", () => {
               internshipKind: conventionCCIEndingTomorrow.internshipKind,
             },
             recipients: [conventionCCIEndingTomorrow.establishmentTutor.email],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: assessmentEmailSender,
           },
           {
             kind: "ASSESSMENT_BENEFICIARY_NOTIFICATION",
@@ -326,10 +319,7 @@ describe("SendAssessmentNeededNotifications", () => {
             recipients: [
               conventionCCIEndingTomorrow.signatories.beneficiary.email,
             ],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: immersionFacileNoReplyEmailSender,
           },
         ],
       });
@@ -370,10 +360,7 @@ describe("SendAssessmentNeededNotifications", () => {
             conventionEndingTomorrow.establishmentTutor.email,
         },
         recipients: [conventionEndingTomorrow.signatories.beneficiary.email],
-        sender: {
-          email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-          name: "Immersion Facilitée",
-        },
+        sender: immersionFacileNoReplyEmailSender,
       };
 
       uow.conventionRepository.setConventions([conventionEndingTomorrow]);
@@ -458,10 +445,7 @@ describe("SendAssessmentNeededNotifications", () => {
               internshipKind: conventionEndingTomorrow.internshipKind,
             },
             recipients: [conventionEndingTomorrow.establishmentTutor.email],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: assessmentEmailSender,
           },
         ],
       });
@@ -514,10 +498,7 @@ describe("SendAssessmentNeededNotifications", () => {
           agencyLogoUrl: undefined,
         },
         recipients: [conventionEndingYesterday.establishmentTutor.email],
-        sender: {
-          email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-          name: "Immersion Facilitée",
-        },
+        sender: assessmentEmailSender,
       };
       // Arrange
 
@@ -611,10 +592,7 @@ describe("SendAssessmentNeededNotifications", () => {
             recipients: [
               conventionEndingYesterday.signatories.beneficiary.email,
             ],
-            sender: {
-              email: "ne-pas-ecrire-a-cet-email@immersion-facile.beta.gouv.fr",
-              name: "Immersion Facilitée",
-            },
+            sender: immersionFacileNoReplyEmailSender,
           },
         ],
       });

--- a/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.ts
+++ b/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.ts
@@ -1,10 +1,10 @@
 import {
   createOpaqueEmail,
+  discussionEmailSender,
   type Email,
   type EmailAttachment,
   type Exchange,
   errors,
-  immersionFacileMiseEnRelationEmailSender,
   type SiretDto,
   type WithDiscussionId,
   withDiscussionIdSchema,
@@ -98,7 +98,7 @@ export class SendExchangeToRecipient extends TransactionalUseCase<SendExchangeTo
       kind: "email",
       templatedContent: {
         kind: "DISCUSSION_EXCHANGE",
-        sender: immersionFacileMiseEnRelationEmailSender,
+        sender: discussionEmailSender,
         params: {
           subject: lastExchange.subject,
           htmlContent: `<div style="color: #b5b5b5; font-size: 12px">Pour rappel, voici les informations liées à cette mise en relation :

--- a/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/discussions/SendExchangeToRecipient.unit.test.ts
@@ -3,12 +3,12 @@ import {
   type Attachment,
   ConnectedUserBuilder,
   DiscussionBuilder,
+  discussionEmailSender,
   type EstablishmentExchange,
   type Exchange,
   errors,
   expectPromiseToFailWithError,
   expectToEqual,
-  immersionFacileNoReplyEmailSender,
   type PotentialBeneficiaryExchange,
 } from "shared";
 import { v4 as uuid } from "uuid";
@@ -177,7 +177,7 @@ describe("SendExchangeToRecipient", () => {
                 email: `${lastEstablishmentExchange.firstname.toLocaleLowerCase()}_${lastEstablishmentExchange.lastname.toLocaleLowerCase()}__${discussion.id}_e@reply.my-domain.com`,
                 name: `${lastEstablishmentExchange.firstname} ${lastEstablishmentExchange.lastname} - ${discussion.businessName}`,
               },
-              sender: immersionFacileNoReplyEmailSender,
+              sender: discussionEmailSender,
               attachments: [
                 {
                   name: lastEstablishmentExchange.attachments[0].name,
@@ -258,7 +258,7 @@ describe("SendExchangeToRecipient", () => {
                 email: `${discussion.potentialBeneficiary.firstName}_${discussion.potentialBeneficiary.lastName}__${discussion.id}_b@reply.my-domain.com`,
                 name: `${discussion.potentialBeneficiary.firstName} ${discussion.potentialBeneficiary.lastName}`,
               },
-              sender: immersionFacileNoReplyEmailSender,
+              sender: discussionEmailSender,
               attachments: [
                 {
                   name: lastBeneficiaryExchange.attachments[0].name,
@@ -325,7 +325,7 @@ describe("SendExchangeToRecipient", () => {
                 email: `${lastEstablishmentExchange.firstname.toLocaleLowerCase()}_${lastEstablishmentExchange.lastname.toLocaleLowerCase()}__${discussion.id}_e@reply.my-domain.com`,
                 name: `${lastEstablishmentExchange.firstname} ${lastEstablishmentExchange.lastname} - ${discussion.businessName}`,
               },
-              sender: immersionFacileNoReplyEmailSender,
+              sender: discussionEmailSender,
               attachments: [
                 {
                   name: lastEstablishmentExchange.attachments[0].name,
@@ -376,7 +376,7 @@ describe("SendExchangeToRecipient", () => {
                 email: `${lastExchange.firstname.toLocaleLowerCase()}_${lastExchange.lastname.toLocaleLowerCase()}__${discussion.id}_e@reply.my-domain.com`,
                 name: `${lastExchange.firstname} ${lastExchange.lastname} - ${discussion.businessName}`,
               },
-              sender: immersionFacileNoReplyEmailSender,
+              sender: discussionEmailSender,
               attachments: [],
             },
           ],
@@ -417,7 +417,7 @@ describe("SendExchangeToRecipient", () => {
                 email: `e-ric_el-ah-e-tru__${discussion.id}_b@reply.my-domain.com`,
                 name: `${discussion.potentialBeneficiary.firstName} ${discussion.potentialBeneficiary.lastName}`,
               },
-              sender: immersionFacileNoReplyEmailSender,
+              sender: discussionEmailSender,
               attachments: [],
             },
           ],

--- a/shared/src/email/knownEmailsAddresses.ts
+++ b/shared/src/email/knownEmailsAddresses.ts
@@ -14,17 +14,16 @@ export const backOfficeEmail = "support@immersion-facile.beta.gouv.fr";
 export const immersionFacileDelegationEmail =
   "delegation@immersion-facile.beta.gouv.fr";
 
-export const immersionFacileMiseEnRelationEmail =
-  "mise-en-relation@immersion-facile.beta.gouv.fr";
+export const discussionEmail = "mise-en-relation@immersion-facile.beta.gouv.fr";
 
-export const immersionFacileMiseEnRelationEmailSender = {
+export const discussionEmailSender = {
   name: "Immersion Facilitée",
-  email: immersionFacileMiseEnRelationEmail,
+  email: discussionEmail,
 };
 
-export const immersionFacileBilanEmail = "bilan@immersion-facile.beta.gouv.fr";
+export const assesmentEmail = "bilan@immersion-facile.beta.gouv.fr";
 
-export const immersionFacileBilanEmailSender = {
+export const assessmentEmailSender = {
   name: "Immersion Facilitée",
-  email: immersionFacileBilanEmail,
+  email: assesmentEmail,
 };


### PR DESCRIPTION
- **feat: use mise-en-relation@ sender for discussion exchange emails**
- **feat: use bilan@ sender for initial assessment notification emails**
- **fix tests**
