### PR TITLE
#4116 - Fix: Afficher la carte LBB quand 0 résultat interne

### DIFF
--- a/front/src/app/components/search/SearchListResults.tsx
+++ b/front/src/app/components/search/SearchListResults.tsx
@@ -57,10 +57,7 @@ export const SearchListResults = ({
   const isSearchWithAppellationAndGeoParams =
     isSearchWithGeoParams && isSearchWithAppellation;
   const shouldShowLaBonneBoiteCTA =
-    !isExternal &&
-    hasResults &&
-    isLastPage &&
-    isSearchWithAppellationAndGeoParams;
+    !isExternal && isLastPage && isSearchWithAppellationAndGeoParams;
   return (
     <div className={fr.cx("fr-container", isExternal && "fr-mb-8w")}>
       <div
@@ -78,7 +75,7 @@ export const SearchListResults = ({
               !hasResults && "fr-grid-row--center",
             )}
           >
-            {!hasResults && (
+            {!hasResults && isExternal && (
               <div
                 className={cx(
                   fr.cx(
@@ -154,7 +151,10 @@ export const SearchListResults = ({
                 );
               })}
             {shouldShowLaBonneBoiteCTA && (
-              <LaBonneBoiteCallToAction searchParams={searchParams} />
+              <LaBonneBoiteCallToAction
+                searchParams={searchParams}
+                hasResults={hasResults}
+              />
             )}
           </div>
         </div>
@@ -283,8 +283,10 @@ const getFilteredSearchParamsForLBB = (
 
 const LaBonneBoiteCallToAction = ({
   searchParams,
+  hasResults,
 }: {
   searchParams: ReturnType<typeof searchSelectors.searchParams>;
+  hasResults: boolean;
 }) => {
   const filteredSearchParams = getFilteredSearchParamsForLBB(searchParams);
   return (
@@ -293,7 +295,11 @@ const LaBonneBoiteCallToAction = ({
         imageUrl={labonneboiteLogoUrl}
         imageAlt="Logo de LaBonneBoite"
         title="Découvrez d'autres entreprises"
-        desc="Explorez plus d'opportunités avec notre partenaire La Bonne Boite"
+        desc={
+          hasResults
+            ? "Explorez plus d'opportunités avec notre partenaire La Bonne Boite"
+            : "Nous n'avons pas trouvé d'entreprises actuellement disponibles sur Immersion Facilitée. Découvrez d'autres opportunités avec notre partenaire La Bonne Boîte"
+        }
         footer={
           <Button
             linkProps={routes.externalSearch(filteredSearchParams).link}


### PR DESCRIPTION
## Contexte

Suite à la PR #4227, la carte La Bonne Boite n'était affichée que lorsqu'il y avait des résultats internes. Ce fix corrige ce comportement pour afficher la carte même quand aucun résultat n'est trouvé sur Immersion Facilitée.

## Travail initial (PR #4227)
- Suppression du tag "Entreprise accueillante"
- Masquage de la mini-carte quand pas de résultats
- Ajout du CTA La Bonne Boite en dernière position sur la page finale
- Suppression de la sidebar LBB (ExternalResultsPush)

## Ce fix
- Affiche la carte LBB même quand 0 résultat interne (au lieu de ne rien afficher)
- Limite le bloc "Aucun résultat" aux recherches externes uniquement
- Adapte le message de la carte LBB selon le contexte:
  - Avec résultats: "Explorez plus d'opportunités avec notre partenaire La Bonne Boite"
  - Sans résultats: "Nous n'avons pas trouvé d'entreprise référencée sur Immersion Facilitée. Découvrez d'autres opportunités avec notre partenaire La Bonne Boite"

## Comportements après modification

| Contexte | hasResults | isExternal | Affichage |
|----------|------------|------------|-----------|
| Recherche interne, résultats | ✅ | ❌ | Carte LBB message standard |
| Recherche interne, 0 résultat | ❌ | ❌ | Carte LBB message "Nous n'avons pas trouvé..." |
| Page LBB, résultats | ✅ | ✅ | Pas de carte LBB |
| Page LBB, 0 résultat | ❌ | ✅ | Message "Aucun résultat..." |


<img width="1326" height="1200" alt="image" src="https://github.com/user-attachments/assets/6441d878-cd52-433b-89af-a8088b5c56ff" />
