### PR TITLE
#4867 - Modification du wording du message d’erreur France travail lorsque le mail ou le téléphone ne correspond pas au dossier

### DIFF
--- a/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
+++ b/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
@@ -178,7 +178,7 @@ export const broadcastFeedbackErrorMessageMap: Record<
   },
   "Identifiant National DE non trouvé": {
     description:
-      "Le bénéficiaire n'est pas inscrit à France Travail OU l'adresse mail indiquée sur la convention n'est pas identique à celle du dossier France travail.",
+      "Le bénéficiaire n’est pas inscrit à France travail OU l’adresse mail OU le numéro de téléphone indiqué sur la convention n’est pas identique à ceux du dossier France travail.",
     solution: (isConventionValidated) => (
       <>
         <p>{"-> "}Dans le cas où il n'est pas inscrit :</p>


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant