### PR TITLE
#4808 + 4883 - Libellé de statut du bilan sur la page convention + fix de l'affichage de l'image dans le header de la page de pilotage de convention dans safari

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -28,6 +28,10 @@ import { SubscriberErrorFeedbackComponent } from "src/app/components/SubscriberE
 import { labelAndSeverityByStatus } from "src/app/contents/convention/labelAndSeverityByStatus";
 import { useFeedbackTopics } from "src/app/hooks/feedback.hooks";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
+import {
+  getAssessmentCompletionStatus,
+  getAssessmentLabelsAndSeverityByStatus,
+} from "src/app/utils/assessment.utils";
 import { commonIllustrations } from "src/assets/img/illustrations";
 import { sendAssessmentLinkSlice } from "src/core-logic/domain/assessment/send-assessment-link/sendAssessmentLink.slice";
 import { connectedUserSelectors } from "src/core-logic/domain/connected-user/connectedUser.selectors";
@@ -37,7 +41,6 @@ import {
 } from "src/core-logic/domain/convention/convention.utils";
 import { sendSignatureLinkSlice } from "src/core-logic/domain/convention/send-signature-link/sendSignatureLink.slice";
 import { partnersErroredConventionSelectors } from "src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.selectors";
-import { useStyles } from "tss-react/dsfr";
 import {
   makeConventionSections,
   SendAssessmentLinkModalWrapper,
@@ -66,7 +69,6 @@ export const ConventionValidation = ({
   jwtParams,
   roles,
 }: ConventionValidationProps) => {
-  const { cx } = useStyles();
   const dispatch = useDispatch();
   const conventionLastBroadcastFeedback = useAppSelector(
     partnersErroredConventionSelectors.lastBroadcastFeedback,
@@ -163,20 +165,31 @@ export const ConventionValidation = ({
 
   return (
     <>
-      <div className={fr.cx("fr-mb-3w")}>
+      <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-mb-3w")}>
         <Badge
-          className={cx(
-            fr.cx("fr-mr-2w"),
-            labelAndSeverityByStatus[status].color,
-          )}
+          className={`${fr.cx("fr-mr-2w")} ${labelAndSeverityByStatus[status].color}`}
         >
           {labelAndSeverityByStatus[status].label}
         </Badge>
         {shouldShowConventionLastBroadcastFeedbackErrorInfo && (
-          <Badge className={cx(fr.cx("fr-mr-2w", "fr-badge--error"))}>
-            ❌ Erreur de synchronisation
+          <Badge className={fr.cx("fr-mr-2w")} severity="error">
+            Erreur de synchronisation
           </Badge>
         )}
+        <Badge
+          className={fr.cx("fr-mr-2w")}
+          severity={
+            getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
+              getAssessmentCompletionStatus(convention.assessment)
+            ].severity
+          }
+        >
+          {
+            getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
+              getAssessmentCompletionStatus(convention.assessment)
+            ].shortLabel
+          }
+        </Badge>
       </div>
       <h1 className={fr.cx("fr-h3")}>{title}</h1>
       {convention.statusJustification && (

--- a/front/src/app/components/agency/agency-dashboard/ConventionsWithAssessmentToCompleteList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionsWithAssessmentToCompleteList.tsx
@@ -7,8 +7,6 @@ import { useCallback } from "react";
 import { HeadingSection, Task } from "react-design-system";
 import { useDispatch } from "react-redux";
 import {
-  type AssessmentCompletionStatusFilter,
-  type ConventionAssessmentFields,
   type ConventionReadDto,
   domElementIds,
   NUMBER_ITEM_TO_DISPLAY_IN_PAGINATED_PAGE,
@@ -16,7 +14,10 @@ import {
 } from "shared";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { routes } from "src/app/routes/routes";
-import { getAssessmentLabelsAndSeverityByStatus } from "src/app/utils/assessment.utils";
+import {
+  getAssessmentCompletionStatus,
+  getAssessmentLabelsAndSeverityByStatus,
+} from "src/app/utils/assessment.utils";
 import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
 import { connectedUserConventionsToManageSelectors } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.selectors";
 import { connectedUserConventionsToManageSlice } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.slice";
@@ -107,7 +108,7 @@ const AssessmentToCompleteTaskItem = ({
 }: {
   convention: ConventionReadDto;
 }) => {
-  const assessmentCompletionStatus = getAssessmentCompletionStatusFilter(
+  const assessmentCompletionStatus = getAssessmentCompletionStatus(
     convention.assessment,
   );
   const title = (
@@ -166,15 +167,4 @@ const AssessmentToCompleteTaskItem = ({
       ]}
     />
   );
-};
-
-const getAssessmentCompletionStatusFilter = (
-  assessment: ConventionAssessmentFields["assessment"],
-): AssessmentCompletionStatusFilter => {
-  if (!assessment) return "to-complete";
-  if ("signedAt" in assessment)
-    return assessment.signedAt !== null || assessment.status === "DID_NOT_SHOW"
-      ? "finalized"
-      : "to-sign";
-  return "finalized";
 };

--- a/front/src/app/pages/convention/AssessmentDocumentPage.tsx
+++ b/front/src/app/pages/convention/AssessmentDocumentPage.tsx
@@ -1,13 +1,11 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { addDays, isBefore } from "date-fns";
 import DOMPurify from "dompurify";
 import { useEffect } from "react";
 import { Document, Loader, MainWrapper } from "react-design-system";
 import { createPortal } from "react-dom";
 import { useDispatch } from "react-redux";
 import {
-  ASSESSEMENT_SIGNATURE_RELEASE_DATE,
   computeTotalHours,
   convertLocaleDateToUtcTimezoneDate,
   domElementIds,
@@ -15,6 +13,7 @@ import {
   getFormattedFirstnameAndLastname,
   immersionFacileHelpdeskRootUrl,
   isAssessmentDto,
+  isBeforeAssessmentSignatureReleaseDate,
   isStringDate,
   makeSiretDescriptionLink,
   toDisplayedDate,
@@ -186,10 +185,7 @@ export const AssessmentDocumentPage = ({
   const isSignedByBeneficiary = !isAssessmentLegacy && !!assessment.signedAt;
   const isBeforeSignatureReleaseDate =
     !isAssessmentLegacy &&
-    isBefore(
-      new Date(assessment.createdAt),
-      addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
-    );
+    isBeforeAssessmentSignatureReleaseDate(assessment.createdAt);
   const isSignatureRequired = !(
     isSignedByBeneficiary ||
     assessment.status === "DID_NOT_SHOW" ||

--- a/front/src/app/utils/assessment.utils.ts
+++ b/front/src/app/utils/assessment.utils.ts
@@ -1,7 +1,8 @@
 import type { BadgeProps } from "@codegouvfr/react-dsfr/Badge";
-import type {
-  AssessmentCompletionStatusFilter,
-  ConventionAssessmentFields,
+import {
+  type AssessmentCompletionStatusFilter,
+  type ConventionAssessmentFields,
+  isBeforeAssessmentSignatureReleaseDate,
 } from "shared";
 
 export type AssessmentLabelsAndSeverity = {
@@ -51,7 +52,8 @@ export const getAssessmentCompletionStatus = (
   if (
     "signedAt" in assessment &&
     assessment.signedAt === null &&
-    assessment.status !== "DID_NOT_SHOW"
+    assessment.status !== "DID_NOT_SHOW" &&
+    !isBeforeAssessmentSignatureReleaseDate(assessment.createdAt)
   )
     return "to-sign";
   return "finalized";

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.scss
@@ -23,7 +23,7 @@
 
     img {
       max-width: 100px;
-      height: fit-content;
+      height: auto;
 
       @include for-screen-min($bp-md) {
         max-width: 100%;

--- a/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
+++ b/libs/react-design-system/src/immersionFacile/components/convention-summary/ConventionSummary.tsx
@@ -70,11 +70,10 @@ export const ConventionSummary = ({
             conventionSummaryStyles.sectionHeader,
           )}
         >
-          <img
-            src={illustration}
-            alt=""
-            className={fr.cx("fr-col-12", "fr-col-md-1")}
-          />
+          <div className={fr.cx("fr-col-12", "fr-col-md-1")}>
+            <img src={illustration} alt="" />
+          </div>
+
           <div
             className={cx(
               fr.cx("fr-col-12", "fr-col-md-11", "fr-grid-row"),

--- a/shared/src/assessment/assessment.helpers.ts
+++ b/shared/src/assessment/assessment.helpers.ts
@@ -1,7 +1,12 @@
+import { addDays, isBefore } from "date-fns";
 import { match } from "ts-pattern";
 import type { ConventionDto } from "../convention/convention.dto";
 import { calculateTotalImmersionHoursBetweenDateComplex } from "../schedule/ScheduleUtils";
-import { type DateString, hoursValueToHoursDisplayed } from "../utils/date";
+import {
+  type DateString,
+  type DateTimeIsoString,
+  hoursValueToHoursDisplayed,
+} from "../utils/date";
 import type {
   AssessmentDto,
   AssessmentStatus,
@@ -9,6 +14,14 @@ import type {
 } from "./assessment.dto";
 
 export const ASSESSEMENT_SIGNATURE_RELEASE_DATE = new Date("2026-03-10");
+
+export const isBeforeAssessmentSignatureReleaseDate = (
+  assessmentCreatedAt: DateTimeIsoString,
+): boolean =>
+  isBefore(
+    new Date(assessmentCreatedAt),
+    addDays(ASSESSEMENT_SIGNATURE_RELEASE_DATE, 1),
+  );
 
 export const computeTotalHours = ({
   convention,


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
