### PR TITLE
#4314 - Suppression de l'info du rome dans le récap de recherche

### DIFF
--- a/front/src/app/pages/search/SearchPage.tsx
+++ b/front/src/app/pages/search/SearchPage.tsx
@@ -855,17 +855,13 @@ export const SearchPage = ({
                             routeParams.appellations.length > 0 && (
                               <span className={cx(fr.cx("fr-text--xs"))}>
                                 pour la recherche{" "}
-                                <strong className={fr.cx("fr-text--bold")}>
-                                  {routeParams.appellations[0].appellationLabel}
-                                </strong>
-                                , étendue au secteur{" "}
                                 <a
                                   href={`https://candidat.francetravail.fr/metierscope/fiche-metier/${routeParams.appellations[0].romeCode}`}
                                   target="_blank"
                                   className={fr.cx("fr-text--bold")}
                                   rel="noreferrer"
                                 >
-                                  {routeParams.appellations[0].romeLabel}
+                                  {routeParams.appellations[0].appellationLabel}
                                 </a>
                               </span>
                             )}


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant