### PR TITLE
#4580 - Wording plus rassurant sur l'écran d'expiration du lien de connexion

### DIFF
--- a/front/src/app/components/auth/RenewExpiredJwtButton.tsx
+++ b/front/src/app/components/auth/RenewExpiredJwtButton.tsx
@@ -58,7 +58,9 @@ export const RenewExpiredJwtButton = ({
         id: domElementIds.magicLinkRenewal.renewalButton,
       }}
     >
-      Demander un nouveau lien
+      {renewExpiredJwtFeedback?.level === "success"
+        ? "Nouveau lien envoyé"
+        : "Demander un nouveau lien"}
     </Button>
   );
 };

--- a/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
+++ b/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
@@ -1,16 +1,13 @@
 import { useDispatch } from "react-redux";
 import {
-  authExpiredMessage,
-  expiredJwtErrorTitle,
   getJwtExpiredSinceInSeconds,
   handleJWTStringPossiblyContainingJsonError,
-  oneMinuteInSeconds,
 } from "shared";
 import { RenewExpiredJwtButton } from "src/app/components/auth/RenewExpiredJwtButton";
 import { FullPageFeedback } from "src/app/components/feedback/FullpageFeedback";
 import { WithFeedbackReplacer } from "src/app/components/feedback/WithFeedbackReplacer";
 import { ErrorPage } from "src/app/pages/error/ErrorPage";
-import { ContactUsButton } from "src/app/pages/error/front-errors";
+import { ContactUsButton, frontErrors } from "src/app/pages/error/front-errors";
 import { type routes, useRoute } from "src/app/routes/routes";
 import { loginIllustration } from "src/assets/img/illustrations";
 import { authSlice } from "src/core-logic/domain/auth/auth.slice";
@@ -33,26 +30,7 @@ export const MagicLinkInterstitialPage = () => {
   );
 
   if (expiredSinceSeconds) {
-    const expiredMessage = authExpiredMessage(
-      Math.ceil(expiredSinceSeconds / oneMinuteInSeconds),
-    );
-    return (
-      <ErrorPage
-        title={expiredJwtErrorTitle}
-        buttons={[
-          RenewJwtButton,
-          <ContactUsButton
-            key={"contact-us-button"}
-            errorMessage={expiredMessage}
-          />,
-        ]}
-        error={{
-          message: expiredMessage,
-          name: "Erreur de connexion",
-        }}
-        feedbackTopic={feedbackTopic}
-      />
-    );
+    throw frontErrors.auth.expiredJwt({ RenewJwtButton });
   }
 
   return (

--- a/front/src/app/pages/error/front-errors.tsx
+++ b/front/src/app/pages/error/front-errors.tsx
@@ -1,8 +1,10 @@
 import Button from "@codegouvfr/react-dsfr/Button";
+import type { ReactElement } from "react";
 import {
   type ConventionId,
   domElementIds,
   type Email,
+  expiredJwtErrorTitle,
   immersionFacileContactEmail,
   type SiretDto,
 } from "shared";
@@ -23,6 +25,31 @@ export class FrontSpecificError extends Error {
 }
 
 export const frontErrors = {
+  auth: {
+    expiredJwt: ({ RenewJwtButton }: { RenewJwtButton: ReactElement }) =>
+      new FrontSpecificError({
+        title: expiredJwtErrorTitle,
+        description: (
+          <>
+            <p>
+              Pour des raisons de sécurité, les liens de connexion sont valables
+              pendant une durée limitée.
+            </p>
+            <p>
+              Vous pouvez demander un nouveau lien ci-dessous. Il vous sera
+              envoyé par email dans les 2 à 3 minutes.
+            </p>
+            <p>
+              Vous n'avez pas reçu le lien ?{" "}
+              <a href={`mailto:${immersionFacileContactEmail}`}>
+                Contactez-nous
+              </a>
+            </p>
+          </>
+        ),
+        buttons: [RenewJwtButton],
+      }),
+  },
   generic: {
     pageNotFound: () =>
       new FrontSpecificError({

--- a/shared/src/tokens/jwt.dto.ts
+++ b/shared/src/tokens/jwt.dto.ts
@@ -25,7 +25,7 @@ export type JwtDto = {
   jwt: AppSupportedJwt;
 };
 
-export const expiredJwtErrorTitle = "Erreur lors du renouvellement de lien";
+export const expiredJwtErrorTitle = "Votre lien de connexion a expiré";
 export const expiredJwtErrorMessage = "Le lien magique est périmé";
 export const unsupportedMagicLinkErrorMessage =
   "Le lien magique est n'est pas valide";


### PR DESCRIPTION
Fixes #4580

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->