### PR TITLE
#4638 - Éviter les doubles envois lors du changement de statut de convention 

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionManageActions.tsx
+++ b/front/src/app/components/admin/conventions/ConventionManageActions.tsx
@@ -119,6 +119,8 @@ export const ConventionManageActions = ({
       | WithConventionId
       | MarkPartnersErroredConventionAsHandledRequest,
   ) => {
+    if (isConventionActionLoading) return;
+
     if (verificationAction === "BROADCAST_AGAIN" && "conventionId" in params) {
       dispatch(
         conventionActionSlice.actions.broadcastConventionToPartnerRequested({
@@ -210,8 +212,6 @@ export const ConventionManageActions = ({
     }
 
     if ("status" in params) {
-      if (isConventionActionLoading) return;
-
       if (params.status === "ACCEPTED_BY_COUNSELLOR") {
         dispatch(
           conventionActionSlice.actions.acceptByCounsellorRequested({


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant