### PR TITLE
#4005 - Remplacer le caractère de nouvelle ligne par " / " sur l'url de formulaire de convention

### DIFF
--- a/front/src/app/components/forms/convention/useUpdateConventionValuesInUrl.ts
+++ b/front/src/app/components/forms/convention/useUpdateConventionValuesInUrl.ts
@@ -4,6 +4,7 @@ import { objectToDependencyList } from "shared";
 import type { ConventionParamsInUrl } from "src/app/routes/routeParams/convention";
 import { conventionParams, routes, useRoute } from "src/app/routes/routes";
 import {
+  cleanParamsValues,
   filterParamsForRoute,
   getUrlParameters,
 } from "src/app/utils/url.utils";
@@ -24,36 +25,35 @@ export const useUpdateConventionValuesInUrl = (
       )
         return;
 
+      const filteredAndCleanedParams = cleanParamsValues(
+        filterParamsForRoute({
+          urlParams,
+          matchingParams: conventionParams,
+          forceExcludeParams: ["fedId", "fedIdProvider"],
+        }),
+      );
+
       if (
         route.name === "conventionImmersion" ||
         route.name === "conventionMiniStage"
       ) {
-        const filteredParams = filterParamsForRoute({
-          urlParams,
-          matchingParams: conventionParams,
-          forceExcludeParams: ["fedId", "fedIdProvider"],
-        });
         const {
           fedId: _,
           fedIdProvider: __,
           ...watchedValuesWithoutFederatedIdentity
         } = watchedValues;
+
         routes[route.name]({
-          ...filteredParams,
-          ...watchedValuesWithoutFederatedIdentity,
+          ...filteredAndCleanedParams,
+          ...cleanParamsValues(watchedValuesWithoutFederatedIdentity),
         }).replace();
       }
 
       if (route.name === "conventionImmersionForExternals") {
-        const filteredParams = filterParamsForRoute({
-          urlParams,
-          matchingParams: conventionParams,
-          forceExcludeParams: ["fedId", "fedIdProvider"],
-        });
         routes
           .conventionImmersionForExternals({
-            ...filteredParams,
-            ...watchedValues,
+            ...filteredAndCleanedParams,
+            ...cleanParamsValues(watchedValues),
             consumer: route.params.consumer,
           })
           .replace();

--- a/front/src/app/utils/url.utils.ts
+++ b/front/src/app/utils/url.utils.ts
@@ -1,3 +1,5 @@
+import { mapObjIndexed } from "ramda";
+
 export const getUrlParameters: (location: Location) => {
   [k: string]: string;
 } = (location) =>
@@ -18,3 +20,9 @@ export const filterParamsForRoute = <T>({
         key in matchingParams && value && !forceExcludeParams?.includes(key),
     ),
   );
+
+const replaceNewLineInValueBySlash = (value: unknown) =>
+  typeof value === "string" ? value.replace(/(?:\r?\n|\r)+/g, " / ") : value;
+
+export const cleanParamsValues = (obj: Record<string, unknown>) =>
+  mapObjIndexed(replaceNewLineInValueBySlash, obj);

--- a/front/src/app/utils/url.utils.unit.test.ts
+++ b/front/src/app/utils/url.utils.unit.test.ts
@@ -1,4 +1,5 @@
 import {
+  cleanParamsValues,
   filterParamsForRoute,
   getUrlParameters,
 } from "src/app/utils/url.utils";
@@ -29,6 +30,25 @@ describe("url.utils", () => {
       const result = filterParamsForRoute({ urlParams, matchingParams });
       expect(result).toEqual({
         param1: "value1",
+      });
+    });
+  });
+
+  describe("cleanParamsValues", () => {
+    it("should return an object with the parameters", () => {
+      const obj = {
+        param1: "value1",
+        param2: "value2\rvalue3",
+        param3: "value2\n\nvalue3",
+        param4: "value2\r\nvalue3\r\nvalue4",
+      };
+      const result = cleanParamsValues(obj);
+
+      expect(result).toEqual({
+        param1: "value1",
+        param2: "value2 / value3",
+        param3: "value2 / value3",
+        param4: "value2 / value3 / value4",
       });
     });
   });


### PR DESCRIPTION
## 🐛 Problème

Lorsque le lien de partage de convention contient des retours à la ligne, on ne peux pas accéder au site IF : on a l'erreur "This site can’t be reached" (blocage défini par notre règle nginx).

La solution ici est des remplacer ce caractère de retour à la ligne par " / ".
Ce n'est pas optimale car on modifie la saisie utilisateur, mais le partage de convention par url ne pourra prochainement plus être possible.