### PR TITLE
#4599 - Fix Supprimer le brouillon lorsque qu'une convention est crée a partir d'un brouillon

### DIFF
--- a/back/src/domains/convention/use-cases/AddConvention.ts
+++ b/back/src/domains/convention/use-cases/AddConvention.ts
@@ -37,7 +37,9 @@ export const makeAddConvention = useCaseBuilder("AddConvention")
         payload: {
           convention,
           triggeredBy: null,
-          ...(fromConventionDraftId ? { fromConventionDraftId } : {}),
+          ...(fromConventionDraftId
+            ? { conventionDraftId: fromConventionDraftId }
+            : {}),
           ...(discussionId ? { discussionId } : {}),
         },
       });

--- a/back/src/domains/convention/use-cases/AddConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/AddConvention.unit.test.ts
@@ -118,6 +118,39 @@ describe("Add Convention", () => {
     ]);
   });
 
+  it("sends conventionDraftId in the event when the convention was created from a draft", async () => {
+    const fromConventionDraftId = "550e8400-e29b-41d4-a716-446655440000";
+    const occurredAt = new Date("2021-10-15T15:00");
+    const id = "eventId";
+    timeGateway.setNextDate(occurredAt);
+    uuidGenerator.setNextUuid(id);
+
+    expect(
+      await addConvention.execute({
+        convention: validConvention,
+        fromConventionDraftId,
+      }),
+    ).toEqual({
+      id: validConvention.id,
+    });
+
+    expectDomainEventsToBeInOutbox([
+      {
+        id,
+        occurredAt: occurredAt.toISOString(),
+        topic: "ConventionSubmittedByBeneficiary",
+        payload: {
+          convention: validConvention,
+          conventionDraftId: fromConventionDraftId,
+          triggeredBy: null,
+        },
+        publications: [],
+        status: "never-published",
+        wasQuarantined: false,
+      },
+    ]);
+  });
+
   it("also sends the discussionId in the event, if initialy provided to the use case", async () => {
     const discussion = new DiscussionBuilder().build();
     const occurredAt = new Date("2021-10-15T15:00");


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant