### PR TITLE
#4172 - Supprimer en local les informations de connexion même si la déconnexion du fournisseur n'est pas allé jusqu'au bout

### DIFF
--- a/front/src/core-logic/domain/auth/auth.slice.ts
+++ b/front/src/core-logic/domain/auth/auth.slice.ts
@@ -98,8 +98,9 @@ export const authSlice = createSlice({
       state,
       _action: PayloadActionWithFeedbackTopic<{ url: AbsoluteUrl | undefined }>,
     ) => state,
-    fetchLogoutUrlFailed: (state, _action: PayloadActionWithFeedbackTopic) =>
-      state,
+    fetchLogoutUrlFailed: (state, _action: PayloadActionWithFeedbackTopic) => {
+      state.federatedIdentityWithUser = null;
+    },
     redirectAfterLogoutSucceeded: (state) => state,
     federatedIdentityInDeviceDeletionSucceeded: (
       state,

--- a/front/src/core-logic/domain/auth/auth.test.ts
+++ b/front/src/core-logic/domain/auth/auth.test.ts
@@ -280,13 +280,13 @@ describe("Auth slice", () => {
 
     expectAuthStateToBe({
       afterLoginRedirectionUrl: null,
-      federatedIdentityWithUser: peConnectedFederatedIdentity,
+      federatedIdentityWithUser: null,
       isLoading: true,
       isRequestingLoginByEmail: false,
       requestedEmail: null,
     });
 
-    expectFederatedIdentityInDevice(peConnectedFederatedIdentity);
+    expectFederatedIdentityInDevice(undefined);
     expectToEqual(dependencies.navigationGateway.wentToUrls, []);
     expectToEqual(
       feedbacksSelectors.feedbacks(store.getState())["auth-global"],
@@ -541,6 +541,7 @@ describe("Auth slice", () => {
       });
       expectToEqual(dependencies.navigationGateway.wentToUrls, [redirectUri]);
     });
+
     it("should handle login by magic link confirmation failed", () => {
       expectAuthStateToBe(initialAuthState);
       store.dispatch(


### PR DESCRIPTION
## 🌈 Contexte

Lorsque l'on accède à une page de mini-stage, on commence toujours par supprimer les informations d'identité résiduels pour éviter d'avoir des informations PE connecté.

## 🐛 Problème

On a une erreur lorsqu'il n'y a pas d'informations d'identité.

## 💯 Solution

Supprimer dans tous les cas, que la déconnexion fournisseur ait réussi ou non, les informations d'identité en local (state + local storage).