### PR TITLE
FIX - stockages de données sur les recherches qui ont été perdu lors du passage en V3

### DIFF
--- a/back/src/domains/establishment/use-cases/GetOffers.ts
+++ b/back/src/domains/establishment/use-cases/GetOffers.ts
@@ -75,7 +75,7 @@ export const makeGetOffers = useCaseBuilder("GetOffers")
       establishmentSearchableBy: searchableBy,
       sortedBy: inputParams.sortBy,
       place,
-      ...validatedGeoParams,
+      ...(validatedGeoParams.geoParams ?? {}),
     };
 
     await uow.searchMadeRepository.insertSearchMade({
@@ -83,6 +83,7 @@ export const makeGetOffers = useCaseBuilder("GetOffers")
       id: deps.uuidGenerator.new(),
       needsToBeSearched: true, // this is useless (legacy TODO : remove this column)
       numberOfResults: result.pagination.totalRecords,
+      apiConsumerName: apiConsumer?.name,
     });
 
     return result;

--- a/shared/src/search/SearchQueryParams.schema.ts
+++ b/shared/src/search/SearchQueryParams.schema.ts
@@ -114,6 +114,7 @@ export const getOffersFlatParamsSchema: z.ZodType<
         error: localization.invalidEnum,
       })
       .optional(),
+    place: z.string().optional(),
   })
   .and(paginationQueryParamsSchema)
   .and(geoParamsAndSortSchema)


### PR DESCRIPTION
## Summary

- Fix GPS coordinates (lat, lon, distanceKm) not being stored in `searches_made` table when using GetOffers use case
- Fix `place` (address) field not being stored (was missing from Zod schema)
- Fix `apiConsumerName` not being stored for V3 API consumers

## Root Causes

| Issue | Root Cause | Fix |
|-------|-----------|-----|
| GPS coords not stored | `getValidatedGeoParams` returns nested `{ geoParams: {...} }` but `SearchMade` expects flat `{ lat, lon, distanceKm }` | Flatten with `...(validatedGeoParams.geoParams ?? {})` |
| `place` not stored | `place` field missing from `getOffersFlatParamsSchema` Zod schema | Add `place: z.string().optional()` to schema |
| `apiConsumerName` not stored | Never passed to `insertSearchMade` in GetOffers (V3 API) | Pass `apiConsumerName: apiConsumer?.name` |

Note: V2 API (`/v2/search`) uses `legacySearchImmersion` which already handled these correctly. This fix is specifically for V3 API (`/v3/offers`) and the public `/offers` endpoint.

## Changes

- `shared/src/search/SearchQueryParams.schema.ts` - Add `place` field to schema
- `back/src/domains/establishment/use-cases/GetOffers.ts` - Flatten geo params + add apiConsumerName
- `back/src/domains/establishment/use-cases/GetOffers.unit.test.ts` - Add unit tests
- `back/src/adapters/primary/routers/apiKeyAuthRouter/getOffersV3.e2e.test.ts` - Add e2e tests for V3 API