### PR TITLE
#4880 - Tech - ajout du suivi de userId dans les notifications

### DIFF
--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -705,6 +705,7 @@ interface NotificationsEmail {
   email_kind: string;
   created_at: Timestamp;
   convention_id: string | null;
+  user_id: string | null;
   establishment_siret: string | null;
   agency_id: string | null;
   params: Json | null;
@@ -735,6 +736,7 @@ interface NotificationsSms {
   created_at: Timestamp;
   recipient_phone: string;
   convention_id: string | null;
+  user_id: string | null;
   establishment_siret: string | null;
   agency_id: string | null;
   params: Json | null;

--- a/back/src/config/pg/migrations/1776855312363_add-userid-in-notifications-table.ts
+++ b/back/src/config/pg/migrations/1776855312363_add-userid-in-notifications-table.ts
@@ -1,0 +1,27 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn("notifications_email", {
+    user_id: { type: "uuid", notNull: false },
+  });
+  pgm.addColumn("notifications_sms", {
+    user_id: { type: "uuid", notNull: false },
+  });
+  pgm.createIndex("notifications_email", "user_id", {
+    name: "notifications_email_user_id_index",
+  });
+  pgm.createIndex("notifications_sms", "user_id", {
+    name: "notifications_sms_user_id_index",
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("notifications_sms", "user_id", {
+    name: "notifications_sms_user_id_index",
+  });
+  pgm.dropIndex("notifications_email", "user_id", {
+    name: "notifications_email_user_id_index",
+  });
+  pgm.dropColumn("notifications_email", "user_id");
+  pgm.dropColumn("notifications_sms", "user_id");
+}

--- a/back/src/domains/core/notifications/adapters/PgNotificationRepository.integration.test.ts
+++ b/back/src/domains/core/notifications/adapters/PgNotificationRepository.integration.test.ts
@@ -404,6 +404,47 @@ describe("PgNotificationRepository", () => {
       });
     });
 
+    it("round-trips followedIds.userId on email and sms notifications", async () => {
+      const userId = "dddddddd-1111-4111-1111-dddddddddddd";
+
+      const { id: emailId, emailNotification } =
+        createTemplatedEmailAndNotification({
+          recipients: ["user@mail.com"],
+          sender: {
+            email: "recette@immersion-facile.beta.gouv.fr",
+            name: "Recette Immersion Facile",
+          },
+        });
+      const emailWithUserId: EmailNotification = {
+        ...emailNotification,
+        followedIds: { ...emailNotification.followedIds, userId },
+      };
+
+      const smsWithUserId: SmsNotification = {
+        ...smsNotification,
+        followedIds: { ...smsNotification.followedIds, userId },
+      };
+
+      await pgNotificationRepository.save(emailWithUserId);
+      await pgNotificationRepository.save(smsWithUserId);
+
+      expectToEqual(
+        await pgNotificationRepository.getByIdAndKind(emailId, "email"),
+        {
+          ...emailWithUserId,
+          templatedContent: {
+            ...emailWithUserId.templatedContent,
+            cc: [],
+          },
+          ...withToBeSendState,
+        },
+      );
+      expectToEqual(
+        await pgNotificationRepository.getByIdAndKind(smsNotificationId, "sms"),
+        { ...smsWithUserId, ...withToBeSendState },
+      );
+    });
+
     it("save and eliminates duplicates when cc ends up empty after de-duplication", async () => {
       const { id, emailNotification } = createTemplatedEmailAndNotification({
         recipients: ["bob@mail.com"],

--- a/back/src/domains/core/notifications/adapters/PgNotificationRepository.ts
+++ b/back/src/domains/core/notifications/adapters/PgNotificationRepository.ts
@@ -378,6 +378,7 @@ export class PgNotificationRepository implements NotificationRepository {
           sms_kind: notification.templatedContent.kind,
           recipient_phone: notification.templatedContent.recipientPhone,
           convention_id: notification.followedIds.conventionId,
+          user_id: notification.followedIds.userId,
           establishment_siret: notification.followedIds.establishmentSiret,
           agency_id: notification.followedIds.agencyId,
           params: JSON.stringify(notification.templatedContent.params),
@@ -442,6 +443,7 @@ export class PgNotificationRepository implements NotificationRepository {
             created_at: createdAt,
             email_kind: templatedContent.kind,
             convention_id: followedIds.conventionId,
+            user_id: followedIds.userId,
             establishment_siret: followedIds.establishmentSiret,
             agency_id: followedIds.agencyId,
             params: JSON.stringify(templatedContent.params),
@@ -475,6 +477,7 @@ const getSmsNotificationBuilder = (transaction: KyselyDb) =>
           conventionId: eb.ref("convention_id"),
           establishmentId: eb.ref("establishment_siret"),
           agencyId: eb.ref("agency_id"),
+          userId: eb.ref("user_id"),
         }),
       ),
       templatedContent: jsonBuildObject({
@@ -511,6 +514,7 @@ const getEmailsNotificationBuilder = (transaction: KyselyDb) =>
             conventionId: ref("convention_id"),
             establishmentId: ref("establishment_siret"),
             agencyId: ref("agency_id"),
+            userId: ref("user_id"),
           }),
         ),
         templatedContent: jsonBuildObject({


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Prérequis isolé de #4358 (alerte utilisateur inactif), refs #4880. Parent #4004.

- Ajoute `notifications_email.user_id` et `notifications_sms.user_id` (uuid, nullable) + index.
- Branche la lecture/écriture de `followedIds.userId` dans `PgNotificationRepository` (email + SMS).
- Test d'intégration de round-trip sur email et SMS.

**Scope volontairement étroit** : pas de backfill, pas de mass-edit des call-sites. `WarnInactiveUsers` (sur #4358) ne lit que ses propres notifications, donc peupler `user_id` dès la première exécution suffit. Les autres call-sites seront migrés de façon opportuniste quand un futur use case aura besoin du lien.

#4358 pourra rebase sur cette PR une fois mergée.