### PR TITLE
#4235 - Ajout des boutons de contact et page d'accueil sur les pages d'erreur (par défaut)

### DIFF
--- a/front/src/app/pages/error/ErrorPage.tsx
+++ b/front/src/app/pages/error/ErrorPage.tsx
@@ -5,7 +5,10 @@ import type {
   ErrorButton,
   FrontErrorProps,
 } from "src/app/contents/error/types";
-import { FrontSpecificError } from "src/app/pages/error/front-errors";
+import {
+  defaultFrontErrorButtons,
+  FrontSpecificError,
+} from "src/app/pages/error/front-errors";
 import { ErrorPageContent } from "./ErrorPageContent";
 
 type ErrorPageProperties = {
@@ -24,7 +27,7 @@ const getPageContentProps = (
   return {
     title: title ?? "Erreur inattendue",
     description: error.message,
-    buttons: buttons ?? [],
+    buttons: buttons ?? defaultFrontErrorButtons,
   };
 };
 

--- a/front/src/app/pages/error/front-errors.tsx
+++ b/front/src/app/pages/error/front-errors.tsx
@@ -44,13 +44,13 @@ export const frontErrors = {
             </p>
           </>
         ),
-        buttons: [HomeButton, ContactUsButton],
+        buttons: defaultFrontErrorButtons,
       }),
     unauthorized: () =>
       new FrontSpecificError({
         title: "Non-autorisé",
         description: "Vous n'êtes pas autorisé à accéder à cette page.",
-        buttons: [HomeButton, ContactUsButton],
+        buttons: defaultFrontErrorButtons,
       }),
   },
   convention: {
@@ -161,3 +161,5 @@ export const ContactUsButton = ({
     </Button>
   );
 };
+
+export const defaultFrontErrorButtons = [HomeButton, ContactUsButton];


### PR DESCRIPTION
<img width="1237" height="507" alt="Capture d’écran 2026-01-15 à 10 24 58" src="https://github.com/user-attachments/assets/aa4630d9-a04c-4b40-a130-16235faff2ff" />

Actuellement, les erreurs inattendues ne proposent pas d'actions pour aider l'utilisateur. Sur d'autres types d'erreur (404, erreurs connues), on le fait et ça aide bien au support. 