### PR TITLE
#4625 - Nouveau texte de la modale validateur et fin du préremplissage par le conseiller référent en l’absence de compte connecté

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
@@ -15,7 +15,6 @@ import { makeFieldError } from "src/app/hooks/formContents.hooks";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { useFormModal } from "src/app/utils/createFormModal";
 import { connectedUserSelectors } from "src/core-logic/domain/connected-user/connectedUser.selectors";
-import { conventionSelectors } from "src/core-logic/domain/convention/convention.selectors";
 
 export const ValidatorModalContent = ({
   onSubmit,
@@ -33,7 +32,6 @@ export const ValidatorModalContent = ({
   >;
 }) => {
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
-  const fetchedConvention = useAppSelector(conventionSelectors.convention);
   const { modalOnCancelCallback, formId } = useFormModal();
   const currentUserName =
     currentUser?.firstName && currentUser?.lastName
@@ -43,15 +41,11 @@ export const ValidatorModalContent = ({
         })
       : undefined;
 
-  const counsellorNameInConvention = fetchedConvention?.agencyReferent
-    ? pick(["firstname", "lastname"], fetchedConvention.agencyReferent)
-    : undefined;
-
   const { register, handleSubmit, formState } =
     useForm<WithFirstnameAndLastname>({
       resolver: zodResolver(withFirstnameAndLastnameSchema),
       mode: "onTouched",
-      defaultValues: currentUserName ?? counsellorNameInConvention,
+      defaultValues: currentUserName,
     });
   const onFormSubmit: SubmitHandler<WithFirstnameAndLastname> = ({
     firstname,
@@ -78,10 +72,10 @@ export const ValidatorModalContent = ({
   return (
     <form onSubmit={handleSubmit(onFormSubmit)} id={formId}>
       <p>
-        Pour {newStatus === "ACCEPTED_BY_VALIDATOR" ? "valider" : "pré-valider"}{" "}
-        la convention, veuillez saisir les informations de la personne qui
-        valide la demande. Ces informations apparaitront sur la convention
-        finale au format PDF.
+        Veuillez saisir votre prénom et votre nom. En{" "}
+        {newStatus === "ACCEPTED_BY_VALIDATOR" ? "validant" : "pré-validant"},
+        vous attestez que ces informations sont exactes : elles apparaîtront sur
+        la convention finale au format PDF.
       </p>
       <Input
         label={"Prénom *"}


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant