### PR TITLE
#4318 - Ajout encart info dans email clôture MER bénéficiaire

### DIFF
--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1136,6 +1136,11 @@ Tél : ${beneficiaryPhone}`,
             url: searchPageUrl,
           },
         ],
+        highlight: {
+          kind: "info",
+          content:
+            "Si vous avez signé une convention avec l'entreprise entre-temps, vous pouvez ne pas tenir compte de ce message.",
+        },
         subContent: `
         N'hésitez pas à nous contacter si vous avez des questions.
 


### PR DESCRIPTION
## Summary

- Ajout d'un encart info (`highlight`) dans l'email de clôture automatique MER (`DISCUSSION_DEPRECATED_NOTIFICATION_BENEFICIARY`)
- Message : « Si vous avez signé une convention avec l'entreprise entre-temps, vous pouvez ne pas tenir compte de ce message. »

Closes #4318

## Test plan

- [x] Vérifier le rendu de l'email avec l'encart info via le preview email
- [x] Vérifier que l'encart est bien positionné entre les boutons et le footer

<img width="692" height="864" alt="image" src="https://github.com/user-attachments/assets/bbb1d73e-72cf-4fc4-bb7a-24d5bab59f70" />
