### PR TITLE
#4672 - seconde tentative de fournir originalUrl au bouton d'erreur mais avec un hook

### DIFF
--- a/front/src/app/pages/convention/ShowConventionErrorOrRenewExpiredJwt.tsx
+++ b/front/src/app/pages/convention/ShowConventionErrorOrRenewExpiredJwt.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { type ConventionSupportedJwt, expiredJwtErrorMessage } from "shared";
 import { frontErrors } from "src/app/pages/error/front-errors";
 import type { FeedbackTopic } from "src/core-logic/domain/feedback/feedback.content";
@@ -10,6 +11,13 @@ export const ShowConventionErrorOrRenewExpiredJwt = ({
   errorMessage: string;
   jwt: ConventionSupportedJwt;
 }) => {
+  const href = window.location.href;
+  const [originalUrl, setOriginalUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (href) setOriginalUrl(href);
+  }, [href]);
+
   // un peu fragile, mais j'attends qu'on remette au carré les erreurs front/back. Ca fait un fix rapide (8/12/2022)
   if (!errorMessage.includes(expiredJwtErrorMessage))
     throw new Error(
@@ -18,14 +26,17 @@ export const ShowConventionErrorOrRenewExpiredJwt = ({
 
   const feedbackTopic: FeedbackTopic = "renew-expired-jwt-convention";
 
-  throw frontErrors.jwtLink.expired({
-    RenewJwtButton: (
-      <RenewExpiredJwtButton
-        key={RenewExpiredJwtButton.name}
-        expiredJwt={jwt}
-        feedbackTopic={feedbackTopic}
-        originalUrl={window.location.href}
-      />
-    ),
-  });
+  if (originalUrl)
+    throw frontErrors.jwtLink.expired({
+      RenewJwtButton: (
+        <RenewExpiredJwtButton
+          key={RenewExpiredJwtButton.name}
+          expiredJwt={jwt}
+          feedbackTopic={feedbackTopic}
+          originalUrl={originalUrl}
+        />
+      ),
+    });
+
+  return undefined;
 };


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
