### PR TITLE
#4449 - Optimisation de la requête de récupération des retours de diffusion en erreur

### DIFF
--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
@@ -22,7 +22,7 @@ export class PgBroadcastFeedbacksRepository
       .with("latest_feedback", (qb) =>
         qb
           .selectFrom("broadcast_feedbacks as bf")
-          .where(sql`bf.request_params ->> 'conventionId'`, "=", id)
+          .where(sql`(bf.request_params ->> 'conventionId')::uuid`, "=", id)
           .select([
             "bf.consumer_id as consumerId",
             "bf.consumer_name as consumerName",
@@ -69,7 +69,7 @@ export class PgBroadcastFeedbacksRepository
     const result = await this.transaction
       .updateTable("broadcast_feedbacks")
       .set({ handled_by_agency: true })
-      .where(sql`(request_params ->> 'conventionId')`, "=", conventionId)
+      .where(sql`(request_params ->> 'conventionId')::uuid`, "=", conventionId)
       .where("handled_by_agency", "=", false)
       .executeTakeFirst();
 


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Cast `conventionId` en `::uuid` dans les requêtes `broadcast_feedbacks` pour matcher l'index existant et éviter un Seq Scan sur ~2.4M lignes.

Fixes #4449