### PR TITLE
#4643 - renouvellement clé consommateur API - résoudre le problème de date IAT vs date renouvelée en DB

### DIFF
--- a/back/src/adapters/primary/routers/admin/createAdminRouter.ts
+++ b/back/src/adapters/primary/routers/admin/createAdminRouter.ts
@@ -161,7 +161,7 @@ export const createAdminRouter = (deps: AppDependencies): Router => {
       sendHttpResponse(req, res, () =>
         deps.useCases.renewApiConsumerKey.execute(
           req.params.consumerId,
-          req.payloads?.currentUser,
+          getGenericAuthOrThrow(req.payloads?.currentUser),
         ),
       ),
   );

--- a/back/src/domains/core/api-consumer/use-cases/RenewApiConsumerKey.ts
+++ b/back/src/domains/core/api-consumer/use-cases/RenewApiConsumerKey.ts
@@ -1,3 +1,4 @@
+import { setMilliseconds } from "date-fns";
 import {
   type ApiConsumerId,
   type ApiConsumerJwt,
@@ -21,7 +22,7 @@ export type RenewApiConsumerKey = ReturnType<typeof makeRenewApiConsumerKey>;
 export const makeRenewApiConsumerKey = useCaseBuilder("RenewApiConsumerKey")
   .withInput<ApiConsumerId>(apiConsumerIdSchema)
   .withOutput<ApiConsumerJwt>()
-  .withCurrentUser<ConnectedUser | undefined>()
+  .withCurrentUser<ConnectedUser>()
   .withDeps<Deps>()
   .build(async ({ inputParams: consumerId, uow, currentUser, deps }) => {
     throwIfNotAdmin(currentUser);
@@ -32,29 +33,27 @@ export const makeRenewApiConsumerKey = useCaseBuilder("RenewApiConsumerKey")
     if (!existingApiConsumer)
       throw errors.apiConsumer.notFound({ id: consumerId });
 
-    const now = deps.timeGateway.now();
-    const newKeyIssuedAt = now.toISOString();
+    const now = setMilliseconds(deps.timeGateway.now(), 0);
 
-    const updatedApiConsumer = {
-      ...existingApiConsumer,
-      currentKeyIssuedAt: newKeyIssuedAt,
-      revokedAt: null,
-    };
-
-    await uow.apiConsumerRepository.save(updatedApiConsumer);
-
-    await uow.outboxRepository.save(
-      deps.createNewEvent({
-        topic: "ApiConsumerKeyRenewed",
-        payload: {
-          consumerId,
-          triggeredBy: {
-            kind: "connected-user",
-            userId: currentUser!.id,
-          },
-        },
+    await Promise.all([
+      uow.apiConsumerRepository.save({
+        ...existingApiConsumer,
+        currentKeyIssuedAt: now.toISOString(),
+        revokedAt: null,
       }),
-    );
+      uow.outboxRepository.save(
+        deps.createNewEvent({
+          topic: "ApiConsumerKeyRenewed",
+          payload: {
+            consumerId,
+            triggeredBy: {
+              kind: "connected-user",
+              userId: currentUser.id,
+            },
+          },
+        }),
+      ),
+    ]);
 
     return deps.generateApiConsumerJwt({
       id: consumerId,

--- a/back/src/domains/core/api-consumer/use-cases/RenewApiConsumerKey.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/RenewApiConsumerKey.unit.test.ts
@@ -1,3 +1,4 @@
+import { setMilliseconds } from "date-fns";
 import {
   ConnectedUserBuilder,
   errors,
@@ -114,18 +115,6 @@ describe("RenewApiConsumerKey", () => {
   });
 
   describe("Wrong paths", () => {
-    it("throws UnauthorizedError without JWT payload", async () => {
-      await expectPromiseToFailWithError(
-        renewApiConsumerKey.execute(
-          authorizedUnJeuneUneSolutionApiConsumer.id,
-          undefined,
-        ),
-        errors.user.unauthorized(),
-      );
-
-      expectToEqual(uow.outboxRepository.events, []);
-    });
-
     it("throws ForbiddenError if user is not admin", async () => {
       await expectPromiseToFailWithError(
         renewApiConsumerKey.execute(
@@ -153,7 +142,7 @@ describe("RenewApiConsumerKey", () => {
   describe("Reactivation of revoked consumer", () => {
     it("reactivates a revoked consumer by clearing revokedAt and generating new key", async () => {
       const revokedAt = "2024-01-10T00:00:00.000Z";
-      const now = new Date("2024-01-15T10:00:00.000Z");
+      const now = new Date("2024-01-15T10:00:00.350");
       const eventId = "event-id-3333-3333-3333-333333333333";
       timeGateway.setNextDates([now, now]);
       uuidGenerator.setNextUuids([eventId]);
@@ -174,14 +163,14 @@ describe("RenewApiConsumerKey", () => {
         generateApiConsumerJwtTestFn({
           id: revokedConsumer.id,
           version: 1,
-          iat: now.getTime() / 1000,
+          iat: setMilliseconds(now, 0).getTime() / 1000,
         }),
       );
 
       expectToEqual(uow.apiConsumerRepository.consumers, [
         {
           ...revokedConsumer,
-          currentKeyIssuedAt: now.toISOString(),
+          currentKeyIssuedAt: setMilliseconds(now, 0).toISOString(),
           revokedAt: null,
         },
       ]);


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

N/A
