### PR TITLE
#4853 - Limite à 40 agences pour le pré-filtre du dashboard Metabase « Pilotage de ma structure »

### DIFF
--- a/back/src/domains/core/dashboard/adapters/MetabaseDashboardGateway.ts
+++ b/back/src/domains/core/dashboard/adapters/MetabaseDashboardGateway.ts
@@ -92,7 +92,10 @@ export class MetabaseDashboardGateway implements DashboardGateway {
       }),
       agencyManagement: this.#makeDashboardUrlByDashboardName({
         dashboardName: "agencyManagement",
-        editableParams: { structure: agencyNames },
+        // this is to avoid too long url, we limit the number of agencies to 40, or we do not apply the default filter
+        editableParams: {
+          structure: agencyNames.length <= 40 ? agencyNames : [],
+        },
         now,
       }),
       establishmentManagement: this.#makeDashboardUrlByDashboardName({


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Closes #4853

Si un prescripteur est rattaché à plus de 40 agences, on n'applique plus le pré-filtre `structure` lors de la construction de l'URL du dashboard Metabase `agencyManagement`, afin d'éviter l'erreur `431 Request Header Fields Too Large`. Seuil aligné avec celui déjà en place pour le dashboard Metabase v2.