### PR TITLE
#3885 - Fix Récupérer seulement les conventions > 2026 ayant des bilans non complétés / sans signature après le 2026-03-10

### DIFF
--- a/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
@@ -1,5 +1,7 @@
+import { addDays } from "date-fns";
 import {
   AgencyDtoBuilder,
+  ASSESSEMENT_SIGNATURE_RELEASE_DATE,
   type AuthenticatedConventionRoutes,
   authExpiredMessage,
   authenticatedConventionRoutes,
@@ -268,9 +270,13 @@ describe("authenticatedConventionRoutes", () => {
   });
 
   describe("GetConventionsForAgencyUser", () => {
+    const assessmentCreatedAt = addDays(
+      ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+      2,
+    ).toISOString();
     const peAgency = new AgencyDtoBuilder().withKind("pole-emploi").build();
 
-    const convention1 = new ConventionDtoBuilder()
+    const conventionWithAssessment = new ConventionDtoBuilder()
       .withId("aaaaac99-9c0b-1bbb-bb6d-6bb9bd38aaaa")
       .withAgencyId(peAgency.id)
       .withDateStart(new Date("2023-03-15").toISOString())
@@ -279,7 +285,7 @@ describe("authenticatedConventionRoutes", () => {
       .withStatus("ACCEPTED_BY_VALIDATOR")
       .build();
 
-    const convention2 = new ConventionDtoBuilder()
+    const conventionWithoutAssessment = new ConventionDtoBuilder()
       .withId("bbbbbc99-9c0b-1bbb-bb6d-6bb9bd38bbbb")
       .withAgencyId(peAgency.id)
       .withDateStart(new Date("2023-02-15").toISOString())
@@ -295,12 +301,12 @@ describe("authenticatedConventionRoutes", () => {
         }),
       ];
       inMemoryUow.conventionRepository.setConventions([
-        convention1,
-        convention2,
+        conventionWithAssessment,
+        conventionWithoutAssessment,
       ]);
       inMemoryUow.assessmentRepository.assessments = [
         {
-          conventionId: convention1.id,
+          conventionId: conventionWithAssessment.id,
           status: "COMPLETED",
           endedWithAJob: false,
           establishmentFeedback: "Ca c'est bien passé",
@@ -308,8 +314,8 @@ describe("authenticatedConventionRoutes", () => {
           numberOfHoursActuallyMade: 35,
           beneficiaryAgreement: true,
           beneficiaryFeedback: "Mon commentaire",
-          signedAt: new Date("2025-01-01").toISOString(),
-          createdAt: new Date("2025-01-01").toISOString(),
+          signedAt: assessmentCreatedAt,
+          createdAt: assessmentCreatedAt,
           _entityName: "Assessment",
         },
       ];
@@ -361,18 +367,18 @@ describe("authenticatedConventionRoutes", () => {
       };
 
       const conventionRead1 = {
-        ...convention1,
+        ...conventionWithAssessment,
         ...agencyFields,
         assessment: {
           status: "COMPLETED" as const,
           endedWithAJob: false,
-          signedAt: new Date("2025-01-01").toISOString(),
-          createdAt: new Date("2025-01-01").toISOString(),
+          signedAt: assessmentCreatedAt,
+          createdAt: assessmentCreatedAt,
         },
       };
 
       const conventionRead2 = {
-        ...convention2,
+        ...conventionWithoutAssessment,
         ...agencyFields,
         assessment: null,
       };
@@ -439,13 +445,13 @@ describe("authenticatedConventionRoutes", () => {
       };
 
       const conventionRead1 = {
-        ...convention1,
+        ...conventionWithAssessment,
         ...agencyFields,
         assessment: {
           status: "COMPLETED" as const,
           endedWithAJob: false,
-          signedAt: new Date("2025-01-01").toISOString(),
-          createdAt: new Date("2025-01-01").toISOString(),
+          signedAt: assessmentCreatedAt,
+          createdAt: assessmentCreatedAt,
         },
       };
 
@@ -559,18 +565,18 @@ describe("authenticatedConventionRoutes", () => {
       };
 
       const conventionRead1 = {
-        ...convention1,
+        ...conventionWithAssessment,
         ...agencyFields,
         assessment: {
           status: "COMPLETED" as const,
           endedWithAJob: false,
-          signedAt: new Date("2025-01-01").toISOString(),
-          createdAt: new Date("2025-01-01").toISOString(),
+          signedAt: assessmentCreatedAt,
+          createdAt: assessmentCreatedAt,
         },
       };
 
       const conventionRead2 = {
-        ...convention2,
+        ...conventionWithoutAssessment,
         ...agencyFields,
         assessment: null,
       };

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -1,7 +1,8 @@
-import { isBefore } from "date-fns";
+import { addDays, isAfter, isBefore } from "date-fns";
 import { propEq, toPairs } from "ramda";
 import {
   type AgencyId,
+  ASSESSEMENT_SIGNATURE_RELEASE_DATE,
   type ConventionDto,
   type ConventionId,
   type ConventionReadDto,
@@ -481,34 +482,48 @@ const makeApplyAssessmentCompletionStatusFilterConventionsRead =
       return true;
     if (convention.status !== "ACCEPTED_BY_VALIDATOR") return false;
 
-    const hasCompletedMaybeSignedFilter =
-      assessmentCompletionStatus.includes("finalized");
+    const hasFinalizedFilter = assessmentCompletionStatus.includes("finalized");
     const hasToSignFilter = assessmentCompletionStatus.includes("to-sign");
     const hasToBeCompletedFilter =
       assessmentCompletionStatus.includes("to-complete");
 
-    const hasAssessment =
+    if (hasFinalizedFilter && hasToSignFilter && hasToBeCompletedFilter)
+      return true;
+
+    const isNotLegacyAssessment =
       convention.assessment !== null &&
       convention.assessment.status !== "FINISHED" &&
       convention.assessment.status !== "ABANDONED";
 
     const assessment = convention.assessment;
-    const isAssessmentCompletedAndMaybeSigned =
-      hasAssessment &&
+    const isAssessementAfterSignatureRelease =
+      assessment !== null &&
+      isAfter(
+        new Date(assessment.createdAt),
+        addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+      );
+    const isAssessmentSigned =
       assessment !== null &&
       "signedAt" in assessment &&
-      (assessment.status === "DID_NOT_SHOW" || assessment.signedAt !== null);
+      assessment.signedAt !== null;
+
+    const isAssessmentFinalized =
+      isNotLegacyAssessment &&
+      assessment !== null &&
+      ((isAssessmentSigned && isAssessementAfterSignatureRelease) ||
+        assessment.status === "DID_NOT_SHOW" ||
+        !isAssessementAfterSignatureRelease);
 
     const isAssessmentToSign =
-      hasAssessment &&
+      isNotLegacyAssessment &&
       assessment !== null &&
-      "signedAt" in assessment &&
-      assessment.signedAt === null &&
+      !isAssessmentSigned &&
+      isAssessementAfterSignatureRelease &&
       assessment.status !== "DID_NOT_SHOW";
     const isAssessmentToBeCompleted = convention.assessment === null;
 
     return (
-      (hasCompletedMaybeSignedFilter && isAssessmentCompletedAndMaybeSigned) ||
+      (hasFinalizedFilter && isAssessmentFinalized) ||
       (hasToSignFilter && isAssessmentToSign) ||
       (hasToBeCompletedFilter && isAssessmentToBeCompleted)
     );

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1,4 +1,4 @@
-import { addDays, subDays } from "date-fns";
+import { addDays, subDays, subMonths } from "date-fns";
 import { sql } from "kysely";
 import type { Pool } from "pg";
 import {
@@ -1111,6 +1111,9 @@ describe("Pg implementation of ConventionQueries", () => {
 
     const completedAssessment = new AssessmentDtoBuilder()
       .withConventionId(conventionC.id)
+      .withCreatedAt(
+        addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 2).toISOString(),
+      )
       .build();
 
     const agencyFields = {
@@ -1446,196 +1449,382 @@ describe("Pg implementation of ConventionQueries", () => {
       ]);
     });
 
-    it(`should filter conventions by assessment completion status - completed and after ${ASSESSEMENT_SIGNATURE_RELEASE_DATE}`, async () => {
-      const conventionWithOldAssessment: ConventionDto = {
-        ...conventionB,
-        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
-        status: "ACCEPTED_BY_VALIDATOR",
-      };
-      const oldAssessment: AssessmentDto = {
-        ...completedAssessment,
-        conventionId: conventionWithOldAssessment.id,
-        createdAt: ASSESSEMENT_SIGNATURE_RELEASE_DATE.toISOString(),
-      };
-      await conventionRepository.save(conventionWithOldAssessment);
-      await assessmentRepo.save(
-        createAssessmentEntity(oldAssessment, conventionWithOldAssessment),
-      );
+    describe("assessment completion status filter", () => {
+      describe("assessment filter is 'finalized'", () => {
+        it(`should return old convention with assessment created before ${ASSESSEMENT_SIGNATURE_RELEASE_DATE.toISOString()}`, async () => {
+          const oldAssessmentCreatedAt = subMonths(
+            ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+            1,
+          ).toISOString();
 
-      const result =
-        await conventionQueries.getPaginatedConventionsForAgencyUser({
-          agencyUserId: validator.id,
-          pagination: { page: 1, perPage: 10 },
-          filters: { assessmentCompletionStatus: ["to-sign"] },
-          sort: {
-            by: "dateSubmission",
-            direction: "desc",
-          },
-        });
+          const conventionWithOldAssessment: ConventionDto = {
+            ...conventionB,
+            id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+            status: "ACCEPTED_BY_VALIDATOR",
+          };
 
-      expectToEqual(result.data, [
-        {
-          ...conventionC,
-          ...agencyFields,
-          assessment: {
-            status: "COMPLETED",
-            endedWithAJob: false,
+          const oldAssessmentWithoutSignature: AssessmentDto = {
+            ...completedAssessment,
+            conventionId: conventionWithOldAssessment.id,
+            createdAt: oldAssessmentCreatedAt,
             signedAt: null,
-            createdAt: completedAssessment.createdAt,
-          },
-        },
-      ]);
-    });
+          };
 
-    it("should return empty array when assessment completion status does not match any convention", async () => {
-      const validatedConvention: ConventionDto = {
-        ...conventionB,
-        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
-        status: "ACCEPTED_BY_VALIDATOR",
-      };
-      const signedAt = new Date().toISOString();
-      const signedAssessment = new AssessmentDtoBuilder()
-        .withConventionId(validatedConvention.id)
-        .withBeneficiarySignature({
-          beneficiaryAgreement: true,
-          beneficiaryFeedback: "feedback",
-          signedAt,
-        })
-        .build();
+          await conventionRepository.save(
+            conventionWithOldAssessment,
+            anyConventionUpdatedAt,
+          );
+          await assessmentRepo.save(
+            createAssessmentEntity(
+              oldAssessmentWithoutSignature,
+              conventionWithOldAssessment,
+            ),
+          );
 
-      await conventionRepository.save(
-        validatedConvention,
-        anyConventionUpdatedAt,
-      );
-      await assessmentRepo.save(
-        createAssessmentEntity(signedAssessment, validatedConvention),
-      );
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["finalized"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
 
-      const result =
-        await conventionQueries.getPaginatedConventionsForAgencyUser({
-          agencyUserId: validator.id,
-          pagination: { page: 1, perPage: 10 },
-          filters: {
-            assessmentCompletionStatus: ["to-complete"],
-          },
-          sort: {
-            by: "dateSubmission",
-            direction: "desc",
-          },
+          expectToEqual(result.data, [
+            {
+              ...conventionWithOldAssessment,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt: null,
+                createdAt: oldAssessmentWithoutSignature.createdAt,
+              },
+            },
+          ]);
         });
 
-      expectToEqual(result.data, []);
-    });
+        it(`should return convention with assessment signed and created after ${ASSESSEMENT_SIGNATURE_RELEASE_DATE.toISOString()}`, async () => {
+          const signedAssessment: AssessmentDto = {
+            ...completedAssessment,
+            conventionId: conventionC.id,
+            createdAt: addDays(
+              ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+              2,
+            ).toISOString(),
+            signedAt: addDays(
+              ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+              2,
+            ).toISOString(),
+          };
 
-    it("should filter conventions by assessment completion statuses to-be-completed", async () => {
-      const validatedConventionWithoutAssessment: ConventionDto = {
-        ...conventionB,
-        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
-        status: "ACCEPTED_BY_VALIDATOR",
-      };
-      await conventionRepository.save(
-        validatedConventionWithoutAssessment,
-        anyConventionUpdatedAt,
-      );
+          await assessmentRepo.update({
+            ...signedAssessment,
+            _entityName: "Assessment",
+            numberOfHoursActuallyMade: null,
+          });
 
-      const result =
-        await conventionQueries.getPaginatedConventionsForAgencyUser({
-          agencyUserId: validator.id,
-          pagination: { page: 1, perPage: 10 },
-          filters: {
-            assessmentCompletionStatus: ["to-complete"],
-          },
-          sort: {
-            by: "dateSubmission",
-            direction: "desc",
-          },
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["finalized"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...conventionC,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt: addDays(
+                  ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+                  2,
+                ).toISOString(),
+                createdAt: completedAssessment.createdAt,
+              },
+            },
+          ]);
+        });
+      });
+
+      describe("assessment filter is 'to-sign'", () => {
+        it(`should return convention when assessment is created after ${ASSESSEMENT_SIGNATURE_RELEASE_DATE.toISOString()}`, async () => {
+          const oldAssessmentCreatedAt = subMonths(
+            ASSESSEMENT_SIGNATURE_RELEASE_DATE,
+            1,
+          ).toISOString();
+
+          const conventionWithOldAssessment: ConventionDto = {
+            ...conventionB,
+            id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+            status: "ACCEPTED_BY_VALIDATOR",
+          };
+
+          const oldAssessment: AssessmentDto = {
+            ...completedAssessment,
+            conventionId: conventionWithOldAssessment.id,
+            createdAt: oldAssessmentCreatedAt,
+          };
+
+          await conventionRepository.save(
+            conventionWithOldAssessment,
+            anyConventionUpdatedAt,
+          );
+          await assessmentRepo.save(
+            createAssessmentEntity(oldAssessment, conventionWithOldAssessment),
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["to-sign"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...conventionC,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt: null,
+                createdAt: completedAssessment.createdAt,
+              },
+            },
+          ]);
+        });
+      });
+
+      describe("assessment filter is 'to-complete'", () => {
+        it("should return convention when missing assessment", async () => {
+          const oldConventionWithoutAssessment: ConventionDto = {
+            ...conventionB,
+            status: "ACCEPTED_BY_VALIDATOR",
+            updatedAt: anyConventionUpdatedAt,
+          };
+          const recentConventionWithoutAssessment = new ConventionDtoBuilder(
+            conventionA,
+          )
+            .withStatus("ACCEPTED_BY_VALIDATOR")
+            .withDateStart(new Date("2023-03-15").toISOString())
+            .withDateEnd(new Date("2023-03-20").toISOString())
+            .withDateSubmission(new Date("2023-03-10").toISOString())
+            .withSchedule(reasonableSchedule)
+            .withUpdatedAt(anyConventionUpdatedAt)
+            .build();
+          await conventionRepository.update(
+            oldConventionWithoutAssessment,
+            anyConventionUpdatedAt,
+          );
+          await conventionRepository.update(
+            recentConventionWithoutAssessment,
+            anyConventionUpdatedAt,
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["to-complete"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...recentConventionWithoutAssessment,
+              ...agencyFields,
+              assessment: null,
+            },
+            {
+              ...oldConventionWithoutAssessment,
+              ...agencyFields,
+              assessment: null,
+            },
+          ]);
         });
 
-      expectToEqual(result.data, [
-        {
-          ...validatedConventionWithoutAssessment,
-          ...agencyFields,
-          assessment: null,
-        },
-      ]);
-    });
+        it("should return empty array when assessment completion status to-complete does not match any convention", async () => {
+          const validatedConvention: ConventionDto = {
+            ...conventionB,
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+            status: "ACCEPTED_BY_VALIDATOR",
+          };
+          const signedAt = new Date().toISOString();
+          const signedAssessment = new AssessmentDtoBuilder()
+            .withConventionId(validatedConvention.id)
+            .withBeneficiarySignature({
+              beneficiaryAgreement: true,
+              beneficiaryFeedback: "feedback",
+              signedAt,
+            })
+            .build();
 
-    it("should filter conventions by multiple assessment completion statuses signed + to-sign", async () => {
-      const anotherValidatedConvention: ConventionDto = {
-        ...conventionB,
-        id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
-        status: "ACCEPTED_BY_VALIDATOR",
-      };
-      const signedAt = new Date().toISOString();
-      const signedAssessment = new AssessmentDtoBuilder()
-        .withConventionId(anotherValidatedConvention.id)
-        .withBeneficiarySignature({
-          beneficiaryAgreement: true,
-          beneficiaryFeedback: "feedback",
-          signedAt,
-        })
-        .build();
+          await conventionRepository.save(
+            validatedConvention,
+            anyConventionUpdatedAt,
+          );
+          await assessmentRepo.save(
+            createAssessmentEntity(signedAssessment, validatedConvention),
+          );
 
-      await conventionRepository.save(
-        anotherValidatedConvention,
-        anyConventionUpdatedAt,
-      );
-      await assessmentRepo.save(
-        createAssessmentEntity(signedAssessment, anotherValidatedConvention),
-      );
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: {
+                assessmentCompletionStatus: ["to-complete"],
+              },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
 
-      const result =
-        await conventionQueries.getPaginatedConventionsForAgencyUser({
-          agencyUserId: validator.id,
-          pagination: { page: 1, perPage: 10 },
-          filters: {
-            assessmentCompletionStatus: ["finalized", "to-sign"],
-          },
-          sort: {
-            by: "dateSubmission",
-            direction: "desc",
-          },
+          expectToEqual(result.data, []);
+        });
+      });
+
+      describe("when multiple filters", () => {
+        it("should filter conventions by assessment completion statuses to-complete + to-sign", async () => {
+          const validatedConventionWithoutAssessment: ConventionDto = {
+            ...conventionB,
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+            status: "ACCEPTED_BY_VALIDATOR",
+          };
+          await conventionRepository.save(
+            validatedConventionWithoutAssessment,
+            anyConventionUpdatedAt,
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: {
+                assessmentCompletionStatus: ["to-complete", "to-sign"],
+              },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...conventionC,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt: null,
+                createdAt: completedAssessment.createdAt,
+              },
+            },
+            {
+              ...validatedConventionWithoutAssessment,
+              ...agencyFields,
+              assessment: null,
+            },
+          ]);
         });
 
-      expectToEqual(result.data, [
-        {
-          ...conventionC,
-          ...agencyFields,
-          assessment: {
-            status: "COMPLETED",
-            endedWithAJob: false,
-            signedAt: null,
-            createdAt: completedAssessment.createdAt,
-          },
-        },
-        {
-          ...anotherValidatedConvention,
-          ...agencyFields,
-          assessment: {
-            status: "COMPLETED",
-            endedWithAJob: false,
-            signedAt,
-            createdAt: signedAssessment.createdAt,
-          },
-        },
-      ]);
-    });
+        it("should filter conventions by multiple assessment completion statuses signed + to-sign", async () => {
+          const anotherValidatedConvention: ConventionDto = {
+            ...conventionB,
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2",
+            status: "ACCEPTED_BY_VALIDATOR",
+          };
+          const signedAt = new Date().toISOString();
+          const signedAssessment = new AssessmentDtoBuilder()
+            .withConventionId(anotherValidatedConvention.id)
+            .withBeneficiarySignature({
+              beneficiaryAgreement: true,
+              beneficiaryFeedback: "feedback",
+              signedAt,
+            })
+            .build();
 
-    it("should not filter conventions by assessment completion statuses if the convention is not accepted by validator", async () => {
-      const result =
-        await conventionQueries.getPaginatedConventionsForAgencyUser({
-          agencyUserId: validator.id,
-          pagination: { page: 1, perPage: 10 },
-          filters: {
-            assessmentCompletionStatus: ["to-complete"],
-          },
-          sort: {
-            by: "dateSubmission",
-            direction: "desc",
-          },
+          await conventionRepository.save(
+            anotherValidatedConvention,
+            anyConventionUpdatedAt,
+          );
+          await assessmentRepo.save(
+            createAssessmentEntity(
+              signedAssessment,
+              anotherValidatedConvention,
+            ),
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: {
+                assessmentCompletionStatus: ["finalized", "to-sign"],
+              },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...conventionC,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt: null,
+                createdAt: completedAssessment.createdAt,
+              },
+            },
+            {
+              ...anotherValidatedConvention,
+              ...agencyFields,
+              assessment: {
+                status: "COMPLETED",
+                endedWithAJob: false,
+                signedAt,
+                createdAt: signedAssessment.createdAt,
+              },
+            },
+          ]);
         });
+      });
 
-      expectToEqual(result.data, []);
+      it("should not filter conventions by assessment completion statuses if the convention is not accepted by validator", async () => {
+        const result =
+          await conventionQueries.getPaginatedConventionsForAgencyUser({
+            agencyUserId: validator.id,
+            pagination: { page: 1, perPage: 10 },
+            filters: {
+              assessmentCompletionStatus: ["to-complete"],
+            },
+            sort: {
+              by: "dateSubmission",
+              direction: "desc",
+            },
+          });
+
+        expectToEqual(result.data, []);
+      });
     });
 
     it("should sort conventions by dateStart, then conventionId", async () => {

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -5,6 +5,7 @@ import {
   type AgencyId,
   ASSESSEMENT_SIGNATURE_RELEASE_DATE,
   type AssessmentCompletionStatusFilter,
+  assessmentStatuses,
   type BroadcastErrorKind,
   type ConventionAssessmentFields,
   type ConventionDto,
@@ -530,42 +531,66 @@ const filterByAssessmentCompletionStatus =
     if (!assessmentCompletionStatus || assessmentCompletionStatus.length === 0)
       return builder;
 
-    const hasSignedFilter = assessmentCompletionStatus.includes("finalized");
+    const hasFinalizedFilter = assessmentCompletionStatus.includes("finalized");
     const hasToSignFilter = assessmentCompletionStatus.includes("to-sign");
     const hasToBeCompletedFilter =
       assessmentCompletionStatus.includes("to-complete");
 
-    if (hasSignedFilter && hasToSignFilter && hasToBeCompletedFilter)
+    if (hasFinalizedFilter && hasToSignFilter && hasToBeCompletedFilter)
       return builder;
 
     return builder
-      .leftJoin("immersion_assessments as ia", (join) =>
-        join
-          .onRef("ia.convention_id", "=", "conventions.id")
-          .on(
-            sql<boolean>`ia.created_at > ${addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1).toISOString()}::timestamptz`,
-          ),
+      .leftJoin(
+        "immersion_assessments as ia",
+        "ia.convention_id",
+        "conventions.id",
       )
       .where("conventions.status", "=", "ACCEPTED_BY_VALIDATOR")
       .where((eb) => {
         const conditions: ReturnType<typeof eb>[] = [];
 
-        if (hasSignedFilter && hasToSignFilter)
-          conditions.push(eb("ia.convention_id", "is not", null));
+        if (hasFinalizedFilter && hasToSignFilter)
+          conditions.push(
+            eb.and([
+              eb("ia.convention_id", "is not", null),
+              eb(
+                "ia.created_at",
+                ">",
+                addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+              ),
+            ]),
+          );
         else {
-          if (hasSignedFilter)
+          if (hasFinalizedFilter)
             conditions.push(
-              eb.and([
-                eb("ia.convention_id", "is not", null),
-                eb.or([
-                  eb("ia.status", "=", "DID_NOT_SHOW"),
+              eb.or([
+                eb("ia.status", "=", "DID_NOT_SHOW"),
+                eb.and([
+                  eb(
+                    "ia.created_at",
+                    ">",
+                    addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+                  ),
                   eb("ia.signed_at", "is not", null),
+                ]),
+                eb.and([
+                  eb(
+                    "ia.created_at",
+                    "<=",
+                    addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+                  ),
+                  eb("ia.status", "in", assessmentStatuses),
                 ]),
               ]),
             );
           if (hasToSignFilter)
             conditions.push(
               eb.and([
+                eb(
+                  "ia.created_at",
+                  ">",
+                  addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+                ),
                 eb("ia.convention_id", "is not", null),
                 eb("ia.signed_at", "is", null),
                 eb("ia.status", "!=", "DID_NOT_SHOW"),

--- a/front/src/app/components/agency/agency-dashboard/AgencyTasks.tsx
+++ b/front/src/app/components/agency/agency-dashboard/AgencyTasks.tsx
@@ -12,6 +12,7 @@ import { NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE } from "shared";
 import { ConventionsToManageList } from "src/app/components/agency/agency-dashboard/ConventionsToManageList";
 import {
   ConventionsWithAssessmentToCompleteList,
+  startOf2026,
   threeDaysAgo,
 } from "src/app/components/agency/agency-dashboard/ConventionsWithAssessmentToCompleteList";
 import { ConventionsWithBroadcastErrorList } from "src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList";
@@ -91,6 +92,7 @@ export const AgencyTasks = ({
               sortBy: "dateEnd",
               sortDirection: "asc",
               assessmentCompletionStatus: ["to-complete", "to-sign"],
+              dateStartFrom: startOf2026,
               dateEndTo: threeDaysAgo,
               page: 1,
               perPage: NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,

--- a/front/src/app/components/agency/agency-dashboard/ConventionsWithAssessmentToCompleteList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionsWithAssessmentToCompleteList.tsx
@@ -11,7 +11,6 @@ import {
   type ConventionAssessmentFields,
   type ConventionReadDto,
   domElementIds,
-  type FlatGetConventionsForAgencyUserParams,
   NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,
   toDisplayedDate,
 } from "shared";
@@ -22,15 +21,8 @@ import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { connectedUserConventionsToManageSelectors } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.selectors";
 import { connectedUserConventionsToManageSlice } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.slice";
 
-const filters: FlatGetConventionsForAgencyUserParams = {
-  sortBy: "dateEnd",
-  sortDirection: "asc",
-  assessmentCompletionStatus: ["to-complete", "to-sign"],
-  page: 1,
-  perPage: NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,
-};
-
 export const threeDaysAgo = subDays(new Date(), 3).toISOString();
+export const startOf2026 = new Date("2026-01-01").toISOString();
 
 export const ConventionsWithAssessmentToCompleteList = () => {
   const dispatch = useDispatch();
@@ -49,9 +41,13 @@ export const ConventionsWithAssessmentToCompleteList = () => {
           connectedUserConventionsToManageSlice.actions.getConventionsWithAssessmentIssueRequested(
             {
               params: {
-                ...filters,
-                page,
+                sortBy: "dateEnd",
+                sortDirection: "asc",
+                assessmentCompletionStatus: ["to-complete", "to-sign"],
+                dateStartFrom: startOf2026,
                 dateEndTo: threeDaysAgo,
+                page,
+                perPage: NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,
               },
               jwt: connectedUserJwt,
               feedbackTopic: "conventions-with-assessment-issue",

--- a/shared/src/assessment/AssessmentDtoBuilder.ts
+++ b/shared/src/assessment/AssessmentDtoBuilder.ts
@@ -48,6 +48,11 @@ export class AssessmentDtoBuilder implements Builder<AssessmentDto> {
     return this;
   }
 
+  public withCreatedAt(createdAt: string) {
+    this.dto.createdAt = createdAt;
+    return this;
+  }
+
   public withBeneficiarySignature(params: {
     beneficiaryAgreement: boolean;
     beneficiaryFeedback: string | null;


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

