### PR TITLE
#4653 - Fix Rendre possible le remplissage des informations sur le tuteur dans le formulaire de convention

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -206,31 +206,37 @@ export const ConventionForm = ({
     !!connectedUserJwt &&
     !!currentUser;
 
-  const makeDefaultValues = ({ mode }: { mode: ConventionFormMode }) => {
-    const isCreationMode = creationFormModes.includes(
-      mode as ExcludeFromExisting<
-        ConventionFormMode,
-        "edit-convention" | "edit-convention-template"
-      >,
-    );
-    if (isCreationMode) {
-      if (isTemplateForm) {
-        return replaceEmptyValuesByUndefinedFromObject(initialValues);
+  const defaultValues: ConventionFormInitialValues = useMemo(() => {
+    const makeDefaultValuesForMode = () => {
+      const isCreationMode = creationFormModes.includes(
+        mode as ExcludeFromExisting<
+          ConventionFormMode,
+          "edit-convention" | "edit-convention-template"
+        >,
+      );
+      if (isCreationMode) {
+        if (isTemplateForm)
+          return replaceEmptyValuesByUndefinedFromObject(initialValues);
       }
-    }
-    return (
-      fetchedConvention ||
-      conventionPresentationFromDraft ||
-      conventionPresentationFromConventionTemplate ||
-      initialValues
-    );
-  };
-  const defaultValues: ConventionFormInitialValues = {
-    ...makeDefaultValues({
-      mode,
-    }),
-    status: "READY_TO_SIGN",
-  };
+      return (
+        fetchedConvention ||
+        conventionPresentationFromDraft ||
+        conventionPresentationFromConventionTemplate ||
+        initialValues
+      );
+    };
+    return {
+      ...makeDefaultValuesForMode(),
+      status: "READY_TO_SIGN",
+    };
+  }, [
+    mode,
+    isTemplateForm,
+    initialValues,
+    fetchedConvention,
+    conventionPresentationFromDraft,
+    conventionPresentationFromConventionTemplate,
+  ]);
 
   return (
     <ConventionFormContent


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant