### PR TITLE
#4720 – Afficher l’erreur si le motif obligatoire est vide dans la modal de renouvellement de convention

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/manageActionModals.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/manageActionModals.tsx
@@ -166,6 +166,7 @@ const createRenewConventionModalParams = {
   id: domElementIds.manageConvention.renewModal,
   isOpenedByDefault: false,
   formId: domElementIds.manageConvention.renewModalForm,
+  doSubmitClosesModal: false,
   submitButton: {
     id: domElementIds.manageConvention.submitRenewModalButton,
     children: "Renouveler la convention",


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

