### PR TITLE
#4714 - Remplacer le mailto vers une redirection sur le support sur les pages d'erreurs

### DIFF
--- a/front/src/app/contents/error/types.ts
+++ b/front/src/app/contents/error/types.ts
@@ -11,6 +11,5 @@ export type FrontErrorProps = {
 export type ErrorButton = ReactElement;
 
 export type ContactErrorInformation = {
-  errorMessage: string;
   priority?: ButtonProps["priority"];
 };

--- a/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
+++ b/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
@@ -41,10 +41,7 @@ export const MagicLinkInterstitialPage = () => {
         return (
           <ErrorPage
             title={title ?? "Erreur de connexion"}
-            buttons={[
-              RenewJwtButton,
-              ContactUsButton({ errorMessage: messageText }),
-            ]}
+            buttons={[RenewJwtButton, ContactUsButton()]}
             error={{
               message: messageText,
               name: title ?? "Erreur de connexion",

--- a/front/src/app/pages/error/ErrorPage.tsx
+++ b/front/src/app/pages/error/ErrorPage.tsx
@@ -33,10 +33,7 @@ const getPageContentProps = (
     description: error.message,
     buttons: buttons ?? [
       HomeButton,
-      <ContactUsButton
-        errorMessage={error.message}
-        key={ContactUsButton.name}
-      />,
+      <ContactUsButton key={ContactUsButton.name} />,
     ],
   };
 };

--- a/front/src/app/pages/error/MinimalErrorPage.tsx
+++ b/front/src/app/pages/error/MinimalErrorPage.tsx
@@ -47,11 +47,7 @@ export const MinimalErrorPage = ({ error }: { error: Error }) => {
       <MainWrapper layout="default" vSpacing={8}>
         <ErrorPageContent
           buttons={[
-            <ContactUsButton
-              errorMessage={error.message}
-              priority="primary"
-              key={ContactUsButton.name}
-            />,
+            <ContactUsButton priority="primary" key={ContactUsButton.name} />,
           ]}
           title="Erreur inattendue"
           description={

--- a/front/src/app/pages/error/front-errors.tsx
+++ b/front/src/app/pages/error/front-errors.tsx
@@ -5,9 +5,9 @@ import {
   domElementIds,
   type Email,
   expiredJwtErrorTitle,
-  immersionFacileContactEmail,
   type SiretDto,
 } from "shared";
+import { immersionFacileSupportUrl } from "src/app/components/layout/LayoutFooter";
 import type {
   ContactErrorInformation,
   ErrorButton,
@@ -41,7 +41,11 @@ export const frontErrors = {
             </p>
             <p>
               Vous n'avez pas reçu le lien ?{" "}
-              <a href={`mailto:${immersionFacileContactEmail}`}>
+              <a
+                href={immersionFacileSupportUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 Contactez-nous
               </a>
             </p>
@@ -66,7 +70,11 @@ export const frontErrors = {
             </p>
             <p>
               Vous n'avez pas reçu le lien ?{" "}
-              <a href={`mailto:${immersionFacileContactEmail}`}>
+              <a
+                href={immersionFacileSupportUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
                 Contactez-nous
               </a>
             </p>
@@ -97,17 +105,14 @@ export const frontErrors = {
             </p>
           </>
         ),
-        buttons: [
-          HomeButton,
-          ContactUsButton({ errorMessage: "Page introuvable." }),
-        ],
+        buttons: [HomeButton, ContactUsButton()],
       }),
     unauthorized: () => {
       const description = "Vous n'êtes pas autorisé à accéder à cette page.";
       return new FrontSpecificError({
         title: "Non-autorisé",
         description,
-        buttons: [HomeButton, ContactUsButton({ errorMessage: description })],
+        buttons: [HomeButton, ContactUsButton()],
       });
     },
   },
@@ -146,7 +151,7 @@ export const frontErrors = {
       return new FrontSpecificError({
         title: "Partenaire inconnu",
         description,
-        buttons: [HomeButton, ContactUsButton({ errorMessage: description })],
+        buttons: [HomeButton, ContactUsButton()],
       });
     },
     noRightsOnConvention: ({
@@ -173,13 +178,7 @@ export const frontErrors = {
             </p>
           </>
         ),
-        buttons: [
-          HomeButton,
-          ContactUsButton({
-            errorMessage: `L’accès à la convention '${conventionId}' n’est pas possible avec le compte
-              actuel (${userEmail}). Ce compte n’a aucun droit sur la convention.`,
-          }),
-        ],
+        buttons: [HomeButton, ContactUsButton()],
       }),
   },
   conventionDraft: {
@@ -224,7 +223,7 @@ export const frontErrors = {
       return new FrontSpecificError({
         title: "Établissment non trouvé",
         description,
-        buttons: [HomeButton, ContactUsButton({ errorMessage: description })],
+        buttons: [HomeButton, ContactUsButton()],
       });
     },
     expiredLink: () => {
@@ -262,23 +261,13 @@ export const HomeButton: ErrorButton = (
 );
 
 export const ContactUsButton = ({
-  errorMessage,
   priority = "secondary",
-}: ContactErrorInformation) => {
-  const emailBody = `%0D%0A________________________%0D%0A
-  %0D%0A
-  Veuillez répondre au dessus de cette ligne.%0D%0A%0D%0A
-  Les infos suivantes peuvent être utiles pour résoudre votre problème :%0D%0A%0D%0A
-  - URL de la page concernée : ${window.location.href}%0D%0A%0D%0A
-  - Date et heure de l'erreur : ${new Date().toISOString()}%0D%0A%0D%0A
-  - Résumé de l'erreur :%0D%0A%0D%0A
-  ${errorMessage}
-  `;
+}: ContactErrorInformation = {}) => {
   return (
     <Button
       priority={priority}
       linkProps={{
-        href: `mailto:${immersionFacileContactEmail}?body=${emailBody}`,
+        href: `${immersionFacileSupportUrl}`,
         target: "_blank",
         id: domElementIds.error.contactUsButton,
       }}


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
