### PR TITLE
#4494 - Meilleure gestion des retours d'erreur de feature flags (backend injoignable)

### DIFF
--- a/front/src/app/App.tsx
+++ b/front/src/app/App.tsx
@@ -26,6 +26,7 @@ export const App = () => {
   const dispatch = useDispatch();
   const consent = useConsent();
   useSetAcquisitionParams();
+
   return (
     <ErrorBoundary
       fallbackRender={({ error }) => <ErrorPage error={error} />}
@@ -42,7 +43,7 @@ export const App = () => {
           userConsent={!!consent?.finalityConsent?.support}
         />
       )}
-      {ENV.envType === "staging" && (
+      {ENV.envType !== "staging" && (
         <TagContainer
           containerUrl={
             "https://cdn.tagcommander.com/7774/uat/tc_ImmersionFacile_31.js"

--- a/front/src/app/pages/error/front-errors.tsx
+++ b/front/src/app/pages/error/front-errors.tsx
@@ -84,6 +84,29 @@ export const frontErrors = {
       }),
   },
   generic: {
+    backendUnreachable: () =>
+      new FrontSpecificError({
+        title: "Immersion Facilitée est momentanément indisponible",
+        description: (
+          <>
+            <p>
+              Ce problème est temporaire. Veuillez réessayer d'ici quelques
+              minutes.
+            </p>
+            <p>
+              Si le problème persiste :{" "}
+              <a
+                href={immersionFacileSupportUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                contactez-nous
+              </a>
+            </p>
+          </>
+        ),
+        buttons: [HomeButton],
+      }),
     pageNotFound: () =>
       new FrontSpecificError({
         title: "Page non trouvée",

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -15,6 +15,7 @@ import {
 } from "shared";
 import { AdminAgencyDetail } from "src/app/components/forms/agency/AdminAgencyDetail";
 import { AgencyDetailForAgencyDashboard } from "src/app/components/forms/agency/AgencyDetailForAgencyDashboard";
+import { useFeedbackTopic } from "src/app/hooks/feedback.hooks";
 import { AdminTabs } from "src/app/pages/admin/AdminTabs";
 import { AdminUserDetail } from "src/app/pages/admin/AdminUserDetail";
 import { AddAgencyPage } from "src/app/pages/agency/AddAgencyPage";
@@ -340,6 +341,14 @@ const getPageByRouteName: {
 };
 
 export const Router = (): ReactNode => {
+  const featureFlagsGlobalFeedback = useFeedbackTopic("feature-flags-global");
+
+  if (
+    featureFlagsGlobalFeedback?.on === "fetch" &&
+    featureFlagsGlobalFeedback.level === "error"
+  )
+    throw frontErrors.generic.backendUnreachable();
+
   const route = useRoute();
   const routeName = route.name;
   const previousRouteName = useRef<keyof Routes | undefined>(undefined);

--- a/front/src/core-logic/domain/featureFlags/featureFlags.epics.ts
+++ b/front/src/core-logic/domain/featureFlags/featureFlags.epics.ts
@@ -1,6 +1,7 @@
 import { filter, map, switchMap } from "rxjs";
 import { getAdminToken } from "src/core-logic/domain/admin/admin.helpers";
 import { featureFlagsSlice } from "src/core-logic/domain/featureFlags/featureFlags.slice";
+import { catchEpicError } from "src/core-logic/storeConfig/catchEpicError";
 import type {
   ActionOfSlice,
   AppEpic,
@@ -18,6 +19,12 @@ const fetchFeatureFlagsEpic: FeatureFlagEpic = (
     filter(featureFlagsSlice.actions.retrieveFeatureFlagsRequested.match),
     switchMap(technicalGateway.getAllFeatureFlags$),
     map(featureFlagsSlice.actions.retrieveFeatureFlagsSucceeded),
+    catchEpicError((error) =>
+      featureFlagsSlice.actions.retrieveFeatureFlagsFailed({
+        feedbackTopic: "feature-flags-global",
+        errorMessage: error.message,
+      }),
+    ),
   );
 
 const setFeatureFlagEpic: FeatureFlagEpic = (
@@ -31,6 +38,7 @@ const setFeatureFlagEpic: FeatureFlagEpic = (
       adminGateway.updateFeatureFlags$(payload, getAdminToken(state$.value)),
     ),
     map(featureFlagsSlice.actions.setFeatureFlagSucceeded),
+    catchEpicError(featureFlagsSlice.actions.setFeatureFlagFailed),
   );
 
 export const featureFlagEpics = [fetchFeatureFlagsEpic, setFeatureFlagEpic];

--- a/front/src/core-logic/domain/featureFlags/featureFlags.slice.ts
+++ b/front/src/core-logic/domain/featureFlags/featureFlags.slice.ts
@@ -56,6 +56,16 @@ export const featureFlagsSlice = createSlice({
       ...action.payload,
       isLoading: false,
     }),
+    retrieveFeatureFlagsFailed: (
+      state,
+      _action: PayloadAction<{
+        feedbackTopic: "feature-flags-global";
+        errorMessage: string;
+      }>,
+    ): FeatureFlagsState => ({
+      ...state,
+      isLoading: false,
+    }),
     setFeatureFlagRequested: (
       state,
       action: PayloadAction<SetFeatureFlagParam>,
@@ -68,6 +78,10 @@ export const featureFlagsSlice = createSlice({
       },
     }),
     setFeatureFlagSucceeded: (state): FeatureFlagsState => ({
+      ...state,
+      isLoading: false,
+    }),
+    setFeatureFlagFailed: (state): FeatureFlagsState => ({
       ...state,
       isLoading: false,
     }),

--- a/front/src/core-logic/domain/featureFlags/featureFlags.test.ts
+++ b/front/src/core-logic/domain/featureFlags/featureFlags.test.ts
@@ -12,6 +12,7 @@ import {
   type FeatureFlagsState,
   featureFlagsSlice,
 } from "src/core-logic/domain/featureFlags/featureFlags.slice";
+import { feedbacksSelectors } from "src/core-logic/domain/feedback/feedback.selectors";
 import {
   createTestStore,
   type TestDependencies,
@@ -111,6 +112,34 @@ describe("feature flag slice", () => {
     });
   });
 
+  it("fetches feature flags and shows when failed", () => {
+    expectFeatureFlagsStateToEqual({
+      ...defaultFeatureFlags,
+      isLoading: true,
+    });
+    store.dispatch(featureFlagsSlice.actions.retrieveFeatureFlagsRequested());
+    expectFeatureFlagsStateToEqual({
+      ...defaultFeatureFlags,
+      isLoading: true,
+    });
+    dependencies.technicalGateway.featureFlags$.error(
+      new Error("Failed to fetch feature flags"),
+    );
+    expectFeatureFlagsStateToEqual({
+      ...defaultFeatureFlags,
+      isLoading: false,
+    });
+
+    expectToEqual(feedbacksSelectors.feedbacks(store.getState()), {
+      "feature-flags-global": {
+        level: "error",
+        message: "Failed to fetch feature flags",
+        on: "fetch",
+        title: "Problème de communication avec le serveur Immersion Facilitée",
+      },
+    });
+  });
+
   it("sets feature flag to given value", () => {
     ({ store, dependencies } = createTestStore({
       featureFlags: {
@@ -164,6 +193,63 @@ describe("feature flag slice", () => {
         title: "",
       }),
     });
+    expectFeatureFlagsStateToEqual({
+      ...defaultFeatureFlags,
+      enableTemporaryOperation: makeTextImageAndRedirectFeatureFlag(true, {
+        imageAlt: "",
+        imageUrl: "https://",
+        message: "",
+        redirectUrl: "https://",
+        overtitle: "",
+        title: "",
+      }),
+      isLoading: false,
+    });
+  });
+  it("sets feature flag to given value and shows when failed", () => {
+    ({ store, dependencies } = createTestStore({
+      featureFlags: {
+        ...defaultFeatureFlags,
+        enableTemporaryOperation: makeTextImageAndRedirectFeatureFlag(false, {
+          imageAlt: "",
+          imageUrl: "https://",
+          message: "",
+          redirectUrl: "https://",
+          overtitle: "",
+          title: "",
+        }),
+        isLoading: false,
+      },
+    }));
+
+    store.dispatch(
+      featureFlagsSlice.actions.setFeatureFlagRequested({
+        flagName: "enableTemporaryOperation",
+        featureFlag: makeTextImageAndRedirectFeatureFlag(true, {
+          imageAlt: "",
+          imageUrl: "https://",
+          message: "",
+          redirectUrl: "https://",
+          overtitle: "",
+          title: "",
+        }),
+      }),
+    );
+    expectFeatureFlagsStateToEqual({
+      ...defaultFeatureFlags,
+      enableTemporaryOperation: makeTextImageAndRedirectFeatureFlag(true, {
+        imageAlt: "",
+        imageUrl: "https://",
+        message: "",
+        redirectUrl: "https://",
+        overtitle: "",
+        title: "",
+      }),
+      isLoading: true,
+    });
+    dependencies.adminGateway.setFeatureFlagResponse$.error(
+      new Error("Failed to set feature flag"),
+    );
     expectFeatureFlagsStateToEqual({
       ...defaultFeatureFlags,
       enableTemporaryOperation: makeTextImageAndRedirectFeatureFlag(true, {

--- a/front/src/core-logic/domain/feedback/feedback.content.ts
+++ b/front/src/core-logic/domain/feedback/feedback.content.ts
@@ -24,6 +24,7 @@ import { conventionTemplateSlice } from "src/core-logic/domain/convention-templa
 import { discussionSlice } from "src/core-logic/domain/discussion/discussion.slice";
 import { establishmentSlice } from "src/core-logic/domain/establishment/establishment.slice";
 import { establishmentBatchSlice } from "src/core-logic/domain/establishmentBatch/establishmentBatch.slice";
+import { featureFlagsSlice } from "src/core-logic/domain/featureFlags/featureFlags.slice";
 import type {
   ActionKindAndLevel,
   Feedback,
@@ -90,6 +91,7 @@ const topics = [
   "sign-assessment",
   "siret-input",
   "close-agency-and-transfer-conventions",
+  "feature-flags-global",
   "transfer-convention-to-agency",
   "unused",
   "user",
@@ -590,6 +592,13 @@ export const feedbacks: Record<
       title: "Problème lors du transfert des conventions",
       message:
         "Une erreur est survenue lors de la fermeture de l'agence et du transfert des conventions.",
+    },
+  },
+  "feature-flags-global": {
+    "fetch.error": {
+      action: featureFlagsSlice.actions.retrieveFeatureFlagsFailed,
+      title: "Problème de communication avec le serveur Immersion Facilitée",
+      message: "Veuillez réessayer plus tard ou contacter l'assistance.",
     },
   },
   "transfer-convention-to-agency": {


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

- wording vu avec @clarahardy-ai et @bbohec 
- la gestion d'erreur est mise sur le setFeatureFlags, juste pour éviter le loading infini, mais pas de message d'erreur fourni (le besoin est pas remonté)