### PR TITLE
#4430 - Rejouer automatiquement la synchronisation lorsqu’un timeout survient lors de la synchronisation d'une convention à FT 

### DIFF
--- a/back/scalingo/cron.json
+++ b/back/scalingo/cron.json
@@ -13,6 +13,10 @@
       "size": "M"
     },
     {
+      "command": "15 0 * * * pnpm back run trigger-resync-old-conventions-to-pe",
+      "size": "M"
+    },
+    {
       "command": "53 0 * * * pnpm back run trigger-refresh-materialized-views",
       "size": "M"
     },

--- a/back/src/domains/convention/ports/FranceTravailGateway.ts
+++ b/back/src/domains/convention/ports/FranceTravailGateway.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from "axios";
 import type { SubscriberErrorFeedback } from "shared";
 import type { AccessTokenResponse } from "../../../config/bootstrap/appConfig";
 import type { BroadcastConventionParams } from "../use-cases/broadcast/broadcastConventionParams";
@@ -21,6 +22,22 @@ export const isBroadcastResponseOk = (
   response: FranceTravailBroadcastResponse,
 ): response is FtBroadcastSuccessResponse =>
   [200, 201, 204].includes(response.status);
+
+export const isBroadcastTimeoutError = (
+  response: FranceTravailBroadcastResponse,
+): boolean => {
+  if (isBroadcastResponseOk(response)) return false;
+  const message = response.subscriberErrorFeedback.message.toLowerCase();
+  if (message.includes("timeout")) return true;
+  const error = response.subscriberErrorFeedback.error;
+
+  if (
+    isAxiosError(error) &&
+    (error.code === "ECONNABORTED" || error.code === "ECONNRESET")
+  )
+    return true;
+  return false;
+};
 
 export interface FranceTravailGateway {
   notifyOnConventionUpdated: (

--- a/back/src/domains/convention/use-cases/ResyncOldConventionsToFt.unit.test.ts
+++ b/back/src/domains/convention/use-cases/ResyncOldConventionsToFt.unit.test.ts
@@ -275,6 +275,43 @@ describe("ResyncOldConventionsToFt use case", () => {
       });
     });
 
+    it("when broadcast times out, keeps TO_PROCESS for a later resync run", async () => {
+      uow.agencyRepository.agencies = [toAgencyWithRights(agencyFT)];
+      uow.conventionRepository.setConventions([conventionToSync1]);
+      uow.conventionsToSyncRepository.setForTesting([
+        {
+          id: conventionToSync1.id,
+          status: "TO_PROCESS",
+        },
+      ]);
+      ftGateway.setNextResponse({
+        status: 500,
+        subscriberErrorFeedback: {
+          message: "timeout of 30000ms exceeded",
+          error: new Error("timeout of 30000ms exceeded"),
+        },
+        body: undefined,
+      });
+
+      const report = await useCase.execute();
+
+      expectToEqual(uow.conventionsToSyncRepository.conventionsToSync, [
+        {
+          id: conventionToSync1.id,
+          status: "TO_PROCESS",
+        },
+      ]);
+      expectToEqual(report, {
+        success: 0,
+        skips: {},
+        errors: {
+          [conventionToSync1.id]: new Error(
+            "Convention still have status TO_PROCESS",
+          ),
+        },
+      });
+    });
+
     it("should consider limit", async () => {
       uow.agencyRepository.agencies = [toAgencyWithRights(agencyFT)];
       uow.conventionRepository.setConventions([

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
@@ -13,6 +13,7 @@ import {
 import {
   type FranceTravailGateway,
   isBroadcastResponseOk,
+  isBroadcastTimeoutError,
 } from "../../ports/FranceTravailGateway";
 import {
   type BroadcastConventionParams,
@@ -78,7 +79,12 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
       convention: makeFranceTravailSupportedConvention(inputParams.convention),
     });
 
-    if (deps.options.resyncMode)
+    if (isBroadcastTimeoutError(response))
+      await uow.conventionsToSyncRepository.save({
+        id: inputParams.convention.id,
+        status: "TO_PROCESS",
+      });
+    else if (deps.options.resyncMode && isBroadcastResponseOk(response))
       await uow.conventionsToSyncRepository.save({
         id: inputParams.convention.id,
         status: "SUCCESS",

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
@@ -174,6 +174,76 @@ describe("Broadcasts events to France Travail", () => {
     });
   });
 
+  it("save the convention id with status TO_PROCESS in the conventionsToSyncWithPe repository when FT broadcast times out", async () => {
+    franceTravailGateway.setNextResponse({
+      status: 500,
+      subscriberErrorFeedback: {
+        message: "timeout of 30000ms exceeded",
+        error: new Error("timeout of 30000ms exceeded"),
+      },
+      body: undefined,
+    });
+    const now = new Date();
+    timeGateway.setNextDate(now);
+
+    await broadcastToFranceTravailOnConventionUpdates.execute({
+      eventType: "CONVENTION_UPDATED",
+      convention: conventionReadDtoFrom({
+        convention: conventionLinkedToFTWithoutFederatedIdentity,
+        agency: {
+          ...peAgencyWithoutCounsellorsAndValidators,
+          counsellorEmails: [counsellor.email],
+          validatorEmails: [validator.email],
+        },
+      }),
+    });
+
+    expectToEqual(uow.conventionsToSyncRepository.conventionsToSync, [
+      {
+        id: conventionLinkedToFTWithoutFederatedIdentity.id,
+        status: "TO_PROCESS",
+      },
+    ]);
+  });
+
+  it("when FT broadcast times out again for a convention already queued, updates the row to TO_PROCESS", async () => {
+    uow.conventionsToSyncRepository.setForTesting([
+      {
+        id: conventionLinkedToFTWithoutFederatedIdentity.id,
+        status: "SUCCESS",
+        processDate: new Date("2020-01-01"),
+      },
+    ]);
+    franceTravailGateway.setNextResponse({
+      status: 500,
+      subscriberErrorFeedback: {
+        message: "timeout of 30000ms exceeded",
+        error: new Error("timeout of 30000ms exceeded"),
+      },
+      body: undefined,
+    });
+    timeGateway.setNextDate(new Date());
+
+    await broadcastToFranceTravailOnConventionUpdates.execute({
+      eventType: "CONVENTION_UPDATED",
+      convention: conventionReadDtoFrom({
+        convention: conventionLinkedToFTWithoutFederatedIdentity,
+        agency: {
+          ...peAgencyWithoutCounsellorsAndValidators,
+          counsellorEmails: [counsellor.email],
+          validatorEmails: [validator.email],
+        },
+      }),
+    });
+
+    expectToEqual(uow.conventionsToSyncRepository.conventionsToSync, [
+      {
+        id: conventionLinkedToFTWithoutFederatedIdentity.id,
+        status: "TO_PROCESS",
+      },
+    ]);
+  });
+
   it("If Pe returns a 404 error, we store the error in a repo", async () => {
     franceTravailGateway.setNextResponse({
       status: 404,

--- a/front/src/app/components/SubscriberErrorFeedback.tsx
+++ b/front/src/app/components/SubscriberErrorFeedback.tsx
@@ -1,13 +1,17 @@
-/** biome-ignore-all lint/complexity/noUselessFragments: <explanation> */
 import { fr } from "@codegouvfr/react-dsfr";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import type { ReactNode } from "react";
 import {
   type ConventionStatus,
   conventionStatusesAllowedForModification,
+  isFranceTravailBroadcastTemporaryNetworkErrorMessage,
   isFunctionalBroadcastFeedbackError,
   type SubscriberErrorFeedback,
 } from "shared";
-import { broadcastFeedbackErrorMessageMap } from "src/app/contents/broadcast-feedback/broadcastFeedback";
+import {
+  broadcastFeedbackErrorMessageMap,
+  franceTravailTemporaryNetworkErrorBroadcastFeedback,
+} from "src/app/contents/broadcast-feedback/broadcastFeedback";
 
 interface SubscriberErrorFeedbackProps {
   subscriberErrorFeedback: SubscriberErrorFeedback;
@@ -23,41 +27,62 @@ export const SubscriberErrorFeedbackComponent = ({
   const isConventionValidated =
     !conventionStatusesAllowedForModification.includes(conventionStatus);
 
-  const managedError = isFunctionalBroadcastFeedbackError(message) && (
-    <div>
-      <strong>
-        Erreur - {broadcastFeedbackErrorMessageMap[message].description}
-      </strong>
-      <Accordion
-        label="Détails des solutions possibles"
-        className={fr.cx("fr-mb-3w", "fr-mt-1w")}
-      >
-        <>
-          {broadcastFeedbackErrorMessageMap[message].solution(
-            isConventionValidated,
-          )}
-        </>
-      </Accordion>
-    </div>
-  );
+  if (isFunctionalBroadcastFeedbackError(message)) {
+    return (
+      <BroadcastErrorDetails
+        description={broadcastFeedbackErrorMessageMap[message].description}
+        solution={broadcastFeedbackErrorMessageMap[message].solution(
+          isConventionValidated,
+        )}
+      />
+    );
+  }
+
+  if (isFranceTravailBroadcastTemporaryNetworkErrorMessage(message)) {
+    return (
+      <BroadcastErrorDetails
+        description={
+          franceTravailTemporaryNetworkErrorBroadcastFeedback.description
+        }
+        solution={franceTravailTemporaryNetworkErrorBroadcastFeedback.solution()}
+      />
+    );
+  }
 
   return (
-    <>
-      {managedError}
-      {!managedError && (
-        <div>
-          <strong>Erreur technique</strong>
-          <Accordion
-            label="Détail de l'erreur"
-            className={fr.cx("fr-mb-4w", "fr-mt-1w")}
-          >
-            <p>
-              Immersion facilitée travaille actuellement à une proposition de
-              solution avec votre DSI. Elle vous sera proposée prochainement.
-            </p>
-          </Accordion>
-        </div>
-      )}
-    </>
+    <BroadcastErrorDetails
+      description="Erreur technique"
+      useErreurPrefix={false}
+      label="Détail de l'erreur"
+      solution={
+        <p>
+          Immersion facilitée travaille actuellement à une proposition de
+          solution avec votre DSI. Elle vous sera proposée prochainement.
+        </p>
+      }
+    />
   );
 };
+
+type BroadcastErrorDetailsProps = {
+  description: string;
+  solution: NonNullable<ReactNode>;
+  label?: string;
+  useErreurPrefix?: boolean;
+};
+
+const BroadcastErrorDetails = ({
+  description,
+  solution,
+  label = "Détails des solutions possibles",
+  useErreurPrefix = true,
+}: BroadcastErrorDetailsProps): JSX.Element => (
+  <div>
+    <strong>
+      {useErreurPrefix ? <>Erreur - {description}</> : description}
+    </strong>
+    <Accordion label={label} className={fr.cx("fr-mt-1w", "fr-mb-3w")}>
+      {solution}
+    </Accordion>
+  </div>
+);

--- a/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
@@ -22,10 +22,14 @@ import {
   domElementIds,
   type FlatGetConventionsWithErroredBroadcastFeedbackParams,
   getFormattedFirstnameAndLastname,
+  isFranceTravailBroadcastTemporaryNetworkErrorMessage,
   isFunctionalBroadcastFeedbackError,
   NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,
 } from "shared";
-import { broadcastFeedbackErrorMessageMap } from "src/app/contents/broadcast-feedback/broadcastFeedback";
+import {
+  broadcastFeedbackErrorMessageMap,
+  franceTravailTemporaryNetworkErrorBroadcastFeedback,
+} from "src/app/contents/broadcast-feedback/broadcastFeedback";
 import { labelAndSeverityByStatus } from "src/app/contents/convention/labelAndSeverityByStatus";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { routes } from "src/app/routes/routes";
@@ -79,9 +83,12 @@ export const ConventionsWithBroadcastErrorList = ({
   }, [filters.broadcastErrorKind, filters.conventionStatus, filters.search]);
 
   const getDescription = (errorMessage: string) => {
-    if (isFunctionalBroadcastFeedbackError(errorMessage)) {
+    if (isFunctionalBroadcastFeedbackError(errorMessage))
       return broadcastFeedbackErrorMessageMap[errorMessage].description;
-    }
+
+    if (isFranceTravailBroadcastTemporaryNetworkErrorMessage(errorMessage))
+      return franceTravailTemporaryNetworkErrorBroadcastFeedback.description;
+
     return "Erreur technique : Immersion facilitée travaille actuellement à une proposition de solution avec votre DSI. Elle vous sera proposée prochainement.";
   };
 

--- a/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
+++ b/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
@@ -3,7 +3,7 @@ import type { FunctionalBroadcastFeedbackErrorMessage } from "shared";
 
 type BroadcastFeedbackError = {
   description: string;
-  solution: (isConventionValidated?: boolean) => ReactNode;
+  solution: (isConventionValidated?: boolean) => NonNullable<ReactNode>;
 };
 
 export const broadcastFeedbackErrorMessageMap: Record<
@@ -299,3 +299,20 @@ export const broadcastFeedbackErrorMessageMap: Record<
   FunctionalBroadcastFeedbackErrorMessage,
   BroadcastFeedbackError
 >;
+
+export const franceTravailTemporaryNetworkErrorBroadcastFeedback: BroadcastFeedbackError =
+  {
+    description: "La synchronisation n'a pas pu aboutir.",
+    solution: () => (
+      <>
+        <p>
+          Ce problème est souvent temporaire (connexion réseau ou disponibilité
+          du service).
+        </p>
+        <p>
+          Vous pouvez relancer une resynchronisation manuelle depuis le bouton «
+          Gérer la synchronisation ».
+        </p>
+      </>
+    ),
+  };

--- a/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
@@ -38,6 +38,15 @@ export const isFunctionalBroadcastFeedbackError = (
     message as FunctionalBroadcastFeedbackErrorMessage,
   );
 
+export const isFranceTravailBroadcastTemporaryNetworkErrorMessage = (
+  message: string,
+): boolean => {
+  const trimmedMessage = message.trim().toLowerCase();
+  return (
+    trimmedMessage === "read econnreset" || trimmedMessage.includes("timeout")
+  );
+};
+
 export type BroadcastErrorKind = "functional" | "technical";
 
 export type ConventionsWithErroredBroadcastFeedbackFilters = {


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
