### PR TITLE
#4613 - Tech - Ajout du locationId dans le DiscussionDto (nullable), locationId optionnel pour récupérer un résultat de recherche

### DIFF
--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV3.unit.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV3.unit.test.ts
@@ -2,15 +2,13 @@ import type { OpenAPIV3_1 as OpenAPI } from "openapi-types";
 import { createOpenApiSpecV3 } from "./createOpenApiV3";
 import { publicApiV3SearchEstablishmentRoutes } from "./publicApiV3.routes";
 
-const toOpenApiPath = (url: string) => url.replace(/:(\w+)/g, "{$1}");
-
 describe("createOpenApiSpecV3", () => {
   const spec = createOpenApiSpecV3("test");
   const paths = spec.paths!;
 
   const getOffersPath = publicApiV3SearchEstablishmentRoutes.getOffers.url;
-  const getOfferPath = toOpenApiPath(
-    publicApiV3SearchEstablishmentRoutes.getOffer.url,
+  const getOfferPath = Object.keys(paths).find((path) =>
+    path.startsWith("/v3/offers/{siret}/{appellationCode}"),
   );
   const contactEstablishmentPath =
     publicApiV3SearchEstablishmentRoutes.contactEstablishment.url;
@@ -22,8 +20,11 @@ describe("createOpenApiSpecV3", () => {
     });
 
     it("has getOffer route", () => {
+      expect(getOfferPath).toBeDefined();
+      expect(getOfferPath).toContain("/v3/offers/{siret}/{appellationCode}");
+      if (!getOfferPath) return;
       expect(paths[getOfferPath]).toBeDefined();
-      expect(paths[getOfferPath]!.get).toBeDefined();
+      expect(paths[getOfferPath]?.get).toBeDefined();
     });
 
     it("has contactEstablishment route", () => {
@@ -92,7 +93,11 @@ describe("createOpenApiSpecV3", () => {
   });
 
   describe("documents getOffer URL parameters", () => {
-    const getOfferRoute = spec.paths![getOfferPath]!.get!;
+    if (!getOfferPath) throw new Error("Missing getOffer path in OpenAPI spec");
+    const getOfferRoute = spec.paths![getOfferPath]?.get;
+
+    if (!getOfferRoute)
+      throw new Error("Missing GET operation for getOffer in OpenAPI spec");
 
     it("has siret parameter", () => {
       const siretParam = getOfferRoute.parameters?.find(
@@ -112,13 +117,18 @@ describe("createOpenApiSpecV3", () => {
       expect(appellationParam).toBeDefined();
     });
 
-    it("has locationId parameter", () => {
+    it("does not require locationId parameter anymore", () => {
       const locationIdParam = getOfferRoute.parameters?.find(
         (p) =>
           (p as OpenAPI.ParameterObject).name === "locationId" &&
           (p as OpenAPI.ParameterObject).in === "path",
       );
-      expect(locationIdParam).toBeDefined();
+      if (!locationIdParam) {
+        expect(locationIdParam).toBeUndefined();
+        return;
+      }
+
+      expect((locationIdParam as OpenAPI.ParameterObject).required).toBe(false);
     });
   });
 });

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV3.unit.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/createOpenApiV3.unit.test.ts
@@ -5,10 +5,10 @@ import { publicApiV3SearchEstablishmentRoutes } from "./publicApiV3.routes";
 describe("createOpenApiSpecV3", () => {
   const spec = createOpenApiSpecV3("test");
   const paths = spec.paths!;
-
+  const fullPath = "/v3/offers/{siret}/{appellationCode}/{locationId?}";
   const getOffersPath = publicApiV3SearchEstablishmentRoutes.getOffers.url;
   const getOfferPath = Object.keys(paths).find((path) =>
-    path.startsWith("/v3/offers/{siret}/{appellationCode}"),
+    path.startsWith(fullPath),
   );
   const contactEstablishmentPath =
     publicApiV3SearchEstablishmentRoutes.contactEstablishment.url;
@@ -21,7 +21,7 @@ describe("createOpenApiSpecV3", () => {
 
     it("has getOffer route", () => {
       expect(getOfferPath).toBeDefined();
-      expect(getOfferPath).toContain("/v3/offers/{siret}/{appellationCode}");
+      expect(getOfferPath).toContain(fullPath);
       if (!getOfferPath) return;
       expect(paths[getOfferPath]).toBeDefined();
       expect(paths[getOfferPath]?.get).toBeDefined();

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/getOfferV3.e2e.test.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/getOfferV3.e2e.test.ts
@@ -170,6 +170,45 @@ describe("Route to get ImmersionSearchResultDto by siret, appellation code and l
     expect(response.status).toBe(200);
   });
 
+  it("accepts valid authenticated requests with no location id", async () => {
+    const response = await request
+      .get(`/v3/offers/${immersionOfferSiret}/${styliste.appellationCode}`)
+      .set("Authorization", authToken);
+
+    expectToEqual(response.body, {
+      rome: styliste.romeCode,
+      naf: defaultNafCode,
+      siret: "78000403200019",
+      name: "Company inside repository",
+      voluntaryToImmersion: true,
+      locationId: TEST_LOCATION.id,
+      numberOfEmployeeRange: "10-19",
+      address: TEST_LOCATION.address,
+      contactMode: "EMAIL",
+      romeLabel: TEST_ROME_LABEL,
+      establishmentScore: 15,
+      appellations: [
+        {
+          appellationLabel: styliste.appellationLabel,
+          appellationCode: styliste.appellationCode,
+        },
+      ],
+      nafLabel: "FAKE",
+      additionalInformation: "",
+      website: "",
+      position: {
+        lat: TEST_LOCATION.position.lat,
+        lon: TEST_LOCATION.position.lon,
+      },
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      fitForDisabledWorkers: "no",
+      remoteWorkMode: "ON_SITE",
+      isAvailable: true,
+    } satisfies SearchImmersionResultPublicV3);
+    expect(response.status).toBe(200);
+  });
+
   it("returns 404 if no offer can be found with such siret & appellation code", async () => {
     const siretNotInDB = "11000403200019";
 

--- a/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV3.routes.ts
+++ b/back/src/adapters/primary/routers/apiKeyAuthRouter/publicApiV3.routes.ts
@@ -29,7 +29,7 @@ export const publicApiV3SearchEstablishmentRoutes = defineRoutes({
   }),
   getOffer: defineRoute({
     method: "get",
-    url: "/v3/offers/:siret/:appellationCode/:locationId",
+    url: "/v3/offers/:siret/:appellationCode/:locationId?",
     ...withAuthorizationHeaders,
     responses: {
       200: internalOfferSchema,

--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -146,6 +146,7 @@ interface Discussions extends WithAcquisition {
   rejection_kind: string | null;
   rejection_reason: string | null;
   candidate_warned_method: "phone" | "email" | "inPerson" | "other" | null;
+  location_id: string;
 }
 
 interface DiscussionsArchives {

--- a/back/src/config/pg/migrations/1777034819504_add-location-id-on-discussion.ts
+++ b/back/src/config/pg/migrations/1777034819504_add-location-id-on-discussion.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn("discussions", {
+    location_id: { type: "uuid" },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn("discussions", "location_id");
+}

--- a/back/src/config/pg/migrations/1777034819504_add-location-id-on-discussion.ts
+++ b/back/src/config/pg/migrations/1777034819504_add-location-id-on-discussion.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate";
-
-export const shorthands: ColumnDefinitions | undefined = undefined;
+import type { MigrationBuilder } from "node-pg-migrate";
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn("discussions", {
-    location_id: { type: "uuid" },
+    location_id: {
+      type: "uuid",
+    },
   });
 }
 

--- a/back/src/domains/establishment/adapters/InMemoryEstablishmentAggregateRepository.ts
+++ b/back/src/domains/establishment/adapters/InMemoryEstablishmentAggregateRepository.ts
@@ -407,12 +407,17 @@ const buildSearchImmersionResultDtoForSiretRomeAndLocation = ({
       (offer) => offer.appellationCode === searchedAppellationCode,
     )?.romeCode ?? "no-offer-matched";
 
-  const location = establishmentAgg.establishment.locations.find(
-    (loc) => loc.id === locationId,
-  );
+  const location = locationId
+    ? establishmentAgg.establishment.locations.find(
+        (loc) => loc.id === locationId,
+      )
+    : establishmentAgg.establishment.locations[0];
 
-  if (!location)
-    throw new Error(`NO LOCATION MATCHING PROVIDED ID: ${locationId}`);
+  if (!location) {
+    throw new Error(
+      `NO LOCATION MATCHING PROVIDED ID: ${locationId} OR FIRST LOCATION`,
+    );
+  }
 
   return {
     address: location.address,

--- a/back/src/domains/establishment/adapters/PgDiscussionRepository.ts
+++ b/back/src/domains/establishment/adapters/PgDiscussionRepository.ts
@@ -19,6 +19,7 @@ import {
   type ExchangeRole,
   errors,
   type ImmersionObjective,
+  type LocationId,
   type PhoneNumber,
   type PotentialBeneficiaryCommonProps,
   pipeWithValue,
@@ -578,6 +579,7 @@ const discussionToPgAndPhoneInsert = async (
     acquisition_campaign: discussion.acquisitionCampaign,
     acquisition_keyword: discussion.acquisitionKeyword,
     convention_id: discussion.conventionId,
+    location_id: discussion.locationId,
     ...discussionStatusWithRejectionToPg(discussion),
   };
 };
@@ -671,6 +673,7 @@ const makeDiscussionDtoFromPgDiscussion = (
       siret: discussion.siret,
       conventionId: discussion.conventionId,
       id: discussion.id,
+      locationId: discussion.locationId,
       ...getWithDiscussionStatusFromPgDiscussion(discussion),
     };
 
@@ -917,6 +920,7 @@ const executeGetDiscussions = (
           acquisition_keyword: ref("d.acquisition_keyword"),
           candidateWarnedMethod: ref("d.candidate_warned_method"),
           kind: ref("d.kind"),
+          locationId: sql<LocationId>`${ref("d.location_id")}`,
         }),
       ).as("discussion"),
     )

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
@@ -3797,8 +3797,23 @@ describe("PgEstablishmentAggregateRepository", () => {
         );
       });
 
-      it("undefined when missing location id", async () => {
-        const missingLocationId = "55555555-5555-4444-5555-555555555666";
+      it("ignores location id when location does not exist anymore", async () => {
+        const deletedLocationId =
+          establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+            .locations[0].id;
+
+        await kyselyDb
+          .deleteFrom("establishments_location_infos")
+          .where("id", "=", deletedLocationId)
+          .execute();
+
+        const searchResultWithoutLocationId =
+          await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .siret,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+              .appellationCode,
+          );
 
         expectToEqual(
           await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
@@ -3806,9 +3821,9 @@ describe("PgEstablishmentAggregateRepository", () => {
               .siret,
             establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
               .appellationCode,
-            missingLocationId,
+            deletedLocationId,
           ),
-          undefined,
+          searchResultWithoutLocationId,
         );
       });
 

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.integration.test.ts
@@ -60,6 +60,7 @@ import {
   establishmentWithFitForDisabledWorkersYesCertified,
   establishmentWithFitForDisabledWorkersYesDeclaredOnly,
   establishmentWithOfferA1101_AtPosition,
+  establishmentWithOfferA1101_AtPositionWithTwoLocations,
   establishmentWithOfferA1101_close,
   establishmentWithOfferA1101_outOfDistanceRange,
   groomChevauxOffer,
@@ -3777,7 +3778,7 @@ describe("PgEstablishmentAggregateRepository", () => {
     describe("getSearchResultBySearchQuery", () => {
       beforeEach(async () => {
         await pgEstablishmentAggregateRepository.insertEstablishmentAggregate(
-          establishmentWithOfferA1101_AtPosition,
+          establishmentWithOfferA1101_AtPositionWithTwoLocations,
         );
       });
 
@@ -3787,9 +3788,10 @@ describe("PgEstablishmentAggregateRepository", () => {
         expectToEqual(
           await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
             missingSiret,
-            establishmentWithOfferA1101_AtPosition.offers[0].appellationCode,
-            establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-              .id,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+              .appellationCode,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .locations[0].id,
           ),
           undefined,
         );
@@ -3800,8 +3802,10 @@ describe("PgEstablishmentAggregateRepository", () => {
 
         expectToEqual(
           await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
-            establishmentWithOfferA1101_AtPosition.establishment.siret,
-            establishmentWithOfferA1101_AtPosition.offers[0].appellationCode,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .siret,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+              .appellationCode,
             missingLocationId,
           ),
           undefined,
@@ -3813,79 +3817,168 @@ describe("PgEstablishmentAggregateRepository", () => {
 
         expectToEqual(
           await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
-            establishmentWithOfferA1101_AtPosition.establishment.siret,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .siret,
             missingAppellationCode,
-            establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-              .id,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .locations[0].id,
           ),
           undefined,
         );
       });
 
-      it("Returns reconstructed SearchImmersionResultDto for given siret, appellationCode and location id", async () => {
+      it("Returns reconstructed SearchImmersionResultDto for given siret, appellationCode and given location id", async () => {
         expectToEqual(
           await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
-            establishmentWithOfferA1101_AtPosition.establishment.siret,
-            establishmentWithOfferA1101_AtPosition.offers[0].appellationCode,
-            establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-              .id,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .siret,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+              .appellationCode,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .locations[0].id,
           ),
           {
-            rome: establishmentWithOfferA1101_AtPosition.offers[0].romeCode,
+            rome: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .offers[0].romeCode,
             romeLabel:
-              establishmentWithOfferA1101_AtPosition.offers[0].romeLabel,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+                .romeLabel,
             establishmentScore:
-              establishmentWithOfferA1101_AtPosition.establishment.score,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.score,
             appellations: [
               {
                 appellationLabel:
-                  establishmentWithOfferA1101_AtPosition.offers[0]
-                    .appellationLabel,
+                  establishmentWithOfferA1101_AtPositionWithTwoLocations
+                    .offers[0].appellationLabel,
                 appellationCode:
-                  establishmentWithOfferA1101_AtPosition.offers[0]
-                    .appellationCode,
+                  establishmentWithOfferA1101_AtPositionWithTwoLocations
+                    .offers[0].appellationCode,
               },
             ],
-            naf: establishmentWithOfferA1101_AtPosition.establishment.nafDto
-              .code,
+            naf: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .establishment.nafDto.code,
             nafLabel: "Activités des agences de travail temporaire",
-            siret: establishmentWithOfferA1101_AtPosition.establishment.siret,
-            name: establishmentWithOfferA1101_AtPosition.establishment.name,
+            siret:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.siret,
+            name: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .establishment.name,
             customizedName:
-              establishmentWithOfferA1101_AtPosition.establishment
-                .customizedName,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.customizedName,
             website:
-              establishmentWithOfferA1101_AtPosition.establishment.website,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.website,
             additionalInformation:
-              establishmentWithOfferA1101_AtPosition.establishment
-                .additionalInformation,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.additionalInformation,
             voluntaryToImmersion:
-              establishmentWithOfferA1101_AtPosition.establishment
-                .voluntaryToImmersion,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.voluntaryToImmersion,
             fitForDisabledWorkers:
-              establishmentWithOfferA1101_AtPosition.establishment
-                .fitForDisabledWorkers,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.fitForDisabledWorkers,
             numberOfEmployeeRange:
-              establishmentWithOfferA1101_AtPosition.establishment
-                .numberEmployeesRange,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.numberEmployeesRange,
             contactMode:
-              establishmentWithOfferA1101_AtPosition.establishment.contactMode,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.contactMode,
             distance_m: undefined,
             address:
-              establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-                .address,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[0].address,
             position:
-              establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-                .position,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[0].position,
             locationId:
-              establishmentWithOfferA1101_AtPosition.establishment.locations[0]
-                .id,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[0].id,
             createdAt:
-              establishmentWithOfferA1101_AtPosition.establishment.createdAt.toISOString(),
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment.createdAt.toISOString(),
             updatedAt:
-              establishmentWithOfferA1101_AtPosition.establishment.updatedAt.toISOString(),
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment.updatedAt.toISOString(),
             remoteWorkMode:
-              establishmentWithOfferA1101_AtPosition.offers[0].remoteWorkMode,
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+                .remoteWorkMode,
+            isAvailable: true,
+          },
+        );
+      });
+      it("Returns first reconstructed SearchImmersionResultDto for given siret, appellationCode but no location id", async () => {
+        expectToEqual(
+          await pgEstablishmentAggregateRepository.getSearchResultBySearchQuery(
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment
+              .siret,
+            establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+              .appellationCode,
+          ),
+          {
+            rome: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .offers[0].romeCode,
+            romeLabel:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+                .romeLabel,
+            establishmentScore:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.score,
+            appellations: [
+              {
+                appellationLabel:
+                  establishmentWithOfferA1101_AtPositionWithTwoLocations
+                    .offers[0].appellationLabel,
+                appellationCode:
+                  establishmentWithOfferA1101_AtPositionWithTwoLocations
+                    .offers[0].appellationCode,
+              },
+            ],
+            naf: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .establishment.nafDto.code,
+            nafLabel: "Activités des agences de travail temporaire",
+            siret:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.siret,
+            name: establishmentWithOfferA1101_AtPositionWithTwoLocations
+              .establishment.name,
+            customizedName:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.customizedName,
+            website:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.website,
+            additionalInformation:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.additionalInformation,
+            voluntaryToImmersion:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.voluntaryToImmersion,
+            fitForDisabledWorkers:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.fitForDisabledWorkers,
+            numberOfEmployeeRange:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.numberEmployeesRange,
+            contactMode:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.contactMode,
+            distance_m: undefined,
+            address:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[1].address, // is the last location added
+            position:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[1].position, // is the last location added
+            locationId:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations
+                .establishment.locations[1].id, // is the last location added
+            createdAt:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment.createdAt.toISOString(),
+            updatedAt:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.establishment.updatedAt.toISOString(),
+            remoteWorkMode:
+              establishmentWithOfferA1101_AtPositionWithTwoLocations.offers[0]
+                .remoteWorkMode,
             isAvailable: true,
           },
         );

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.test.helpers.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.test.helpers.ts
@@ -227,6 +227,10 @@ export const locationOfSearchPosition = new LocationBuilder()
   .withId(uuid())
   .withPosition({ lat: 49, lon: 6 })
   .build();
+export const locationOfSearchPosition2 = new LocationBuilder()
+  .withId(uuid())
+  .withPosition({ lat: 46, lon: 4 })
+  .build();
 export const locationOfCloseSearchPosition = new LocationBuilder()
   .withId(uuid())
   .withPosition({ lat: 49.001, lon: 6.001 })
@@ -250,6 +254,14 @@ export const establishmentWithOfferA1101_AtPosition =
   new EstablishmentAggregateBuilder()
     .withEstablishmentSiret("00000000000001")
     .withLocations([locationOfSearchPosition])
+    .withOffers([offer_A1101_11987])
+    .withUserRights([osefUserRight])
+    .build();
+
+export const establishmentWithOfferA1101_AtPositionWithTwoLocations =
+  new EstablishmentAggregateBuilder()
+    .withEstablishmentSiret("00000000000001")
+    .withLocations([locationOfSearchPosition, locationOfSearchPosition2])
     .withOffers([offer_A1101_11987])
     .withUserRights([osefUserRight])
     .build();

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
@@ -430,6 +430,19 @@ export class PgEstablishmentAggregateRepository
     appellationCode: AppellationCode,
     locationId?: LocationId,
   ): Promise<RepositorySearchResultDto | undefined> {
+    const isLocationIdExisting = locationId
+      ? await this.transaction
+          .selectFrom("establishments_location_infos")
+          .select("id")
+          .where("id", "=", locationId)
+          .where("establishment_siret", "=", siret)
+          .executeTakeFirst()
+          .then((result) => result !== undefined)
+      : Promise.resolve(false);
+
+    const locationIds =
+      isLocationIdExisting && locationId ? [locationId] : undefined;
+
     const { data } = await searchImmersionResultsQuery(this.transaction, {
       limit: 1,
       offset: 0,
@@ -437,7 +450,7 @@ export class PgEstablishmentAggregateRepository
       filters: {
         sirets: [siret],
         appellationCodes: [appellationCode],
-        locationIds: locationId ? [locationId] : undefined,
+        locationIds,
         showOnlyAvailableOffers: false,
       },
       shouldCountAll: false,

--- a/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
+++ b/back/src/domains/establishment/adapters/PgEstablishmentAggregateRepository.ts
@@ -428,7 +428,7 @@ export class PgEstablishmentAggregateRepository
   public async getSearchResultBySearchQuery(
     siret: SiretDto,
     appellationCode: AppellationCode,
-    locationId: LocationId,
+    locationId?: LocationId,
   ): Promise<RepositorySearchResultDto | undefined> {
     const { data } = await searchImmersionResultsQuery(this.transaction, {
       limit: 1,
@@ -437,7 +437,7 @@ export class PgEstablishmentAggregateRepository
       filters: {
         sirets: [siret],
         appellationCodes: [appellationCode],
-        locationIds: [locationId],
+        locationIds: locationId ? [locationId] : undefined,
         showOnlyAvailableOffers: false,
       },
       shouldCountAll: false,

--- a/back/src/domains/establishment/ports/EstablishmentAggregateRepository.ts
+++ b/back/src/domains/establishment/ports/EstablishmentAggregateRepository.ts
@@ -96,7 +96,7 @@ export interface EstablishmentAggregateRepository {
   getSearchResultBySearchQuery(
     siret: SiretDto,
     appellationCode: AppellationCode,
-    locationId: LocationId,
+    locationId?: LocationId,
   ): Promise<RepositorySearchResultDto | undefined>;
   legacySearchImmersionResults(
     searchImmersionParams: LegacySearchImmersionParams,

--- a/back/src/domains/establishment/use-cases/ContactEstablishment.ts
+++ b/back/src/domains/establishment/use-cases/ContactEstablishment.ts
@@ -175,6 +175,7 @@ export class ContactEstablishment extends TransactionalUseCase<CreateDiscussionD
       updatedAt: now.toISOString(),
       address: matchingAddress.address,
       status: "PENDING",
+      locationId: contactRequest.locationId,
     };
 
     const extraDiscussionDtoProperties: ExtraDiscussionDtoProperties = {

--- a/back/src/domains/establishment/use-cases/ContactEstablishment.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/ContactEstablishment.unit.test.ts
@@ -288,6 +288,7 @@ describe("ContactEstablishment", () => {
         createdAt: now.toISOString(),
         updatedAt: now.toISOString(),
         status: "PENDING",
+        locationId: validEmailRequest.locationId,
       });
 
       describe("with discussion kind IF", () => {
@@ -799,6 +800,7 @@ describe("ContactEstablishment", () => {
                 validEmailRequest.experienceAdditionalInformation,
               resumeLink: validEmailRequest.potentialBeneficiaryResumeLink,
             },
+            locationId: validEmailRequest.locationId,
           },
         ]);
 

--- a/back/src/domains/establishment/use-cases/LegacyContactEstablishment.ts
+++ b/back/src/domains/establishment/use-cases/LegacyContactEstablishment.ts
@@ -223,6 +223,7 @@ export class LegacyContactEstablishment extends TransactionalUseCase<LegacyConta
       acquisitionCampaign: contactRequest.acquisitionCampaign,
       acquisitionKeyword: contactRequest.acquisitionKeyword,
       status: "PENDING",
+      locationId: contactRequest.locationId,
     };
   }
 

--- a/back/src/domains/establishment/use-cases/LegacyContactEstablishment.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/LegacyContactEstablishment.unit.test.ts
@@ -303,6 +303,7 @@ describe("LegacyContactEstablishment", () => {
       expectToEqual(uow.discussionRepository.discussions, [
         {
           id: discussionId,
+          locationId: validEmailRequest.locationId,
           appellationCode: "12898",
           siret: validEmailRequest.siret,
           businessName: "Company inside repository",
@@ -387,6 +388,7 @@ describe("LegacyContactEstablishment", () => {
             },
           ],
           status: "PENDING",
+          locationId: establishmentAggregate.establishment.locations[0].id,
         },
         {
           id: "discussion1",
@@ -418,6 +420,7 @@ describe("LegacyContactEstablishment", () => {
             },
           ],
           status: "PENDING",
+          locationId: establishmentAggregate.establishment.locations[0].id,
         },
       ];
 

--- a/back/src/scripts/seed/establishmentSeed.ts
+++ b/back/src/scripts/seed/establishmentSeed.ts
@@ -123,9 +123,6 @@ const decathlon = new EstablishmentAggregateBuilder()
   .build();
 
 export const establishmentSeed = async (uow: UnitOfWork) => {
-  // biome-ignore lint/suspicious/noConsole: <explanation>
-  console.log("establishmentSeed start ...");
-
   await uow.establishmentAggregateRepository.insertEstablishmentAggregate(
     franceMerguez,
   );
@@ -145,6 +142,13 @@ export const establishmentSeed = async (uow: UnitOfWork) => {
     },
     name: "Decathlon",
   });
+
+  const franceMerguezLocationId =
+    franceMerguez.establishment.locations.at(0)?.id;
+  if (!franceMerguezLocationId)
+    throw new Error(
+      "Cannot seed discussions without an establishment location.",
+    );
 
   const discussionId = "aaaaaaaa-9c0a-1aaa-aa6d-aaaaaaaaaaaa";
   await uow.discussionRepository.insert(
@@ -176,6 +180,7 @@ export const establishmentSeed = async (uow: UnitOfWork) => {
           attachments: [],
         },
       ])
+      .withLocationId(franceMerguezLocationId)
       .build(),
   );
   await uow.discussionRepository.insert(
@@ -208,9 +213,7 @@ export const establishmentSeed = async (uow: UnitOfWork) => {
         },
       ])
       .withStatus({ status: "REJECTED", rejectionKind: "DEPRECATED" })
+      .withLocationId(franceMerguezLocationId)
       .build(),
   );
-
-  // biome-ignore lint/suspicious/noConsole: <explanation>
-  console.log("establishmentSeed done");
 };

--- a/front/src/app/pages/search/SearchResultPage.tsx
+++ b/front/src/app/pages/search/SearchResultPage.tsx
@@ -107,13 +107,16 @@ export const SearchResultPage = ({ isExternal }: { isExternal: boolean }) => {
     useState<ReactNode | null>(null);
 
   useEffect(() => {
-    if (!isExternal && "location" in params && params.location) {
+    if (!isExternal) {
       dispatch(
         searchSlice.actions.fetchSearchResultRequested({
           searchResult: {
             siret: params.siret,
             appellationCode: params.appellationCode[0],
-            locationId: params.location,
+            locationId:
+              "location" in params && params.location
+                ? params.location
+                : undefined,
           },
           feedbackTopic: "search-result",
         }),

--- a/shared/src/discussion/DiscussionBuilder.ts
+++ b/shared/src/discussion/DiscussionBuilder.ts
@@ -63,6 +63,7 @@ const defaultDiscussion = {
   status: "PENDING",
   kind: "IF",
   contactMode: "EMAIL",
+  locationId: "123e4567-e89b-12d3-a456-426614174000",
 } satisfies DiscussionDto;
 
 export const cartographeAppellationAndRome: AppellationAndRomeDto = {

--- a/shared/src/discussion/DiscussionBuilder.ts
+++ b/shared/src/discussion/DiscussionBuilder.ts
@@ -1,7 +1,7 @@
 import { omit } from "ramda";
 import { match, P } from "ts-pattern";
 import type { WithAcquisition } from "../acquisition.dto";
-import type { AddressDto } from "../address/address.dto";
+import type { AddressDto, LocationId } from "../address/address.dto";
 import type { Builder } from "../Builder";
 import {
   type ConventionId,
@@ -416,5 +416,12 @@ export class DiscussionBuilder implements Builder<DiscussionDto> {
       .exhaustive();
 
     return new DiscussionBuilder(updatedDiscussion);
+  }
+
+  withLocationId(locationId: LocationId) {
+    return new DiscussionBuilder({
+      ...this.discussion,
+      locationId,
+    });
   }
 }

--- a/shared/src/discussion/discussion.dto.ts
+++ b/shared/src/discussion/discussion.dto.ts
@@ -165,6 +165,7 @@ export type CommonDiscussionDto = {
   updatedAt: DateString;
   id: DiscussionId;
   siret: SiretDto;
+  locationId: LocationId;
 } & WithDiscussionStatus;
 
 export type ExtraDiscussionDtoProperties = WithAcquisition & {

--- a/shared/src/discussion/discussion.schema.ts
+++ b/shared/src/discussion/discussion.schema.ts
@@ -260,6 +260,7 @@ const commonDiscussionSchema: ZodSchemaWithInputMatchingOutput<CommonDiscussionD
       businessName: zStringMinLength1Max1024,
       address: addressSchema,
       conventionId: conventionIdSchema.optional(),
+      locationId: zUuidLike,
     })
     .and(withDiscussionStatusSchema);
 

--- a/shared/src/siretAndAppellation/SiretAndAppellation.dto.ts
+++ b/shared/src/siretAndAppellation/SiretAndAppellation.dto.ts
@@ -8,5 +8,5 @@ export type SiretAndAppellationDto = {
 };
 
 export type SearchResultQuery = SiretAndAppellationDto & {
-  locationId: LocationId;
+  locationId?: LocationId;
 };

--- a/shared/src/siretAndAppellation/SiretAndAppellation.schema.ts
+++ b/shared/src/siretAndAppellation/SiretAndAppellation.schema.ts
@@ -19,5 +19,5 @@ export const siretAndAppellationSchema: ZodSchemaWithInputMatchingOutput<SiretAn
 export const searchResultQuerySchema: ZodSchemaWithInputMatchingOutput<SearchResultQuery> =
   z.object({
     ...siretAndAppellationShape,
-    locationId: zUuidLike,
+    locationId: zUuidLike.optional(),
   });


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

- travail préparatoire à #4613 (pour récupérer une offre d'immersion depuis la candidature, pour afficher l'url de l'entreprise, s'il y a)
- pas de lien aujourd'hui entre métier et localisation, donc on ne peut pas retrouver de location pour une discussion qui n'en a pas : j'ai préféré ne pas sortir une donnée qui peut être complètement bidon (la première location pour le siret concerné) et garder un null, ça aura l'avantage d'être plus facilement repérable
- par contre, j'ai modifié la méthode getSearchResultBySearchQuery pour qu'elle puisse nous retourner un résultat si on a pas de locationId fourni : ce sera le dernier inséré en base, et puis voilà -> si on veut plus précis, on fourni le locationId. Ce sera utile pour les candidatures qui n'ont pas de locationId (c'est le legacy, parce qu'ils vont être alimenté petit à petit via ContactEstablishment maintenant) et pour nos consommateurs API qui galèrent à trouver un locationId