### PR TITLE
#4445 - Fix - Correction de l'erreur lors du double-envoi du bilan d'immersion (erreur dans les prod errors)

### DIFF
--- a/back/src/domains/convention/adapters/PgAssessmentRepository.ts
+++ b/back/src/domains/convention/adapters/PgAssessmentRepository.ts
@@ -131,6 +131,9 @@ export class PgAssessmentRepository implements AssessmentRepository {
             conventionId: assessmentEntity.conventionId,
           });
 
+        if (error?.message.includes(assessmentAlreadyExistsErrorMessage))
+          throw errors.assessment.alreadyExist(assessmentEntity.conventionId);
+
         throw error;
       });
   }
@@ -138,3 +141,6 @@ export class PgAssessmentRepository implements AssessmentRepository {
 
 const noConventionMatchingErrorMessage =
   '"immersion_assessments" violates foreign key constraint "immersion_assessments_convention_id_fkey"';
+
+const assessmentAlreadyExistsErrorMessage =
+  '"immersion_assessments" violates unique constraint "immersion_assessments_pkey"';

--- a/front/src/app/components/forms/assessment/AssessmentForm.tsx
+++ b/front/src/app/components/forms/assessment/AssessmentForm.tsx
@@ -37,7 +37,9 @@ import { Feedback } from "src/app/components/feedback/Feedback";
 import { ImmersionDescription } from "src/app/components/forms/assessment/ImmersionDescription";
 import { printWeekSchedule } from "src/app/contents/convention/conventionSummary.helpers";
 import { makeFieldError } from "src/app/hooks/formContents.hooks";
+import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { commonIllustrations } from "src/assets/img/illustrations";
+import { assessmentSelectors } from "src/core-logic/domain/assessment/assessment.selectors";
 import { assessmentSlice } from "src/core-logic/domain/assessment/assessment.slice";
 import { match } from "ts-pattern";
 
@@ -503,6 +505,7 @@ const AssessmentCommentsSection = ({
   jobTitle: string;
   objective: string;
 }) => {
+  const isLoading = useAppSelector(assessmentSelectors.isLoading);
   const { register, formState } = useFormContext<AssessmentDto>();
   const getFieldError = makeFieldError(formState);
   return (
@@ -551,6 +554,7 @@ const AssessmentCommentsSection = ({
               type: "submit",
               priority: "primary",
               id: domElementIds.assessment.formSubmitButton,
+              disabled: isLoading,
             },
           ]}
         />


### PR DESCRIPTION
Fixes #4445

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

- Côté front : le bouton de soumission du bilan est désactivé pendant le chargement (évite double-clic)
- Côté back : l'erreur de clé primaire dupliquée est interceptée et retournée comme erreur métier explicite