### PR TITLE
TECH - Préparation du code des JWT pour renouvellement de lien générique

### DIFF
--- a/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
+++ b/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
@@ -776,7 +776,9 @@ describe("Admin router", () => {
         body: createApiConsumerParamsFromApiConsumer(
           authorizedUnJeuneUneSolutionApiConsumer,
         ),
-        headers: { authorization: generateApiConsumerJwt({ id: "osef" }) },
+        headers: {
+          authorization: generateApiConsumerJwt({ id: "osef", version: 1 }),
+        },
       });
 
       expectResponseAndReturnJwt(response, {
@@ -816,7 +818,9 @@ describe("Admin router", () => {
         body: createApiConsumerParamsFromApiConsumer(
           authorizedUnJeuneUneSolutionApiConsumer,
         ),
-        headers: { authorization: generateApiConsumerJwt({ id: "osef" }) },
+        headers: {
+          authorization: generateApiConsumerJwt({ id: "osef", version: 1 }),
+        },
       });
 
       expectHttpResponseToEqual(response, {
@@ -854,7 +858,9 @@ describe("Admin router", () => {
 
     it("401 - not with backOfficeJwt", async () => {
       const response = await sharedRequest.getUsers({
-        headers: { authorization: generateApiConsumerJwt({ id: "osef" }) },
+        headers: {
+          authorization: generateApiConsumerJwt({ id: "osef", version: 1 }),
+        },
         queryParams: { emailContains: "yolo" },
       });
 

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV2.e2e.test.ts
@@ -62,6 +62,7 @@ describe("POST contact-establishment public V2 route", () => {
     inMemoryUow.userRepository.users = [user];
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
     sharedRequest = createSupertestSharedClient(
       publicApiV2SearchEstablishmentRoutes,
@@ -86,6 +87,7 @@ describe("POST contact-establishment public V2 route", () => {
       headers: {
         authorization: generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       },
       body: contactEstablishment,
@@ -105,6 +107,7 @@ describe("POST contact-establishment public V2 route", () => {
       headers: {
         authorization: generateApiConsumerJwt({
           id: unauthorizedApiConsumer.id,
+          version: 1,
         }),
       },
       body: contactEstablishment,
@@ -271,6 +274,7 @@ describe("POST contact-establishment public V2 route", () => {
         "Authorization",
         generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       )
       .send(contactEstablishment);
@@ -324,6 +328,7 @@ describe("POST contact-establishment public V2 route", () => {
         "Authorization",
         generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       )
       .send(contactEstablishmentWithoutLocationId);

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV3.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/contactEstablishmentPublicV3.e2e.test.ts
@@ -64,6 +64,7 @@ describe("POST /v3/apply-to-offers public V3 route", () => {
     inMemoryUow.userRepository.users = [user];
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
     sharedRequest = createSupertestSharedClient(
       publicApiV3SearchEstablishmentRoutes,
@@ -88,6 +89,7 @@ describe("POST /v3/apply-to-offers public V3 route", () => {
       headers: {
         authorization: generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       },
       body: contactEstablishment,
@@ -107,6 +109,7 @@ describe("POST /v3/apply-to-offers public V3 route", () => {
       headers: {
         authorization: generateApiConsumerJwt({
           id: unauthorizedApiConsumer.id,
+          version: 1,
         }),
       },
       body: contactEstablishment,
@@ -276,6 +279,7 @@ describe("POST /v3/apply-to-offers public V3 route", () => {
         "Authorization",
         generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       )
       .send(contactEstablishment);
@@ -326,6 +330,7 @@ describe("POST /v3/apply-to-offers public V3 route", () => {
         "Authorization",
         generateApiConsumerJwt({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       )
       .send(contactEstablishment);

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/conventionPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/conventionPublicV2.e2e.test.ts
@@ -80,12 +80,15 @@ describe("Convention routes", () => {
     ];
     conventionReadConsumerWithAgencyIdsScopeToken = generateApiConsumerJwt({
       id: conventionReadConsumerWithAgencyIdsScope.id,
+      version: 1,
     });
     conventionReadConsumerWithNoScopeToken = generateApiConsumerJwt({
       id: conventionReadConsumerWithNoScope.id,
+      version: 1,
     });
     conventionUnauthorizedConsumerToken = generateApiConsumerJwt({
       id: conventionUnauthorizedConsumer.id,
+      version: 1,
     });
     sharedRequest = createSupertestSharedClient(
       publicApiV2ConventionRoutes,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/getOfferV3.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/getOfferV3.e2e.test.ts
@@ -65,6 +65,7 @@ describe("Route to get ImmersionSearchResultDto by siret, appellation code and l
       await buildTestApp(config));
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
 
     sharedRequest = createSupertestSharedClient(
@@ -194,6 +195,7 @@ describe("Route to get ImmersionSearchResultDto by siret, appellation code and l
   it("return 403 if forbidden", async () => {
     const authToken = generateApiConsumerJwt({
       id: unauthorizedApiConsumer.id,
+      version: 1,
     });
 
     const response = await sharedRequest.getOffer({

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/getSearchResultBySiretAndAppellationCodeV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/getSearchResultBySiretAndAppellationCodeV2.e2e.test.ts
@@ -53,6 +53,7 @@ describe("Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
       await buildTestApp(config));
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
 
     sharedRequest = createSupertestSharedClient(
@@ -172,6 +173,7 @@ describe("Route to get ImmersionSearchResultDto by siret and rome - /v2/offers/:
   it("return 403 if forbidden", async () => {
     const authToken = generateApiConsumerJwt({
       id: unauthorizedApiConsumer.id,
+      version: 1,
     });
 
     const response = await sharedRequest.getOfferBySiretAndAppellationCode({

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2Bottleneck.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV2Bottleneck.e2e.test.ts
@@ -69,9 +69,11 @@ describe("bottleneck", () => {
     inMemoryUow.apiConsumerRepository.consumers = [consumer1, consumer2];
     authorizationToken1 = generateApiConsumerJwt({
       id: consumer1.id,
+      version: 1,
     });
     authorizationToken2 = generateApiConsumerJwt({
       id: consumer2.id,
+      version: 1,
     });
     sharedRequest = createSupertestSharedClient(
       publicApiV2ConventionRoutes,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/searchImmersionApiPublicV2.e2e.test.ts
@@ -47,6 +47,7 @@ describe("search route", () => {
     );
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
   });
 
@@ -74,6 +75,7 @@ describe("search route", () => {
       it("rejects unauthorized consumer", async () => {
         const authToken = generateApiConsumerJwt({
           id: unauthorizedApiConsumer.id,
+          version: 1,
         });
         const response = await sharedRequest.searchImmersion({
           headers: {
@@ -183,6 +185,7 @@ describe("search route", () => {
             "Authorization",
             generateApiConsumerJwt({
               id: authorizedUnJeuneUneSolutionApiConsumer.id,
+              version: 1,
             }),
           );
 
@@ -199,6 +202,7 @@ describe("search route", () => {
             "Authorization",
             generateApiConsumerJwt({
               id: authorizedUnJeuneUneSolutionApiConsumer.id,
+              version: 1,
             }),
           );
 
@@ -217,6 +221,7 @@ describe("search route", () => {
             "Authorization",
             generateApiConsumerJwt({
               id: authorizedUnJeuneUneSolutionApiConsumer.id,
+              version: 1,
             }),
           );
         expect(response.status).toBe(200);
@@ -231,6 +236,7 @@ describe("search route", () => {
             "Authorization",
             generateApiConsumerJwt({
               id: authorizedUnJeuneUneSolutionApiConsumer.id,
+              version: 1,
             }),
           )
           .expect(200, []);
@@ -245,6 +251,7 @@ describe("search route", () => {
             "Authorization",
             generateApiConsumerJwt({
               id: authorizedUnJeuneUneSolutionApiConsumer.id,
+              version: 1,
             }),
           )
           .expect(200, []);
@@ -411,6 +418,7 @@ describe("search route", () => {
               "Authorization",
               generateApiConsumerJwt({
                 id: authorizedUnJeuneUneSolutionApiConsumer.id,
+                version: 1,
               }),
             );
 
@@ -429,6 +437,7 @@ describe("search route", () => {
               "Authorization",
               generateApiConsumerJwt({
                 id: authorizedUnJeuneUneSolutionApiConsumer.id,
+                version: 1,
               }),
             )
             .expect(200, toSearchImmersionResults([siret1, siret3]));
@@ -443,6 +452,7 @@ describe("search route", () => {
               "Authorization",
               generateApiConsumerJwt({
                 id: authorizedUnJeuneUneSolutionApiConsumer.id,
+                version: 1,
               }),
             )
             .expect(200, toSearchImmersionResults([siret1, siret2, siret3]));

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/statisticsPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/statisticsPublicV2.e2e.test.ts
@@ -24,6 +24,7 @@ describe("Statistics routes", () => {
     ];
     authToken = generateApiConsumerJwt({
       id: authorizedUnJeuneUneSolutionApiConsumer.id,
+      version: 1,
     });
     httpClient = createSupertestSharedClient(
       publicApiV2StatisticsRoutes,

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/webhookPublicV2.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/webhookPublicV2.e2e.test.ts
@@ -46,6 +46,7 @@ describe("Webhook routes", () => {
       ];
       const authToken = generateApiConsumerJwt({
         id: authorizedSubscriptionApiConsumer.id,
+        version: 1,
       });
 
       const response = await sharedRequest.subscribeToWebhook({
@@ -73,6 +74,7 @@ describe("Webhook routes", () => {
       inMemoryUow.apiConsumerRepository.consumers = [unauthorizedApiConsumer];
       const authToken = generateApiConsumerJwt({
         id: unauthorizedApiConsumer.id,
+        version: 1,
       });
 
       const response = await sharedRequest.subscribeToWebhook({
@@ -136,6 +138,7 @@ describe("Webhook routes", () => {
       ];
       const authToken = generateApiConsumerJwt({
         id: apiConsumersWithSubscriptions.id,
+        version: 1,
       });
 
       const response = await sharedRequest.listActiveSubscriptions({
@@ -157,6 +160,7 @@ describe("Webhook routes", () => {
       ];
       const authToken = generateApiConsumerJwt({
         id: unauthorizedSubscriptionApiConsumer.id,
+        version: 1,
       });
 
       const response = await sharedRequest.listActiveSubscriptions({
@@ -212,6 +216,7 @@ describe("Webhook routes", () => {
       ];
       const authToken = generateApiConsumerJwt({
         id: authorizedSubscriptionApiConsumer.id,
+        version: 1,
       });
 
       const response = await sharedRequest.unsubscribeToWebhook({
@@ -285,6 +290,7 @@ describe("Webhook routes", () => {
       ];
       const authToken = generateApiConsumerJwt({
         id: unauthorizedApiConsumerWithSubscriptions.id,
+        version: 1,
       });
 
       const response = await sharedRequest.unsubscribeToWebhook({

--- a/back/src/adapters/primary/routers/auth/createAuthRouter.ts
+++ b/back/src/adapters/primary/routers/auth/createAuthRouter.ts
@@ -67,5 +67,11 @@ export const createAuthRouter = (deps: AppDependencies) => {
       ),
   );
 
+  authSharedRouter.renewExpiredJwt((req, res) =>
+    sendHttpResponse(req, res, () =>
+      deps.useCases.renewExpiredJwt.execute(req.query),
+    ),
+  );
+
   return router;
 };

--- a/back/src/adapters/primary/routers/convention/createConventionRouter.ts
+++ b/back/src/adapters/primary/routers/convention/createConventionRouter.ts
@@ -41,12 +41,6 @@ export const createConventionRouter = (deps: AppDependencies) => {
     ),
   );
 
-  unauthenticatedConventionSharedRouter.renewMagicLink((req, res) =>
-    sendHttpResponse(req, res, () =>
-      deps.useCases.renewConventionMagicLink.execute(req.query),
-    ),
-  );
-
   authenticatedConventionSharedRouter.getApiConsumersByConvention(
     deps.connectedUserAuthMiddleware,
     (req, res) =>

--- a/back/src/config/bootstrap/createAppDependencies.ts
+++ b/back/src/config/bootstrap/createAppDependencies.ts
@@ -32,12 +32,11 @@ import { createEventCrawler } from "./createEventCrawler";
 import { createGateways } from "./createGateways";
 import { createUseCases } from "./createUseCases";
 
-const uuidGenerator = new UuidV4Generator();
-
 export type AppDependencies =
   ReturnType<typeof createAppDependencies> extends Promise<infer T> ? T : never;
 
 export const createAppDependencies = async (config: AppConfig) => {
+  const uuidGenerator = new UuidV4Generator();
   const getPgPoolFn = createMakeProductionPgPool(config);
   const gateways = await createGateways(config, uuidGenerator);
 

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -62,7 +62,7 @@ import { NotifyUserAgencyRightChanged } from "../../domains/convention/use-cases
 import { NotifyUserAgencyRightRejected } from "../../domains/convention/use-cases/notifications/NotifyUserAgencyRightRejected";
 import { MarkPartnersErroredConventionAsHandled } from "../../domains/convention/use-cases/partners-errored-convention/MarkPartnersErroredConventionAsHandled";
 import { RenewConvention } from "../../domains/convention/use-cases/RenewConvention";
-import { RenewConventionMagicLink } from "../../domains/convention/use-cases/RenewConventionMagicLink";
+import { RenewExpiredJwt } from "../../domains/convention/use-cases/RenewExpiredJwt";
 import { makeSendAssessmentLink } from "../../domains/convention/use-cases/SendAssessmentLink";
 import { SendEmailsWhenAgencyIsActivated } from "../../domains/convention/use-cases/SendEmailsWhenAgencyIsActivated";
 import { SendEmailWhenAgencyIsRejected } from "../../domains/convention/use-cases/SendEmailWhenAgencyIsRejected";
@@ -339,7 +339,7 @@ export const createUseCases = ({
         createNewEvent,
         gateways.timeGateway,
       ),
-      renewConventionMagicLink: new RenewConventionMagicLink(
+      renewExpiredJwt: new RenewExpiredJwt(
         uowPerformer,
         createNewEvent,
         generateConventionMagicLinkUrl,

--- a/back/src/domains/connected-users/helpers/authorization.helper.ts
+++ b/back/src/domains/connected-users/helpers/authorization.helper.ts
@@ -2,7 +2,7 @@ import {
   type AgencyId,
   type ConnectedUser,
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   type ConventionReadDto,
   type ConventionRelatedJwtPayload,
   errors,
@@ -91,7 +91,7 @@ const onMagicLink = async ({
   isValidatorOfAgencyRefersToAllowed,
 }: {
   uow: UnitOfWork;
-  jwtPayload: ConventionDomainPayload;
+  jwtPayload: ConventionDomainJwtPayload;
   authorizedRoles: Role[];
   errorToThrow: Error;
   convention: ConventionReadDto;

--- a/back/src/domains/convention/entities/Convention.ts
+++ b/back/src/domains/convention/entities/Convention.ts
@@ -6,7 +6,7 @@ import {
   type ApiConsumer,
   allSignatoryRoles,
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   type ConventionDto,
   type ConventionId,
   type ConventionReadDto,
@@ -302,7 +302,7 @@ export const shouldBroadcastToFranceTravail = ({
 };
 
 const getRoleAndIcUser = async (
-  jwtPayload: ConventionDomainPayload | ConnectedUserDomainJwtPayload,
+  jwtPayload: ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload,
   uow: UnitOfWork,
   initialConvention: ConventionDto,
 ): Promise<{ role: Role; userWithRights: UserWithRights | undefined }> => {
@@ -336,7 +336,7 @@ export const signConvention = async ({
 }: {
   uow: UnitOfWork;
   convention: ConventionReadDto;
-  jwtPayload: ConventionDomainPayload | ConnectedUserDomainJwtPayload;
+  jwtPayload: ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload;
   now: DateTimeIsoString;
 }) => {
   const { role, userWithRights } = await getRoleAndIcUser(
@@ -374,7 +374,7 @@ export const domainTopicByTargetStatusMap: Partial<
 };
 
 export const extractUserRolesOnConventionFromJwtPayload = async (
-  jwtPayload: ConventionDomainPayload | ConnectedUserDomainJwtPayload,
+  jwtPayload: ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload,
   uow: UnitOfWork,
   initialConvention: ConventionDto,
 ): Promise<Role[]> => {

--- a/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
+++ b/back/src/domains/convention/use-cases/CreateAssessment.unit.test.ts
@@ -4,7 +4,7 @@ import {
   type AssessmentDto,
   allRoles,
   ConnectedUserBuilder,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   ConventionDtoBuilder,
   type ConventionRole,
   conventionStatuses,
@@ -66,7 +66,7 @@ describe("CreateAssessment", () => {
     establishmentAdvices: "mon conseil",
   };
 
-  const tutorPayload: ConventionDomainPayload = {
+  const tutorPayload: ConventionDomainJwtPayload = {
     applicationId: validatedConvention.id,
     role: "establishment-tutor",
     emailHash: makeEmailHash(validatedConvention.establishmentTutor.email),

--- a/back/src/domains/convention/use-cases/GetAssessmentByConventionId.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetAssessmentByConventionId.unit.test.ts
@@ -3,7 +3,7 @@ import {
   type AssessmentDto,
   allRoles,
   ConnectedUserBuilder,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   ConventionDtoBuilder,
   type ConventionJwtPayload,
   type ConventionRole,
@@ -48,7 +48,7 @@ describe("GetAssessmentByConventionId", () => {
     .withIsAdmin(true)
     .buildUser();
   const convention = new ConventionDtoBuilder().withAgencyId(agency.id).build();
-  const establishmentTutorPayload: ConventionDomainPayload = {
+  const establishmentTutorPayload: ConventionDomainJwtPayload = {
     applicationId: convention.id,
     role: "establishment-tutor",
     emailHash: makeEmailHash(convention.establishmentTutor.email),

--- a/back/src/domains/convention/use-cases/RenewConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/RenewConvention.unit.test.ts
@@ -3,7 +3,7 @@ import {
   AgencyDtoBuilder,
   BadRequestError,
   ConnectedUserBuilder,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   ConventionDtoBuilder,
   type ConventionId,
   type ConventionRelatedJwtPayload,
@@ -106,7 +106,7 @@ describe("RenewConvention", () => {
   }: {
     conventionId: ConventionId;
     role: ConventionRole;
-  }): ConventionDomainPayload => ({
+  }): ConventionDomainJwtPayload => ({
     applicationId: conventionId,
     role,
     emailHash: "my-hash",

--- a/back/src/domains/convention/use-cases/RenewExpiredJwt.unit.test.ts
+++ b/back/src/domains/convention/use-cases/RenewExpiredJwt.unit.test.ts
@@ -10,7 +10,7 @@ import {
   expectPromiseToFailWithError,
   expectToEqual,
   frontRoutes,
-  type RenewMagicLinkRequestDto,
+  type RenewExpiredJwtRequestDto,
 } from "shared";
 import type { AppConfig } from "../../../config/bootstrap/appConfig";
 import { AppConfigBuilder } from "../../../utils/AppConfigBuilder";
@@ -29,7 +29,7 @@ import {
 import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
 import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
 import type { RenewMagicLinkPayload } from "./notifications/DeliverRenewedMagicLink";
-import { RenewConventionMagicLink } from "./RenewConventionMagicLink";
+import { RenewExpiredJwt } from "./RenewExpiredJwt";
 
 describe("RenewConventionMagicLink use case", () => {
   const currentEmployer: BeneficiaryCurrentEmployer = {
@@ -69,7 +69,7 @@ describe("RenewConventionMagicLink use case", () => {
   const timeGateway = new CustomTimeGateway(new Date());
 
   let uow: InMemoryUnitOfWork;
-  let useCase: RenewConventionMagicLink;
+  let useCase: RenewExpiredJwt;
   let shortLinkIdGeneratorGateway: DeterministShortLinkIdGeneratorGateway;
 
   beforeEach(() => {
@@ -77,7 +77,7 @@ describe("RenewConventionMagicLink use case", () => {
     uow.agencyRepository.agencies = [toAgencyWithRights(defaultAgency)];
     uow.conventionRepository.setConventions([validConvention]);
     shortLinkIdGeneratorGateway = new DeterministShortLinkIdGeneratorGateway();
-    useCase = new RenewConventionMagicLink(
+    useCase = new RenewExpiredJwt(
       new InMemoryUowPerformer(uow),
       makeCreateNewEvent({
         timeGateway,
@@ -128,7 +128,7 @@ describe("RenewConventionMagicLink use case", () => {
         now: timeGateway.now(),
       });
 
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: "http://immersionfacile.fr/verifier-et-signer",
 
         expiredJwt: generateConventionJwt(expiredPayload),
@@ -184,7 +184,7 @@ describe("RenewConventionMagicLink use case", () => {
         now: timeGateway.now(),
       });
 
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: encodeURIComponent(
           "http://immersionfacile.fr/verifier-et-signer",
         ),
@@ -201,7 +201,7 @@ describe("RenewConventionMagicLink use case", () => {
     it("requires a valid application id", async () => {
       const invalidConventionId: ConventionId = "not-a-valid-id";
 
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: "https://immersionfacile.com/%jwt%",
         expiredJwt: generateConventionJwt(
           createConventionMagicLinkPayload({
@@ -226,7 +226,7 @@ describe("RenewConventionMagicLink use case", () => {
         .build();
       uow.conventionRepository.setConventions([convention]);
 
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: "https://immersionfacile.com/%jwt%",
         expiredJwt: generateConventionJwt(
           createConventionMagicLinkPayload({
@@ -246,7 +246,7 @@ describe("RenewConventionMagicLink use case", () => {
 
     // Admins use non-magic-link based authentication, so no need to renew these.
     it("Refuses to generate backoffice magic links", async () => {
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: "https://immersionfacile.com/verification",
         expiredJwt: generateConventionJwt(
           createConventionMagicLinkPayload({
@@ -265,7 +265,7 @@ describe("RenewConventionMagicLink use case", () => {
     });
 
     it("does not accept to renew links from url that are not supported", async () => {
-      const request: RenewMagicLinkRequestDto = {
+      const request: RenewExpiredJwtRequestDto = {
         originalUrl: "immersionfacile.com/",
         expiredJwt: generateConventionJwt(
           createConventionMagicLinkPayload({

--- a/back/src/domains/convention/use-cases/SignConvention.ts
+++ b/back/src/domains/convention/use-cases/SignConvention.ts
@@ -1,6 +1,6 @@
 import {
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   errors,
   type WithConventionId,
   type WithConventionIdLegacy,
@@ -19,7 +19,7 @@ import {
 export class SignConvention extends TransactionalUseCase<
   WithConventionId,
   WithConventionIdLegacy,
-  ConventionDomainPayload | ConnectedUserDomainJwtPayload
+  ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload
 > {
   protected inputSchema = withConventionIdSchema;
 
@@ -40,7 +40,7 @@ export class SignConvention extends TransactionalUseCase<
   public async _execute(
     { conventionId }: WithConventionId,
     uow: UnitOfWork,
-    jwtPayload: ConventionDomainPayload | ConnectedUserDomainJwtPayload,
+    jwtPayload: ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload,
   ): Promise<WithConventionIdLegacy> {
     const convention =
       await uow.conventionQueries.getConventionById(conventionId);

--- a/back/src/domains/convention/use-cases/UpdateConvention.ts
+++ b/back/src/domains/convention/use-cases/UpdateConvention.ts
@@ -1,7 +1,7 @@
 import {
   allModifierRoles,
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   type ConventionDto,
   type ConventionStatus,
   errors,
@@ -36,7 +36,7 @@ import {
 export class UpdateConvention extends TransactionalUseCase<
   UpdateConventionRequestDto,
   WithConventionIdLegacy,
-  ConventionDomainPayload | ConnectedUserDomainJwtPayload
+  ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload
 > {
   protected inputSchema = updateConventionRequestSchema;
 
@@ -51,7 +51,7 @@ export class UpdateConvention extends TransactionalUseCase<
   protected async _execute(
     { convention }: UpdateConventionRequestDto,
     uow: UnitOfWork,
-    jwtPayload?: ConventionDomainPayload | ConnectedUserDomainJwtPayload,
+    jwtPayload?: ConventionDomainJwtPayload | ConnectedUserDomainJwtPayload,
   ): Promise<WithConventionIdLegacy> {
     if (!jwtPayload) throw errors.user.unauthorized();
 

--- a/back/src/domains/convention/use-cases/UpdateConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/UpdateConvention.unit.test.ts
@@ -5,7 +5,7 @@ import {
   type AgencyRole,
   ConnectedUserBuilder,
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   type ConventionDto,
   ConventionDtoBuilder,
   type ConventionRole,
@@ -231,7 +231,7 @@ describe("Update Convention", () => {
           uow.conventionRepository.setConventions([convention]);
 
           const requestedConventionId = "1dd5c20e-6dd2-45af-affe-927358005250";
-          const jwtPayload: ConventionDomainPayload = {
+          const jwtPayload: ConventionDomainJwtPayload = {
             applicationId: requestedConventionId,
             role: "beneficiary",
             emailHash: "yolo",
@@ -412,7 +412,7 @@ describe("Update Convention", () => {
           validatorUser,
         )["establishment-representative"],
       },
-    ] as ConventionDomainPayload[])("updates the Convention in the repository when updated by signatories user", async (payload) => {
+    ] as ConventionDomainJwtPayload[])("updates the Convention in the repository when updated by signatories user", async (payload) => {
       uow.agencyRepository.agencies = [toAgencyWithRights(agency, {})];
       uow.conventionRepository.setConventions([convention]);
 
@@ -485,7 +485,7 @@ describe("Update Convention", () => {
       { userId: validatorUser.id },
       { userId: counsellorUser.id },
     ] as (
-      | ConventionDomainPayload
+      | ConventionDomainJwtPayload
       | ConnectedUserDomainJwtPayload
     )[])("updates the Convention in the repository updated by non signatories user", async (payload) => {
       uow.userRepository.users = [

--- a/back/src/domains/core/api-consumer/use-cases/SaveApiConsumer.ts
+++ b/back/src/domains/core/api-consumer/use-cases/SaveApiConsumer.ts
@@ -77,6 +77,7 @@ export class SaveApiConsumer extends TransactionalUseCase<
     if (isNewApiConsumer)
       return this.#generateApiConsumerJwt({
         id: input.id,
+        version: 1,
       });
 
     return;

--- a/back/src/domains/core/api-consumer/use-cases/SaveApiConsumer.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/SaveApiConsumer.unit.test.ts
@@ -70,6 +70,7 @@ describe("SaveApiConsumer", () => {
         result,
         generateApiConsumerJwtTestFn({
           id: authorizedUnJeuneUneSolutionApiConsumer.id,
+          version: 1,
         }),
       );
       expectToEqual(uow.apiConsumerRepository.consumers, [

--- a/back/src/domains/core/dashboard/useCases/GetDashboardUrl.ts
+++ b/back/src/domains/core/dashboard/useCases/GetDashboardUrl.ts
@@ -1,7 +1,7 @@
 import {
   type AbsoluteUrl,
   type ConnectedUser,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   type DashboardUrlAndName,
   errors,
   type GetDashboardParams,
@@ -15,7 +15,7 @@ import type { DashboardGateway } from "../port/DashboardGateway";
 export class GetDashboardUrl extends UseCase<
   GetDashboardParams,
   DashboardUrlAndName,
-  ConnectedUser | ConventionDomainPayload
+  ConnectedUser | ConventionDomainJwtPayload
 > {
   protected inputSchema = getDashboardParams;
 
@@ -32,7 +32,7 @@ export class GetDashboardUrl extends UseCase<
 
   protected async _execute(
     params: GetDashboardParams,
-    currentUser: ConnectedUser | ConventionDomainPayload,
+    currentUser: ConnectedUser | ConventionDomainJwtPayload,
   ): Promise<DashboardUrlAndName> {
     if (!currentUser) throw errors.user.unauthorized();
 

--- a/back/src/domains/core/useCase.helpers.ts
+++ b/back/src/domains/core/useCase.helpers.ts
@@ -2,7 +2,7 @@ import {
   type ApiConsumer,
   type ConnectedUser,
   type ConnectedUserDomainJwtPayload,
-  type ConventionDomainPayload,
+  type ConventionDomainJwtPayload,
   calculateDurationInSecondsFrom,
   castError,
   type LegacySearchQueryParamsDto,
@@ -39,7 +39,7 @@ export const extractValue = (
 };
 
 export type UseCaseIdentityPayload =
-  | ConventionDomainPayload
+  | ConventionDomainJwtPayload
   | ConnectedUserDomainJwtPayload
   | ConnectedUser
   | ApiConsumer

--- a/front/src/app/pages/auth/RenewExpiredLinkPage.tsx
+++ b/front/src/app/pages/auth/RenewExpiredLinkPage.tsx
@@ -7,7 +7,7 @@ import {
   type ConventionJwtPayload,
   decodeMagicLinkJwtWithoutSignatureCheck,
   domElementIds,
-  type RenewMagicLinkRequestDto,
+  type RenewExpiredJwtRequestDto,
 } from "shared";
 import { HeaderFooterLayout } from "src/app/components/layout/HeaderFooterLayout";
 import { routes } from "src/app/routes/routes";
@@ -19,7 +19,7 @@ interface RenewExpiredLinkProps {
 }
 
 export const RenewExpiredLinkContent = (
-  renewMagicLinkRequestDto: RenewMagicLinkRequestDto,
+  renewMagicLinkRequestDto: RenewExpiredJwtRequestDto,
 ) => {
   const jwtPayload =
     decodeMagicLinkJwtWithoutSignatureCheck<ConventionJwtPayload>(
@@ -45,8 +45,8 @@ export const RenewExpiredLinkContent = (
     }
 
     setRequested(true);
-    outOfReduxDependencies.conventionGateway
-      .renewMagicLink(renewMagicLinkRequestDto)
+    outOfReduxDependencies.authGateway
+      .renewExpiredJwt(renewMagicLinkRequestDto)
       .then(() => {
         setRequestSuccessful(true);
       })

--- a/front/src/config/dependencies.ts
+++ b/front/src/config/dependencies.ts
@@ -54,6 +54,7 @@ const {
   localDeviceRepository,
   sessionDeviceRepository,
   technicalGateway,
+  authGateway,
 } = dependencies;
 
 export const outOfReduxDependencies = {
@@ -62,6 +63,7 @@ export const outOfReduxDependencies = {
   localDeviceRepository,
   sessionDeviceRepository,
   technicalGateway,
+  authGateway,
 };
 
 export const store = createStore({

--- a/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
@@ -8,6 +8,7 @@ import type {
   InitiateLoginByEmailParams,
   LogoutQueryParams,
   OAuthSuccessLoginParams,
+  RenewExpiredJwtRequestDto,
   WithUserFilters,
 } from "shared";
 import type { HttpClient } from "shared-routes";
@@ -109,5 +110,16 @@ export class HttpAuthGateway implements AuthGateway {
             .otherwise(otherwiseThrow),
         ),
     );
+  }
+
+  public async renewExpiredJwt(
+    param: RenewExpiredJwtRequestDto,
+  ): Promise<void> {
+    await this.httpClient.renewExpiredJwt({
+      queryParams: {
+        expiredJwt: param.expiredJwt,
+        originalUrl: encodeURIComponent(param.originalUrl),
+      },
+    });
   }
 }

--- a/front/src/core-logic/adapters/AuthGateway/SimulatedAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/SimulatedAuthGateway.ts
@@ -7,6 +7,8 @@ import {
   type ConnectedUser,
   type InitiateLoginByEmailParams,
   type OAuthSuccessLoginParams,
+  type RenewExpiredJwtRequestDto,
+  sleep,
   toAgencyDtoForAgencyUsersAndAdmins,
 } from "shared";
 import type { AuthGateway } from "src/core-logic/ports/AuthGateway";
@@ -89,6 +91,13 @@ export class SimulatedAuthGateway implements AuthGateway {
       token: "fake-token",
       redirectUri: "http://fake-redirect.com",
     });
+  }
+
+  public async renewExpiredJwt(_: RenewExpiredJwtRequestDto): Promise<void> {
+    // This is supposed to ask the backend to send a new email to the owner of the expired magic link.
+    // Since this operation makes no sense for local development, the implementation here is left empty.
+    this.simulatedLatency && (await sleep(this.simulatedLatency));
+    throw new Error("500 Not Implemented In InMemory Gateway");
   }
 }
 

--- a/front/src/core-logic/adapters/AuthGateway/TestAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/TestAuthGateway.ts
@@ -5,6 +5,7 @@ import type {
   ConnectedUser,
   InitiateLoginByEmailParams,
   OAuthSuccessLoginParams,
+  RenewExpiredJwtRequestDto,
 } from "shared";
 import type { AuthGateway } from "src/core-logic/ports/AuthGateway";
 
@@ -38,5 +39,11 @@ export class TestAuthGateway implements AuthGateway {
     _params: OAuthSuccessLoginParams,
   ): Observable<AfterOAuthSuccessRedirectionResponse> {
     return this.confirmLoginByMagicLinkResponse$;
+  }
+
+  public async renewExpiredJwt(_: RenewExpiredJwtRequestDto): Promise<void> {
+    // This is supposed to ask the backend to send a new email to the owner of the expired magic link.
+    // Since this operation makes no sense for local development, the implementation here is left empty.
+    throw new Error("500 Not Implemented In InMemory Gateway");
   }
 }

--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -19,7 +19,6 @@ import type {
   FlatGetConventionsWithErroredBroadcastFeedbackParams,
   MarkPartnersErroredConventionAsHandledRequest,
   RenewConventionParams,
-  RenewMagicLinkRequestDto,
   SendSignatureLinkRequestDto,
   ShareLinkByEmailDto,
   TransferConventionToAgencyRequestDto,
@@ -233,18 +232,6 @@ export class HttpConventionGateway implements ConventionGateway {
             .otherwise(otherwiseThrow),
         ),
     );
-  }
-
-  public async renewMagicLink({
-    expiredJwt,
-    originalUrl,
-  }: RenewMagicLinkRequestDto): Promise<void> {
-    await this.unauthenticatedHttpClient.renewMagicLink({
-      queryParams: {
-        expiredJwt,
-        originalUrl: encodeURIComponent(originalUrl),
-      },
-    });
   }
 
   public retrieveFromToken$(

--- a/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
@@ -19,7 +19,6 @@ import {
   type MarkPartnersErroredConventionAsHandledRequest,
   type PaginationQueryParams,
   type RenewConventionParams,
-  type RenewMagicLinkRequestDto,
   type SendSignatureLinkRequestDto,
   type ShareLinkByEmailDto,
   sleep,
@@ -138,13 +137,6 @@ export class InMemoryConventionGateway implements ConventionGateway {
     _jwt: ConventionSupportedJwt,
   ): Observable<void> {
     return this.conventionRenewalResult$;
-  }
-
-  public async renewMagicLink(_: RenewMagicLinkRequestDto): Promise<void> {
-    // This is supposed to ask the backend to send a new email to the owner of the expired magic link.
-    // Since this operation makes no sense for local development, the implementation here is left empty.
-    this.simulatedLatency && (await sleep(this.simulatedLatency));
-    throw new Error("500 Not Implemented In InMemory Gateway");
   }
 
   public async retreiveById(id: ConventionId): Promise<ConventionReadDto> {

--- a/front/src/core-logic/ports/AuthGateway.ts
+++ b/front/src/core-logic/ports/AuthGateway.ts
@@ -7,6 +7,7 @@ import type {
   InitiateLoginByEmailParams,
   LogoutQueryParams,
   OAuthSuccessLoginParams,
+  RenewExpiredJwtRequestDto,
   WithUserFilters,
 } from "shared";
 
@@ -23,4 +24,7 @@ export interface AuthGateway {
   confirmLoginByMagicLink$(
     params: OAuthSuccessLoginParams,
   ): Observable<AfterOAuthSuccessRedirectionResponse>;
+  renewExpiredJwt(
+    renewMagicLinkRequestDto: RenewExpiredJwtRequestDto,
+  ): Promise<void>;
 }

--- a/front/src/core-logic/ports/ConventionGateway.ts
+++ b/front/src/core-logic/ports/ConventionGateway.ts
@@ -17,7 +17,6 @@ import type {
   FlatGetConventionsWithErroredBroadcastFeedbackParams,
   MarkPartnersErroredConventionAsHandledRequest,
   RenewConventionParams,
-  RenewMagicLinkRequestDto,
   SendSignatureLinkRequestDto,
   ShareLinkByEmailDto,
   TransferConventionToAgencyRequestDto,
@@ -68,9 +67,7 @@ export interface ConventionGateway {
     params: SendSignatureLinkRequestDto,
     jwt: ConventionSupportedJwt,
   ): Observable<void>;
-  renewMagicLink(
-    renewMagicLinkRequestDto: RenewMagicLinkRequestDto,
-  ): Promise<void>;
+
   renewConvention$(
     params: RenewConventionParams,
     jwt: ConventionSupportedJwt,

--- a/shared/src/apiConsumer/ApiConsumer.ts
+++ b/shared/src/apiConsumer/ApiConsumer.ts
@@ -8,10 +8,6 @@ import type { DateString, DateTimeIsoString } from "../utils/date";
 
 export type ApiConsumerId = Flavor<string, "ApiConsumerId">;
 
-export type ApiConsumerJwtPayload = {
-  id: ApiConsumerId;
-};
-
 export type ApiConsumerName = Flavor<string, "ApiConsumerName">;
 
 export type ApiConsumerKind = (typeof apiConsumerKinds)[number];

--- a/shared/src/auth/auth.routes.ts
+++ b/shared/src/auth/auth.routes.ts
@@ -4,6 +4,7 @@ import { absoluteUrlSchema } from "../AbsoluteUrl";
 import { withUserFiltersSchema } from "../admin/admin.schema";
 import { withAuthorizationHeaders } from "../headers";
 import { httpErrorSchema } from "../httpClient/httpErrors.schema";
+import { renewExpiredJwtRequestSchema } from "../tokens/jwt.schema";
 import {
   connectedUserSchema,
   withOptionalUserIdSchema,
@@ -79,6 +80,16 @@ export const authRoutes = defineRoutes({
     responses: {
       200: absoluteUrlSchema,
       401: httpErrorSchema,
+    },
+  }),
+  renewExpiredJwt: defineRoute({
+    url: "/renew-expired-jwt",
+    method: "post",
+    queryParamsSchema: renewExpiredJwtRequestSchema,
+    responses: {
+      200: expressEmptyResponseBody,
+      400: httpErrorSchema,
+      404: httpErrorSchema,
     },
   }),
 });

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -29,7 +29,6 @@ import type {
 import type { ScheduleDto } from "../schedule/Schedule.dto";
 import type { NumberEmployeesRange, SiretDto } from "../siret/siret";
 import type {
-  AppSupportedJwt,
   expiredMagicLinkErrorMessage,
   unsupportedMagicLinkErrorMessage,
 } from "../tokens/jwt.dto";
@@ -393,11 +392,6 @@ export type GenerateMagicLinkRequestDto = {
   applicationId: ConventionId;
   role: Role;
   expired: boolean;
-};
-
-export type RenewMagicLinkRequestDto = {
-  originalUrl: string;
-  expiredJwt: AppSupportedJwt;
 };
 
 export type RenewMagicLinkResponse = {

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -99,7 +99,6 @@ import {
   type MarkPartnersErroredConventionAsHandledRequest,
   MINI_STAGE_CCI_BENEFICIARY_MINIMUM_AGE_REQUIREMENT,
   type RenewConventionParams,
-  type RenewMagicLinkRequestDto,
   type RenewMagicLinkResponse,
   type SendSignatureLinkRequestDto,
   SIGNATORIES_PHONE_NUMBER_DISTINCT_RELEASE_DATE,
@@ -627,12 +626,6 @@ export const generateMagicLinkRequestSchema: ZodSchemaWithInputMatchingOutput<Ge
       error: localization.invalidEnum,
     }),
     expired: z.boolean(), //< defaults to false
-  });
-
-export const renewMagicLinkRequestSchema: ZodSchemaWithInputMatchingOutput<RenewMagicLinkRequestDto> =
-  z.object({
-    originalUrl: z.string(),
-    expiredJwt: z.string(),
   });
 
 export const renewMagicLinkResponseSchema: ZodSchemaWithInputMatchingOutput<RenewMagicLinkResponse> =

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -752,6 +752,10 @@ export const errors = {
       new ForbiddenError(
         "Le jeton d'authentification (JWT) fourni est invalide.",
       ),
+    unsupportedJwtPayload: () =>
+      new ForbiddenError(
+        "Les données du jeton d'authentification ne sont pas supportés.",
+      ),
     expiredJwt: (expiredDurationText?: string) =>
       new ForbiddenError(authExpiredMessage(expiredDurationText ?? "")),
     notFound: ({ userId }: { userId: UserId }) =>

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -134,6 +134,7 @@ export * from "./sms/smsTemplateByName";
 export * from "./tallyForm";
 export * from "./test.helpers";
 export * from "./tokens/jwt.dto";
+export * from "./tokens/jwt.schema";
 export * from "./tokens/jwt.utils";
 export * from "./tokens/payload.dto";
 export * from "./typeFlavors";

--- a/shared/src/routes/convention.routes.ts
+++ b/shared/src/routes/convention.routes.ts
@@ -15,7 +15,6 @@ import {
   markPartnersErroredConventionAsHandledRequestSchema,
   paginatedConventionReadSchema,
   renewConventionParamsSchema,
-  renewMagicLinkRequestSchema,
   renewMagicLinkResponseSchema,
   sendSignatureLinkRequestSchema,
   transferConventionToAgencyRequestSchema,
@@ -203,16 +202,7 @@ export const unauthenticatedConventionRoutes = defineRoutes({
     requestBodySchema: shareLinkByEmailSchema,
     responses: { 200: expressEmptyResponseBody, 400: httpErrorSchema },
   }),
-  renewMagicLink: defineRoute({
-    url: "/renew-magic-link",
-    method: "get",
-    queryParamsSchema: renewMagicLinkRequestSchema,
-    responses: {
-      200: expressEmptyResponseBody,
-      400: httpErrorSchema,
-      404: httpErrorSchema,
-    },
-  }),
+
   findSimilarConventions: defineRoute({
     url: "/find-similar-immersion",
     method: "get",

--- a/shared/src/tokens/jwt.dto.ts
+++ b/shared/src/tokens/jwt.dto.ts
@@ -27,3 +27,8 @@ export type JwtDto = {
 export const expiredMagicLinkErrorMessage = "Le lien magique est périmé";
 export const unsupportedMagicLinkErrorMessage =
   "Le lien magique est n'est pas valide";
+
+export type RenewExpiredJwtRequestDto = {
+  originalUrl: string;
+  expiredJwt: AppSupportedJwt;
+};

--- a/shared/src/tokens/jwt.schema.ts
+++ b/shared/src/tokens/jwt.schema.ts
@@ -1,0 +1,9 @@
+import z from "zod";
+import type { ZodSchemaWithInputMatchingOutput } from "../zodUtils";
+import type { RenewExpiredJwtRequestDto } from "./jwt.dto";
+
+export const renewExpiredJwtRequestSchema: ZodSchemaWithInputMatchingOutput<RenewExpiredJwtRequestDto> =
+  z.object({
+    originalUrl: z.string(),
+    expiredJwt: z.string(),
+  });

--- a/shared/src/tokens/payload.dto.ts
+++ b/shared/src/tokens/payload.dto.ts
@@ -1,3 +1,4 @@
+import type { ApiConsumerId } from "../apiConsumer/ApiConsumer";
 import type { ConventionId } from "../convention/convention.dto";
 import type { ConventionRole } from "../role/role.dto";
 import type { Flavor } from "../typeFlavors";
@@ -16,22 +17,43 @@ export type JwtPayloads = {
   currentUser?: ConnectedUser;
 };
 
+export type AppSupportedDomainJwtPayload =
+  | ApiConsumerDomainJwtPayload
+  | ConventionDomainJwtPayload
+  | ConnectedUserDomainJwtPayload
+  | EmailAuthCodeDomainJwtPayload;
+
 export type ConnectedUserDomainJwtPayload = { userId: UserId };
 export type ConnectedUserJwtPayload = CommonJwtPayload &
   ConnectedUserDomainJwtPayload;
 
 export type EmailHash = Flavor<string, "EmailHash">;
 
-export type ConventionDomainPayload = {
+export type ConventionDomainJwtPayload = {
   applicationId: ConventionId;
   role: ConventionRole;
   emailHash: EmailHash; //< md5 of email
   sub?: string;
 };
-export type ConventionJwtPayload = CommonJwtPayload & ConventionDomainPayload;
+
+export type ApiConsumerDomainJwtPayload = {
+  id: ApiConsumerId;
+};
+
+// biome-ignore lint/complexity/noBannedTypes: Empty domain payload
+export type EmailAuthCodeDomainJwtPayload = {};
+
+export type EmailAuthCodeJwtPayload = CommonJwtPayload &
+  EmailAuthCodeDomainJwtPayload;
+
+export type ApiConsumerJwtPayload = CommonJwtPayload &
+  ApiConsumerDomainJwtPayload;
+
+export type ConventionJwtPayload = CommonJwtPayload &
+  ConventionDomainJwtPayload;
 
 export type ConventionRelatedJwtPayload =
-  | ConventionDomainPayload
+  | ConventionDomainJwtPayload
   | ConnectedUserDomainJwtPayload;
 
 export type CreateConventionMagicLinkPayloadProperties = {


### PR DESCRIPTION
Prérequis pour faire #4126 

Suive les commits mais en gros:
- Review des DTO de JWT / JWT Payloads / JWT Domain Payloads
- Renommage + déplacement du usecase de renew magic link qui fonctionne que pour les token de convention vers le routeur auth en prévision de supporter le renouvellement des jwt payloads EmailAuthCode + ConnectedUser.