### PR TITLE
Tech - Log des identifiants utilisateurs et consommateurs API au niveau des fonctionnalités en succès ou en erreur

### DIFF
--- a/back/src/domains/core/UseCase.ts
+++ b/back/src/domains/core/UseCase.ts
@@ -39,10 +39,10 @@ export abstract class UseCase<
         logger,
         useCaseName,
       }),
-      payload: payload,
-      cb: ({ useCaseName, validInput, payload }) =>
+      identityPayload: payload,
+      cb: ({ useCaseName, validInput, identityPayload }) =>
         Sentry.startSpan({ name: useCaseName }, () =>
-          this._execute(validInput, payload),
+          this._execute(validInput, identityPayload),
         ),
     });
   }
@@ -77,11 +77,11 @@ export abstract class TransactionalUseCase<
         inputSchema: this.inputSchema,
         logger,
       }),
-      payload,
-      cb: ({ useCaseName, validInput, payload }) =>
+      identityPayload: payload,
+      cb: ({ useCaseName, validInput, identityPayload }) =>
         this.uowPerformer.perform((uow) =>
           Sentry.startSpan({ name: useCaseName }, () =>
-            this._execute(validInput, uow, payload),
+            this._execute(validInput, uow, identityPayload),
           ),
         ),
     });

--- a/back/src/domains/core/useCaseBuilder.ts
+++ b/back/src/domains/core/useCaseBuilder.ts
@@ -111,12 +111,12 @@ export const useCaseBuilder = <
           input: input,
           logger,
         }),
-        payload,
-        cb: ({ useCaseName, validInput, payload }) => {
+        identityPayload: payload,
+        cb: ({ useCaseName, validInput, identityPayload }) => {
           const commonCbParams = {
             inputParams: validInput,
             deps: (config as any).deps,
-            currentUser: payload,
+            currentUser: identityPayload,
           };
 
           return options.isTransactional

--- a/back/src/utils/logger.ts
+++ b/back/src/utils/logger.ts
@@ -6,6 +6,7 @@ import pino, { type Logger, type LoggerOptions } from "pino";
 import { complement, isNil, pickBy } from "ramda";
 import type {
   AgencyId,
+  ApiConsumerId,
   ConventionId,
   FtExternalId,
   LegacySearchQueryParamsDto,
@@ -146,6 +147,7 @@ type LoggerParams = Partial<{
   topic: DomainTopic;
   useCaseName: string;
   userId: UserId;
+  apiConsumerId: ApiConsumerId;
 }>;
 
 export type OpacifiedLogger = {
@@ -219,6 +221,7 @@ export const createLogger = (filename: string): OpacifiedLogger => {
       reportTitle,
       sqlQuery,
       userId,
+      apiConsumerId,
       ...rest
     }) => {
       const _noValuesForgotten: Record<string, never> = rest;
@@ -258,6 +261,7 @@ export const createLogger = (filename: string): OpacifiedLogger => {
         cacheKey,
         crispTicket,
         userId,
+        apiConsumerId,
       };
 
       const opacifiedWithoutNullOrUndefined = pickBy(


### PR DESCRIPTION
Le précédent travail pour ajouter les ids dans les logs n'était pas complet.
Il ne prenait pas tout les type de payload d'identité et on n'ajoutait pas en cas de succès.

Grâce à cette PR,

On va pouvoir suivre les usages par utilisateurs :
- usage en succès ou en erreur
- tout type de payload hors usage non connecté ou avec un payload de convention à savoir : UserId & ApiConsumerId