### PR TITLE
#4794 - Ajustement sur l'affichage des feedbacks utilisateur (lien de connexion déjà utilisé)

### DIFF
--- a/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
+++ b/front/src/app/pages/auth/MagicLinkInterstitialPage.tsx
@@ -7,7 +7,7 @@ import { RenewExpiredJwtButton } from "src/app/components/auth/RenewExpiredJwtBu
 import { FullPageFeedback } from "src/app/components/feedback/FullpageFeedback";
 import { WithFeedbackReplacer } from "src/app/components/feedback/WithFeedbackReplacer";
 import { ErrorPage } from "src/app/pages/error/ErrorPage";
-import { ContactUsButton, frontErrors } from "src/app/pages/error/front-errors";
+import { frontErrors } from "src/app/pages/error/front-errors";
 import { type routes, useRoute } from "src/app/routes/routes";
 import { loginIllustration } from "src/assets/img/illustrations";
 import { authSlice } from "src/core-logic/domain/auth/auth.slice";
@@ -41,12 +41,11 @@ export const MagicLinkInterstitialPage = () => {
         return (
           <ErrorPage
             title={title ?? "Erreur de connexion"}
-            buttons={[RenewJwtButton, ContactUsButton()]}
+            buttons={[RenewJwtButton]}
             error={{
               message: messageText,
               name: title ?? "Erreur de connexion",
             }}
-            feedbackTopic={feedbackTopic}
           />
         );
       }}


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant