### PR TITLE
#4431 - Limiter certains champs à  255 octets quand on transfert une convention à FT

### DIFF
--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
@@ -1,4 +1,8 @@
-import { type ConventionReadDto, cleanSpecialChars } from "shared";
+import {
+  type ConventionReadDto,
+  cleanSpecialChars,
+  sliceTextUpToBytesLimit,
+} from "shared";
 import { broadcastToFtServiceName } from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../../core/useCaseBuilder";
@@ -28,8 +32,11 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
     options: { resyncMode: boolean };
   }>()
   .build(async ({ inputParams, uow, deps }): Promise<void> => {
-    const { convention } = inputParams;
-    const { agency, refersToAgency } = await getLinkedAgencies(uow, convention);
+    const { agency, refersToAgency } = await getLinkedAgencies(
+      uow,
+      inputParams.convention,
+    );
+
     const featureFlags = await uow.featureFlagQueries.getAll();
 
     if (
@@ -41,31 +48,21 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
     )
       return deps.options.resyncMode
         ? uow.conventionsToSyncRepository.save({
-            id: convention.id,
+            id: inputParams.convention.id,
             status: "SKIP",
             processDate: deps.timeGateway.now(),
             reason: "Agency is not of kind pole-emploi",
           })
         : undefined;
 
-    const cleanedConventionParams: ConventionReadDto = {
-      ...inputParams.convention,
-      sanitaryPreventionDescription: cleanSpecialChars(
-        inputParams.convention.sanitaryPreventionDescription,
-      ),
-      individualProtectionDescription: cleanSpecialChars(
-        inputParams.convention.individualProtectionDescription,
-      ),
-    };
-
     const response = await deps.franceTravailGateway.notifyOnConventionUpdated({
       ...inputParams,
-      convention: cleanedConventionParams,
+      convention: makeFranceTravailSupportedConvention(inputParams.convention),
     });
 
     if (deps.options.resyncMode)
       await uow.conventionsToSyncRepository.save({
-        id: convention.id,
+        id: inputParams.convention.id,
         status: "SUCCESS",
         processDate: deps.timeGateway.now(),
       });
@@ -75,8 +72,8 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
       consumerName: "France Travail",
       serviceName: broadcastToFtServiceName,
       requestParams: {
-        conventionId: convention.id,
-        conventionStatus: convention.status,
+        conventionId: inputParams.convention.id,
+        conventionStatus: inputParams.convention.status,
       },
       response: { httpStatus: response.status, body: response.body },
       occurredAt: deps.timeGateway.now().toISOString(),
@@ -86,3 +83,21 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
         : {}),
     });
   });
+
+const makeFranceTravailSupportedConvention = (
+  convention: ConventionReadDto,
+): ConventionReadDto => ({
+  ...convention,
+  establishmentTutor: {
+    ...convention.establishmentTutor,
+    job: sliceTextUpToBytesLimit(convention.establishmentTutor.job, 255),
+  },
+  sanitaryPreventionDescription: sliceTextUpToBytesLimit(
+    cleanSpecialChars(convention.sanitaryPreventionDescription),
+    255,
+  ),
+  individualProtectionDescription: sliceTextUpToBytesLimit(
+    cleanSpecialChars(convention.individualProtectionDescription),
+    255,
+  ),
+});

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
@@ -317,6 +317,57 @@ describe("Broadcasts events to France Travail", () => {
     });
   });
 
+  it("Converts and sends conventions, with limit 255 bytes on sanitaryPreventionDescription, individualProtectionDescription & tutor job", async () => {
+    const convention = new ConventionDtoBuilder()
+      .withAgencyId(peAgencyWithoutCounsellorsAndValidators.id)
+      .withSanitaryPreventionDescription(
+        "•	Lavage régulier des mains 	•	Port d’une tenue propre (blouse, tablier) 	•	Port du filet à cheveux ou charlotte 	•	Nettoyage fréquent du plan de travail et du matériel 	•	Respect des règles d’hygiène liées à la manipulation des produits alimentaires",
+      )
+      .withIndividualProtectionDescription(
+        "Gants à usage unique  Masques (chirurgicaux ou FFP2 selon les situations)  Tenue professionnelle (pantalon, polo ou blouson aux normes)  Chaussures de sécurité ou adaptées au transport sanitaire  Gilet fluorescent pour interventions sur voie publique",
+      )
+      .withEstablishmentTutorJob(
+        "Responsable des affaires juridiques et institutionnelles au sein du Service des Affaires juridiques et institutionnelles ; Délégué à la protection des données personnelles (DPO) ; Responsable de l’accès aux documents administratifs (PRADA)",
+      )
+      .build();
+
+    await broadcastToFranceTravailOnConventionUpdates.execute({
+      eventType: "CONVENTION_UPDATED",
+      convention: conventionReadDtoFrom({
+        convention,
+        agency: {
+          ...peAgencyWithoutCounsellorsAndValidators,
+          counsellorEmails: [counsellor.email],
+          validatorEmails: [validator.email],
+        },
+      }),
+    });
+
+    expectToEqual(franceTravailGateway.broadcastParamsCalls, [
+      {
+        eventType: "CONVENTION_UPDATED",
+        convention: conventionReadDtoFrom({
+          convention: {
+            ...convention,
+            sanitaryPreventionDescription:
+              "•	Lavage regulier des mains 	•	Port d'une tenue propre (blouse, tablier) 	•	Port du filet a cheveux ou charlotte 	•	Nettoyage frequent du plan de travail et du materiel 	•	Respect des regles d'hygiene liees a la manipulation des produits aliment",
+            individualProtectionDescription:
+              "Gants a usage unique  Masques (chirurgicaux ou FFP2 selon les situations)  Tenue professionnelle (pantalon, polo ou blouson aux normes)  Chaussures de securite ou adaptees au transport sanitaire  Gilet fluorescent pour interventions sur voie publique",
+            establishmentTutor: {
+              ...convention.establishmentTutor,
+              job: "Responsable des affaires juridiques et institutionnelles au sein du Service des Affaires juridiques et institutionnelles ; Délégué à la protection des données personnelles (DPO) ; Responsable de l’accès aux documents administratifs (PRADA)",
+            },
+          },
+          agency: {
+            ...peAgencyWithoutCounsellorsAndValidators,
+            counsellorEmails: [counsellor.email],
+            validatorEmails: [validator.email],
+          },
+        }),
+      },
+    ]);
+  });
+
   it("broadcast to pole-emploi when convention is from an agency RefersTo", async () => {
     // Prepare
     const agencyWithRefersTo = toAgencyWithRights(

--- a/shared/src/convention/ConventionDtoBuilder.ts
+++ b/shared/src/convention/ConventionDtoBuilder.ts
@@ -545,6 +545,10 @@ export class ConventionDtoBuilder implements Builder<ConventionDto> {
     return this.withEstablishmentTutor({ ...this.#establishmentTutor, phone });
   }
 
+  public withEstablishmentTutorJob(job: string) {
+    return this.withEstablishmentTutor({ ...this.#establishmentTutor, job });
+  }
+
   public withFederatedIdentity(
     federatedIdentity: FtConnectIdentity | undefined,
   ): ConventionDtoBuilder {

--- a/shared/src/utils/string.ts
+++ b/shared/src/utils/string.ts
@@ -146,3 +146,15 @@ export const parseStringToJsonOrThrow = <T>(
     throw errors.routeParams.malformedJson({ paramName });
   }
 };
+
+export const sliceTextUpToBytesLimit = (
+  text: string,
+  MAX_BYTES: number,
+): string => {
+  const textBytesEncoded = new TextEncoder().encode(text);
+  return textBytesEncoded.length > MAX_BYTES
+    ? new TextDecoder("utf-8")
+        .decode(textBytesEncoded.slice(0, MAX_BYTES))
+        .replace(/\uFFFD/g, "")
+    : text;
+};

--- a/shared/src/utils/string.unit.test.ts
+++ b/shared/src/utils/string.unit.test.ts
@@ -1,6 +1,7 @@
 import { ZodError } from "zod";
 import type { $ZodIssue } from "zod/v4/core/errors.cjs";
 import { emailExchangeSplitters } from "../discussion/discussion.helpers";
+import { expectToEqual } from "../test.helpers";
 import { localization } from "../zodUtils";
 import {
   cleanSpecialChars,
@@ -9,6 +10,7 @@ import {
   getFormattedFirstnameAndLastname,
   looksLikeSiret,
   removeDiacritics,
+  sliceTextUpToBytesLimit,
   slugify,
   splitTextOnFirstSeparator,
   toLowerCaseWithoutDiacritics,
@@ -220,6 +222,41 @@ describe("string utils", () => {
       ["test espace insécable \u00A0", "test espace insecable  "],
     ])("should clean special chars", (input, expected) => {
       expect(cleanSpecialChars(input)).toBe(expected);
+    });
+  });
+
+  describe("sliceTextUpToBytesLimit", () => {
+    type ExpectedResult = {
+      original: string;
+      expectedResult: string;
+    };
+
+    it.each([
+      { original: "a", expectedResult: "a" },
+      { original: "a".repeat(254), expectedResult: "a".repeat(254) },
+      { original: "a".repeat(255), expectedResult: "a".repeat(255) },
+      { original: "a".repeat(256), expectedResult: "a".repeat(255) },
+      {
+        original: `${"a".repeat(254)}é`,
+        expectedResult: `${"a".repeat(254)}`,
+      },
+      {
+        original:
+          "gants de jardinage, bottes ou chaussures de sécurité, chapeau ou casquette, gilet de visibilité si travail près de routes, tablier ou combinaison légère, protections contre le soleil (crème, lunettes), éventuellement genouillères pour le travail à genoux.",
+        expectedResult:
+          "gants de jardinage, bottes ou chaussures de sécurité, chapeau ou casquette, gilet de visibilité si travail près de routes, tablier ou combinaison légère, protections contre le soleil (crème, lunettes), éventuellement genouillères pour le travail ",
+      },
+      {
+        original:
+          "Tenue professionnelle obligatoire, veste ou blouse de pâtissier, un pantalon professionnel, charlotte, et des chaussures de sécurité ou antidérapantes. Gants à usage alimentaire. Tablier de protection, protections contre la chaleur (gants thermiques).",
+        expectedResult:
+          "Tenue professionnelle obligatoire, veste ou blouse de pâtissier, un pantalon professionnel, charlotte, et des chaussures de sécurité ou antidérapantes. Gants à usage alimentaire. Tablier de protection, protections contre la chaleur (gants thermiques)",
+      },
+    ] satisfies ExpectedResult[])("slice '$original' to '$expectedResult'", ({
+      expectedResult,
+      original,
+    }) => {
+      expectToEqual(sliceTextUpToBytesLimit(original, 255), expectedResult);
     });
   });
 });


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
