### PR TITLE
#4865 - Ne pas bloquer le script d'envoi de mail de bilan au tuteur si des conventions ne passent pas le schéma de validation

### DIFF
--- a/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
+++ b/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
@@ -189,7 +189,7 @@ describe("Assessment routes", () => {
 
     it("fails with 403 if convention id does not matches the one in token", async () => {
       const anotherConvention = new ConventionDtoBuilder()
-        .withId("another-convention-id")
+        .withId("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
         .withAgencyId(agency.id)
         .build();
 

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -384,6 +384,8 @@ const makeApplyFiltersToGetConventionIds =
     withAppelationCodes,
     withBeneficiary,
     withDateStart,
+    withEndDate,
+    withUpdateDate,
     withEstablishmentRepresentative,
     withEstablishmentTutor,
     withSirets,
@@ -396,6 +398,18 @@ const makeApplyFiltersToGetConventionIds =
           withDateStart?.to ? dateStart <= withDateStart : true,
         ({ dateStart }) =>
           withDateStart?.from ? dateStart >= withDateStart : true,
+        ({ dateEnd }) =>
+          withEndDate?.to ? new Date(dateEnd) <= withEndDate.to : true,
+        ({ dateEnd }) =>
+          withEndDate?.from ? new Date(dateEnd) >= withEndDate.from : true,
+        ({ updatedAt }) =>
+          withUpdateDate?.to && updatedAt
+            ? new Date(updatedAt) <= withUpdateDate.to
+            : true,
+        ({ updatedAt }) =>
+          withUpdateDate?.from && updatedAt
+            ? new Date(updatedAt) >= withUpdateDate.from
+            : true,
         ({ establishmentTutor }) =>
           withEstablishmentTutor?.email
             ? establishmentTutor.email === withEstablishmentTutor.email

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -9,6 +9,7 @@ import {
   type ConventionScope,
   type ConventionsWithErroredBroadcastFeedbackFilters,
   type ConventionWithBroadcastFeedback,
+  conventionReadSchema,
   conventionSchema,
   type DataWithPagination,
   errors,
@@ -68,7 +69,15 @@ export class InMemoryConventionQueries implements ConventionQueries {
     );
     if (!convention) return;
 
-    return this.#addAgencyAndAssessmentDataToConvention(convention);
+    const conventionReadDto =
+      await this.#addAgencyAndAssessmentDataToConvention(convention);
+    return validateAndParseZodSchema({
+      schemaName: "conventionReadSchema",
+      inputSchema: conventionReadSchema,
+      schemaParsingInput: conventionReadDto,
+      id: convention.id,
+      logger,
+    });
   }
 
   public getConventionsByFiltersCalled = 0;

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -840,6 +840,84 @@ describe("Pg implementation of ConventionQueries", () => {
       });
     });
 
+    describe("with date filters", () => {
+      const conventionFrom15To25 = new ConventionDtoBuilder()
+        .withId("a56ce4c4-0fe9-49f8-b1fb-e84d9994a1f0")
+        .withAgencyId(agency.id)
+        .withDateStart("2026-01-15")
+        .withDateEnd("2026-01-25")
+        .build();
+      const conventionFrom10To20 = new ConventionDtoBuilder()
+        .withId("dc5d0d4f-6f49-4658-9075-6f4ff7f0d4ca")
+        .withAgencyId(agency.id)
+        .withDateStart("2026-01-10")
+        .withDateEnd("2026-01-20")
+        .build();
+      const conventionFrom20To30 = new ConventionDtoBuilder()
+        .withId("5e7eb66f-854f-4e99-83e9-f348ac767f45")
+        .withAgencyId(agency.id)
+        .withDateStart("2026-01-20")
+        .withDateEnd("2026-01-30")
+        .build();
+
+      beforeEach(async () => {
+        await conventionRepository.save(
+          conventionFrom10To20,
+          new Date("2026-01-11T00:00:00.000Z").toISOString(),
+        );
+        await conventionRepository.save(
+          conventionFrom15To25,
+          new Date("2026-01-16T00:00:00.000Z").toISOString(),
+        );
+        await conventionRepository.save(
+          conventionFrom20To30,
+          new Date("2026-01-21T00:00:00.000Z").toISOString(),
+        );
+      });
+
+      it("filters by withDateStart range", async () => {
+        expectToEqual(
+          await conventionQueries.getConventionIdsByFilters({
+            filters: {
+              withDateStart: {
+                from: new Date("2026-01-12"),
+                to: new Date("2026-01-18"),
+              },
+            },
+          }),
+          [conventionFrom15To25.id],
+        );
+      });
+
+      it("filters by withEndDate range", async () => {
+        expectToEqual(
+          await conventionQueries.getConventionIdsByFilters({
+            filters: {
+              withEndDate: {
+                from: new Date("2026-01-18"),
+                to: new Date("2026-01-26"),
+              },
+            },
+          }),
+          [conventionFrom15To25.id, conventionFrom10To20.id],
+        );
+      });
+
+      it("filters by withUpdateDate range", async () => {
+        expectToEqual(
+          await conventionQueries.getConventionIdsByFilters({
+            filters: {
+              withUpdateDate: {
+                from: new Date("2026-01-15"),
+                to: new Date("2026-01-18"),
+              },
+            },
+          }),
+          [conventionFrom15To25.id],
+        );
+      });
+    });
+
     describe("limit", () => {
       const convention1 = new ConventionDtoBuilder()
         .withId(uuid())

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -69,6 +69,8 @@ export class PgConventionQueries implements ConventionQueries {
       withAppelationCodes,
       withBeneficiary,
       withDateStart,
+      withEndDate,
+      withUpdateDate,
       withEstablishmentRepresentative,
       withEstablishmentTutor,
       withSirets,
@@ -81,6 +83,7 @@ export class PgConventionQueries implements ConventionQueries {
         .selectFrom("conventions")
         .select("conventions.id")
         .orderBy("conventions.date_start", "desc"),
+      addDateFilters({ withDateStart, withEndDate, withUpdateDate }),
       (qb) =>
         withAppelationCodes
           ? qb.where(
@@ -93,15 +96,6 @@ export class PgConventionQueries implements ConventionQueries {
         withSirets ? qb.where("conventions.siret", "in", withSirets) : qb,
       (qb) =>
         withStatuses ? qb.where("conventions.status", "in", withStatuses) : qb,
-      (qb) =>
-        withDateStart?.to
-          ? qb.where("conventions.date_start", "<=", withDateStart.to)
-          : qb,
-      (qb) =>
-        withDateStart?.from
-          ? qb.where("conventions.date_start", ">=", withDateStart.from)
-          : qb,
-      (qb) => (limit ? qb.limit(limit) : qb),
       (qb) =>
         withEstablishmentRepresentative?.email
           ? qb
@@ -156,6 +150,8 @@ export class PgConventionQueries implements ConventionQueries {
                   : qb,
             )
           : qb,
+      (qb) => qb.orderBy("conventions.date_start", "desc"),
+      (qb) => (limit ? qb.limit(limit) : qb),
     ).execute();
 
     return pgResults.map(({ id }) => id);
@@ -813,17 +809,61 @@ const addFiltersToBuilder =
         withSirets && withSirets.length > 0
           ? b.where("conventions.siret", "=", sql<SiretDto>`ANY(${withSirets})`)
           : b,
+      addDateFilters({
+        withEndDate: endDate,
+        withUpdateDate: updateDate,
+      }),
+    );
+
+type DateFilterableBuilder<TBuilder> = {
+  where: (...args: unknown[]) => TBuilder;
+};
+
+const addDateFilters =
+  <TBuilder extends DateFilterableBuilder<TBuilder>>({
+    withDateStart,
+    withEndDate,
+    withUpdateDate,
+  }: {
+    withDateStart?: {
+      from?: Date | string;
+      to?: Date | string;
+    };
+    withEndDate?: {
+      from?: Date | string;
+      to?: Date | string;
+    };
+    withUpdateDate?: {
+      from?: Date | string;
+      to?: Date | string;
+    };
+  }) =>
+  (builder: TBuilder): TBuilder =>
+    pipeWithValue(
+      builder,
       (b) =>
-        endDate?.from ? b.where("conventions.date_end", ">=", endDate.from) : b,
-      (b) =>
-        endDate?.to ? b.where("conventions.date_end", "<=", endDate.to) : b,
-      (b) =>
-        updateDate?.from
-          ? b.where("conventions.updated_at", ">=", updateDate.from)
+        withDateStart?.to
+          ? b.where("conventions.date_start", "<=", withDateStart.to)
           : b,
       (b) =>
-        updateDate?.to
-          ? b.where("conventions.updated_at", "<=", updateDate.to)
+        withDateStart?.from
+          ? b.where("conventions.date_start", ">=", withDateStart.from)
+          : b,
+      (b) =>
+        withEndDate?.from
+          ? b.where("conventions.date_end", ">=", withEndDate.from)
+          : b,
+      (b) =>
+        withEndDate?.to
+          ? b.where("conventions.date_end", "<=", withEndDate.to)
+          : b,
+      (b) =>
+        withUpdateDate?.from
+          ? b.where("conventions.updated_at", ">=", withUpdateDate.from)
+          : b,
+      (b) =>
+        withUpdateDate?.to
+          ? b.where("conventions.updated_at", "<=", withUpdateDate.to)
           : b,
     );
 

--- a/back/src/domains/convention/ports/ConventionQueries.ts
+++ b/back/src/domains/convention/ports/ConventionQueries.ts
@@ -51,6 +51,8 @@ export type GetConventionIdsParams = {
   filters: {
     withAppelationCodes?: AppellationCode[];
     withDateStart?: OptionalDateRange;
+    withEndDate?: OptionalDateRange;
+    withUpdateDate?: OptionalDateRange;
     withSirets?: SiretDto[];
     withStatuses?: ConventionStatus[];
     withBeneficiary?: {

--- a/back/src/domains/convention/use-cases/GetConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetConvention.unit.test.ts
@@ -82,28 +82,31 @@ describe("Get Convention", () => {
     .withAgencyId(agency.id)
     .withEstablishmentRepresentative({
       email: "estab-rep@email.com",
-      firstName: "",
-      lastName: "",
-      phone: "",
+      firstName: "John",
+      lastName: "LeRepEtablissement",
+      phone: "+590590275843",
       role: "establishment-representative",
+      signedAt: new Date().toISOString(),
     })
     .withBeneficiaryRepresentative({
       email: "benef-rep@email.com",
-      firstName: "",
-      lastName: "",
-      phone: "",
+      firstName: "Joel",
+      lastName: "LeRepBeneficiaire",
+      phone: "+262269612345",
       role: "beneficiary-representative",
+      signedAt: new Date().toISOString(),
     })
     .withBeneficiaryCurrentEmployer({
-      email: "benef-rep@email.com",
-      firstName: "",
-      lastName: "",
-      phone: "",
+      email: "benef-employer@email.com",
+      firstName: "Julie",
+      lastName: "Lemployeur",
+      phone: "+33555689727",
       businessAddress: "",
-      businessName: "",
-      businessSiret: "",
+      businessName: "Current employer",
+      businessSiret: "12345678912345",
       job: "",
       role: "beneficiary-current-employer",
+      signedAt: new Date().toISOString(),
     })
     .withStatus("ACCEPTED_BY_VALIDATOR")
     .withEstablishmentRepresentativeEmail(establishmentRep.email)

--- a/back/src/domains/convention/use-cases/SignConvention.unit.test.ts
+++ b/back/src/domains/convention/use-cases/SignConvention.unit.test.ts
@@ -19,6 +19,7 @@ import {
   type Signatories,
   splitCasesBetweenPassingAndFailing,
 } from "shared";
+import { match } from "ts-pattern";
 import { toAgencyWithRights } from "../../../utils/agency";
 import type { DomainEvent } from "../../core/events/events";
 import { makeCreateNewEvent } from "../../core/events/ports/EventBus";
@@ -34,7 +35,7 @@ import { makeSignConvention, type SignConvention } from "./SignConvention";
 const beneficiaryRepresentative: BeneficiaryRepresentative = {
   role: "beneficiary-representative",
   email: "bob@email.com",
-  phone: "0665565432",
+  phone: "+33665565432",
   firstName: "Bob",
   lastName: "L'éponge",
 };
@@ -42,7 +43,7 @@ const beneficiaryRepresentative: BeneficiaryRepresentative = {
 const establishmentRepresentative: EstablishmentRepresentative = {
   role: "establishment-representative",
   email: "patron@email.com",
-  phone: "0665565432",
+  phone: "+33665565432",
   firstName: "Pa",
   lastName: "Tron",
 };
@@ -189,7 +190,13 @@ describe("Sign convention", () => {
           ),
           errors.convention.badStatusTransition({
             currentStatus: initialStatus,
-            targetStatus: "PARTIALLY_SIGNED",
+            targetStatus: [
+              "ACCEPTED_BY_VALIDATOR",
+              "ACCEPTED_BY_COUNSELLOR",
+              "IN_REVIEW",
+            ].includes(initialStatus)
+              ? "IN_REVIEW"
+              : "PARTIALLY_SIGNED",
           }),
         );
       });
@@ -439,20 +446,55 @@ describe("Sign convention", () => {
   });
 
   const conventionId: ConventionId = "abd5c20e-6dd2-45af-affe-927358005251";
-  const prepareAgencyAndConventionWithStatus = (status: ConventionStatus) => {
+  const prepareAgencyAndConventionWithStatus = (
+    initialStatus: ConventionStatus,
+  ) => {
     const agency = new AgencyDtoBuilder().build();
 
-    return {
-      agency,
-      convention: new ConventionDtoBuilder()
-        .withId(conventionId)
-        .withAgencyId(agency.id)
-        .withStatus(status)
-        .withBeneficiaryRepresentative(beneficiaryRepresentative)
-        .withEstablishmentRepresentative(establishmentRepresentative)
-        .notSigned()
-        .build(),
-    };
+    const conventionBuilder = new ConventionDtoBuilder()
+      .withId(conventionId)
+      .withAgencyId(agency.id)
+      .withStatus(initialStatus)
+      .withBeneficiaryRepresentative(beneficiaryRepresentative)
+      .withEstablishmentRepresentative(establishmentRepresentative);
+
+    return match(initialStatus)
+      .with(
+        "ACCEPTED_BY_VALIDATOR",
+        "ACCEPTED_BY_COUNSELLOR",
+        "IN_REVIEW",
+        () => {
+          return {
+            agency,
+            convention: conventionBuilder
+              .withBeneficiarySignedAt(new Date())
+              .withEstablishmentRepresentative({
+                ...establishmentRepresentative,
+                signedAt: new Date().toISOString(),
+              })
+              .withBeneficiaryRepresentative({
+                ...beneficiaryRepresentative,
+                signedAt: new Date().toISOString(),
+              })
+              .build(),
+          };
+        },
+      )
+      .with("PARTIALLY_SIGNED", () => {
+        return {
+          agency,
+          convention: conventionBuilder
+            .withBeneficiarySignedAt(new Date())
+            .build(),
+        };
+      })
+      .with("READY_TO_SIGN", "REJECTED", "CANCELLED", "DEPRECATED", () => {
+        return {
+          agency,
+          convention: conventionBuilder.notSigned().build(),
+        };
+      })
+      .exhaustive();
   };
 
   const expectAllowedInitialStatus = (status: ConventionStatus) =>

--- a/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreated.unit.test.ts
@@ -38,7 +38,7 @@ const validator = new ConnectedUserBuilder()
 const convention = new ConventionDtoBuilder()
   .withAgencyId(agency.id)
   .withDateStart(new Date("2025-01-01").toISOString())
-  .withDateEnd(new Date("2025-01-15").toISOString())
+  .withDateEnd(new Date("2025-01-03").toISOString())
   .withSchedule(reasonableSchedule)
   .withStatus("ACCEPTED_BY_VALIDATOR")
   .build();
@@ -155,7 +155,7 @@ describe("NotifyAgencyThatAssessmentIsCreated", () => {
             immersionAppellationLabel:
               convention.immersionAppellation.appellationLabel,
             assessment: signedAssessment,
-            numberOfHoursMade: "45h",
+            numberOfHoursMade: "17h",
             manageConventionLink: `${config.immersionFacileBaseUrl}${makeUrlWithQueryParams(
               `/${frontRoutes.manageConventionUserConnected}`,
               { conventionId: convention.id },
@@ -183,7 +183,7 @@ describe("NotifyAgencyThatAssessmentIsCreated", () => {
             immersionAppellationLabel:
               convention.immersionAppellation.appellationLabel,
             assessment: signedAssessment,
-            numberOfHoursMade: "45h",
+            numberOfHoursMade: "17h",
             manageConventionLink: `${config.immersionFacileBaseUrl}${makeUrlWithQueryParams(
               `/${frontRoutes.manageConventionUserConnected}`,
               { conventionId: convention.id },
@@ -332,7 +332,7 @@ describe("NotifyAgencyThatAssessmentIsCreated", () => {
               immersionAppellationLabel:
                 convention.immersionAppellation.appellationLabel,
               assessment: signedAssessment,
-              numberOfHoursMade: "45h",
+              numberOfHoursMade: "17h",
               manageConventionLink: `${config.immersionFacileBaseUrl}${makeUrlWithQueryParams(
                 `/${frontRoutes.manageConventionUserConnected}`,
                 { conventionId: convention.id },

--- a/back/src/domains/convention/use-cases/notifications/NotifyConventionReminder.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyConventionReminder.unit.test.ts
@@ -630,7 +630,6 @@ describe("NotifyThatConventionStillNeedToBeSigned use case", () => {
       ["+33600000001"], // Metropole
       ["+262639000001"], // Mayotte
       ["+590690000001"], // Guadeloupe
-      ["+590691000001"], // Guadeloupe
       ["+594694000001"], // Guyane
       ["+596696000001"], // Martinique
       ["+262692000001"], // Réunion

--- a/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
@@ -13,6 +13,7 @@ import {
   getFormattedFirstnameAndLastname,
   makeUrlWithQueryParams,
   type Notification,
+  reasonableSchedule,
 } from "shared";
 import type { AppConfig } from "../../../config/bootstrap/appConfig";
 import { AppConfigBuilder } from "../../../utils/AppConfigBuilder";
@@ -142,6 +143,7 @@ describe("AssessmentReminder", () => {
   });
 
   describe("reminders are sent", () => {
+    let immersionDateEnd: Date;
     let now: Date;
     let agency: AgencyDto;
     let convention: ConventionDto;
@@ -149,10 +151,13 @@ describe("AssessmentReminder", () => {
 
     beforeEach(async () => {
       now = timeGateway.now();
+      immersionDateEnd = subMonths(now, 3);
       agency = new AgencyDtoBuilder().build();
       convention = new ConventionDtoBuilder()
         .withStatus("ACCEPTED_BY_VALIDATOR")
-        .withDateEnd(subMonths(now, 3).toISOString())
+        .withDateStart(subDays(immersionDateEnd, 2).toISOString())
+        .withDateEnd(immersionDateEnd.toISOString())
+        .withSchedule(reasonableSchedule)
         .withAgencyId(agency.id)
         .build();
 
@@ -431,11 +436,13 @@ describe("AssessmentReminder", () => {
 
     it("when internshipKind is mini-stage-cci, only send reminder to tutor and not agency", async () => {
       const miniStageConvention = new ConventionDtoBuilder()
-        .withId("77777777-6666-4777-7777-777777777777")
+        .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2")
         .withInternshipKind("mini-stage-cci")
         .withStatus("ACCEPTED_BY_VALIDATOR")
-        .withDateEnd(subMonths(now, 3).toISOString())
+        .withDateStart(subDays(immersionDateEnd, 2).toISOString())
+        .withDateEnd(immersionDateEnd.toISOString())
         .withAgencyId(agency.id)
+        .withSchedule(reasonableSchedule)
         .build();
       await uow.conventionRepository.save(miniStageConvention);
       const initialEstablishmentNotification: Notification =

--- a/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
+++ b/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
@@ -1,5 +1,5 @@
 import subDays from "date-fns/subDays";
-import { partition, uniqBy } from "ramda";
+import { partition, uniq } from "ramda";
 import {
   type AbsoluteUrl,
   type AgencyWithUsersRights,
@@ -80,15 +80,17 @@ export const makeSendAssessmentNeededNotifications = useCaseBuilder(
       conventionsQtyWithImmersionEnding,
       conventionsQtyWithAlreadyExistingAssessment,
       conventionsThatDontHaveAssessment,
-    } = await getConventionsToSendEmailTo(deps, inputParams);
+    } = await getConventionIdsToSendEmailTo(deps, inputParams);
 
     const results = await executeInSequence(
       conventionsThatDontHaveAssessment,
-      (convention) =>
+      (conventionId) =>
         deps.uowPerformer
           // each transaction could fail here without impacting others
-          .perform((uow) => sendAssessmentNotifications(uow, deps, convention))
-          .catch((error) => ({ id: convention.id, error: castError(error) })),
+          .perform((uow) =>
+            sendAssessmentNotifications(uow, deps, conventionId),
+          )
+          .catch((error) => ({ id: conventionId, error: castError(error) })),
     );
 
     const [conventionIdsWithError, conventionIdsWithoutError] = partition(
@@ -114,58 +116,51 @@ export const makeSendAssessmentNeededNotifications = useCaseBuilder(
     };
   });
 
-const getConventionsToSendEmailTo = async (
+const getConventionIdsToSendEmailTo = async (
   deps: Deps,
   params: SendAssessmentParams,
 ): Promise<{
   conventionsQtyWithImmersionEnding: number;
-  conventionsThatDontHaveAssessment: ConventionDto[];
+  conventionsThatDontHaveAssessment: ConventionId[];
   conventionsQtyWithAlreadyExistingAssessment: number;
 }> => {
   const conventionsEndingInRange =
-    await deps.outOfTransaction.conventionQueries.getConventions({
+    await deps.outOfTransaction.conventionQueries.getConventionIdsByFilters({
       filters: {
-        endDate: params.conventionEndDate,
+        withEndDate: params.conventionEndDate,
         withStatuses: validatedConventionStatuses,
       },
-      sortBy: "dateStart",
     });
 
   const conventionsUpdatedInRangeAndEndingUpToRange =
-    await deps.outOfTransaction.conventionQueries.getConventions({
+    await deps.outOfTransaction.conventionQueries.getConventionIdsByFilters({
       filters: {
-        endDate: {
+        withEndDate: {
           to: params.conventionEndDate.to,
         },
-        updateDate: {
+        withUpdateDate: {
           from: subDays(params.conventionEndDate.from, 2),
           to: params.conventionEndDate.to,
         },
         withStatuses: validatedConventionStatuses,
       },
-      sortBy: "dateStart",
     });
 
-  const conventionsThatRequireAnAssessment = uniqBy(
-    (c) => c.id,
-    [
-      ...conventionsEndingInRange,
-      ...conventionsUpdatedInRangeAndEndingUpToRange,
-    ],
-  );
+  const conventionsThatRequireAnAssessment = uniq([
+    ...conventionsEndingInRange,
+    ...conventionsUpdatedInRangeAndEndingUpToRange,
+  ]);
 
   const conventionIdsWithAlreadyExistingAssessment =
     await deps.outOfTransaction.assessmentRepository
-      .getByConventionIds(
-        conventionsThatRequireAnAssessment.map(({ id }) => id),
-      )
+      .getByConventionIds(conventionsThatRequireAnAssessment)
       .then((assessments) =>
         assessments.map(({ conventionId }) => conventionId),
       );
 
   const conventionsThatDontHaveAssessment =
     conventionsThatRequireAnAssessment.filter(
-      ({ id }) => !conventionIdsWithAlreadyExistingAssessment.includes(id),
+      (id) => !conventionIdsWithAlreadyExistingAssessment.includes(id),
     );
 
   return {
@@ -180,14 +175,18 @@ const getConventionsToSendEmailTo = async (
 const sendAssessmentNotifications = async (
   uow: UnitOfWork,
   deps: Deps,
-  convention: ConventionDto,
+  conventionId: ConventionId,
 ): Promise<{ id: ConventionId }> => {
+  const convention =
+    await uow.conventionQueries.getConventionById(conventionId);
+  if (!convention) throw errors.convention.notFound({ conventionId });
+
   const agency = await uow.agencyRepository.getById(convention.agencyId);
   if (!agency) throw errors.agency.notFound({ agencyId: convention.agencyId });
 
   const alreadySentNotifications =
     await uow.notificationRepository.getEmailsByFilters({
-      conventionId: convention.id,
+      conventionId,
     });
 
   const isBeneficiaryNotificationNotSent =

--- a/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
+++ b/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.ts
@@ -79,11 +79,11 @@ export const makeSendAssessmentNeededNotifications = useCaseBuilder(
     const {
       conventionsQtyWithImmersionEnding,
       conventionsQtyWithAlreadyExistingAssessment,
-      conventionsThatDontHaveAssessment,
+      conventionIdsThatDontHaveAssessment,
     } = await getConventionIdsToSendEmailTo(deps, inputParams);
 
     const results = await executeInSequence(
-      conventionsThatDontHaveAssessment,
+      conventionIdsThatDontHaveAssessment,
       (conventionId) =>
         deps.uowPerformer
           // each transaction could fail here without impacting others
@@ -121,10 +121,10 @@ const getConventionIdsToSendEmailTo = async (
   params: SendAssessmentParams,
 ): Promise<{
   conventionsQtyWithImmersionEnding: number;
-  conventionsThatDontHaveAssessment: ConventionId[];
+  conventionIdsThatDontHaveAssessment: ConventionId[];
   conventionsQtyWithAlreadyExistingAssessment: number;
 }> => {
-  const conventionsEndingInRange =
+  const conventionIdsEndingInRange =
     await deps.outOfTransaction.conventionQueries.getConventionIdsByFilters({
       filters: {
         withEndDate: params.conventionEndDate,
@@ -132,7 +132,7 @@ const getConventionIdsToSendEmailTo = async (
       },
     });
 
-  const conventionsUpdatedInRangeAndEndingUpToRange =
+  const conventionIdsUpdatedInRangeAndEndingUpToRange =
     await deps.outOfTransaction.conventionQueries.getConventionIdsByFilters({
       filters: {
         withEndDate: {
@@ -146,29 +146,29 @@ const getConventionIdsToSendEmailTo = async (
       },
     });
 
-  const conventionsThatRequireAnAssessment = uniq([
-    ...conventionsEndingInRange,
-    ...conventionsUpdatedInRangeAndEndingUpToRange,
+  const conventionIdsThatRequireAnAssessment = uniq([
+    ...conventionIdsEndingInRange,
+    ...conventionIdsUpdatedInRangeAndEndingUpToRange,
   ]);
 
   const conventionIdsWithAlreadyExistingAssessment =
     await deps.outOfTransaction.assessmentRepository
-      .getByConventionIds(conventionsThatRequireAnAssessment)
+      .getByConventionIds(conventionIdsThatRequireAnAssessment)
       .then((assessments) =>
         assessments.map(({ conventionId }) => conventionId),
       );
 
-  const conventionsThatDontHaveAssessment =
-    conventionsThatRequireAnAssessment.filter(
+  const conventionIdsThatDontHaveAssessment =
+    conventionIdsThatRequireAnAssessment.filter(
       (id) => !conventionIdsWithAlreadyExistingAssessment.includes(id),
     );
 
   return {
     conventionsQtyWithImmersionEnding:
-      conventionsThatRequireAnAssessment.length,
+      conventionIdsThatRequireAnAssessment.length,
     conventionsQtyWithAlreadyExistingAssessment:
       conventionIdsWithAlreadyExistingAssessment.length,
-    conventionsThatDontHaveAssessment,
+    conventionIdsThatDontHaveAssessment,
   };
 };
 

--- a/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/SendAssessmentNeededNotifications.unit.test.ts
@@ -608,8 +608,58 @@ describe("SendAssessmentNeededNotifications", () => {
   });
 
   describe("Error handling report", () => {
+    it("shows error in report about schema parsing error but does not fail the entire script", async () => {
+      const phoneNumber =
+        conventionEndedYesterday.signatories.beneficiary.phone;
+      const conventionWithSignatoriesWithSamePhoneNumber =
+        new ConventionDtoBuilder({ ...conventionEndedYesterday })
+          .withBeneficiaryPhone(phoneNumber)
+          .withEstablishmentRepresentativePhone(phoneNumber)
+          .withDateSubmission(
+            new Date("2026-01-01T00:00:00.000Z").toISOString(),
+          )
+          .build();
+      uow.conventionRepository.setConventions([
+        conventionWithSignatoriesWithSamePhoneNumber,
+        conventionEndingTomorrow,
+      ]);
+
+      expectToEqual(
+        await sendEmailWithAssessmentCreationLink.execute({
+          conventionEndDate: {
+            from: yesterday,
+            to: inOneDay,
+          },
+        }),
+        {
+          conventionsQtyWithAlreadyExistingAssessment: 0,
+          conventionsQtyWithAssessmentSentSuccessfully: 1,
+          conventionsQtyWithImmersionEnding: 2,
+          conventionsAssessmentSentErrored: {
+            [conventionWithSignatoriesWithSamePhoneNumber.id]: new Error(
+              `Schema validation failed for schema conventionReadSchema for element with id ${conventionWithSignatoriesWithSamePhoneNumber.id}. See issues for details.`,
+            ),
+          },
+        },
+      );
+
+      expectObjectInArrayToMatch(uow.outboxRepository.events, [
+        { topic: "NotificationAdded" },
+        { topic: "NotificationAdded" },
+        {
+          topic: "EmailWithLinkToCreateAssessmentSent",
+          payload: { id: conventionEndingTomorrow.id },
+        },
+        {
+          topic: "BeneficiaryAssessmentEmailSent",
+          payload: {
+            id: conventionEndingTomorrow.id,
+          },
+        },
+      ]);
+    });
+
     it("shows error in report about convention on missing user but does not fail the entire script", async () => {
-      // Arrange
       const conventionWithoutAgency = new ConventionDtoBuilder(
         conventionValidatedWithAgencyStartedTwoDaysAgo,
       )
@@ -623,7 +673,6 @@ describe("SendAssessmentNeededNotifications", () => {
       ]);
       uow.userRepository.users = [];
 
-      // Act
       expectToEqual(
         await sendEmailWithAssessmentCreationLink.execute({
           conventionEndDate: {
@@ -645,15 +694,12 @@ describe("SendAssessmentNeededNotifications", () => {
     });
 
     it("shows error in report about convention on missing agency but does not fail the entire script", async () => {
-      // Arrange
-
       uow.conventionRepository.setConventions([
         conventionEndingTomorrow,
         conventionEndingInTwoDays,
       ]);
       uow.agencyRepository.agencies = [];
 
-      // Act
       expectToEqual(
         await sendEmailWithAssessmentCreationLink.execute({
           conventionEndDate: {

--- a/shared/src/phone/phone.schema.unit.test.ts
+++ b/shared/src/phone/phone.schema.unit.test.ts
@@ -7,6 +7,8 @@ import {
 
 describe("phonesShema", () => {
   it.each<string>([
+    "+33600000000", //FR default number
+    "+33600000001", //FR default number
     "+33100000000", //FR
     "+33555689727", //FR
     "+262269612345", //YT


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

