### PR TITLE
#4114 (partiel) - ajout d'un petit encart pour pousser les bénéficaires à indiquer une date de naissance correct

### DIFF
--- a/front/src/app/contents/forms/convention/formConvention.tsx
+++ b/front/src/app/contents/forms/convention/formConvention.tsx
@@ -267,6 +267,8 @@ const beneficiarySection = (internshipKind: InternshipKind) => ({
   },
   "signatories.beneficiary.birthdate": {
     label: "Date de naissance du candidat",
+    hintText:
+      "Merci d’indiquer la vraie date de naissance. Cette information est indispensable pour identifier la personne en immersion et traiter la convention. Une erreur ou une date volontairement différente peut empêcher la validation de la convention.",
     id: beneficiarySectionIds.birthdate,
     required: true,
   },


### PR DESCRIPTION
Voilà  :
<img width="864" height="167" alt="image" src="https://github.com/user-attachments/assets/e940f335-13f7-4c09-821d-8ad968cf76fd" />
