### PR TITLE
#4588 - Ajouter les tables groups et groups_sirets au metabase v2

### DIFF
--- a/bi/dbt_project.yml
+++ b/bi/dbt_project.yml
@@ -37,6 +37,8 @@ on-run-end:
   - "ANALYZE public_analytics.establishment_users"
   - "ANALYZE public_analytics.agencies"
   - "ANALYZE public_analytics.discussion_with_number_of_exchanges"
+  - "ANALYZE public_analytics.groups"
+  - "ANALYZE public_analytics.groups_sirets"
 
 models:
   immersion_bi:

--- a/bi/models/groups/groups.sql
+++ b/bi/models/groups/groups.sql
@@ -1,0 +1,18 @@
+{{
+  config(
+    materialized='table',
+    schema='analytics'
+  )
+}}
+
+select
+    slug,
+    created_at,
+    updated_at,
+    name,
+    hero_header_title,
+    hero_header_description,
+    hero_header_logo_url,
+    hero_header_background_color,
+    tint_color
+from {{ source('immersion', 'groups') }}

--- a/bi/models/groups/groups_sirets.sql
+++ b/bi/models/groups/groups_sirets.sql
@@ -1,0 +1,11 @@
+{{
+  config(
+    materialized='table',
+    schema='analytics'
+  )
+}}
+
+select
+    group_slug,
+    siret::text as siret
+from {{ source('immersion', 'groups__sirets') }}

--- a/bi/models/groups/schema.yml
+++ b/bi/models/groups/schema.yml
@@ -1,0 +1,39 @@
+version: 2
+
+models:
+  - name: groups
+    description: "Groups information - one row per group slug"
+    columns:
+      - name: slug
+        description: "Primary key - URL slug"
+        tests:
+          - unique
+          - not_null
+      - name: created_at
+        description: "Timestamp when created"
+      - name: updated_at
+        description: "Timestamp when updated"
+      - name: name
+        description: "Name of the group"
+      - name: hero_header_title
+        description: "Hero header title"
+      - name: hero_header_description
+        description: "Hero header description"
+      - name: hero_header_logo_url
+        description: "URL of hero header logo"
+      - name: hero_header_background_color
+        description: "Background color of hero header"
+      - name: tint_color
+        description: "Tint color"
+
+  - name: groups_sirets
+    description: "Relationship between groups and SIRETs - one row per (group_slug, siret)"
+    columns:
+      - name: group_slug
+        description: "Foreign key to groups table"
+        tests:
+          - not_null
+      - name: siret
+        description: "SIRET number"
+        tests:
+          - not_null


### PR DESCRIPTION
Fixes #4588

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Ajout de 2 modèles DBT bruts (sans transformation) pour exposer les tables `groups` et `groups__sirets` dans le schema analytics du metabase v2.