### PR TITLE
#4759 - Message d'erreur explicite lors du pilotage d'une convention invalide

### DIFF
--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -377,7 +377,7 @@ export class AppConfig {
       v2: {
         url: this.#throwIfNotDefinedOrDefault(
           "METABASE_V2_URL",
-          "MISSING_METABASE_V2_URL",
+          "http://missing-metabase-v2-url.com",
         ) as AbsoluteUrl,
         apiKey: this.#throwIfNotDefinedOrDefault(
           "METABASE_V2_API_KEY",

--- a/back/src/scripts/seed/conventionDraftSeed.ts
+++ b/back/src/scripts/seed/conventionDraftSeed.ts
@@ -11,6 +11,7 @@ export const conventionDraftSeed = async (uow: UnitOfWork) => {
   const conventionDraftImmersion: ConventionDraftDto = {
     id: "11111111-1111-4111-9111-111111111111",
     internshipKind: "immersion",
+    remoteWorkMode: "ON_SITE",
     signatories: {
       beneficiary: {
         firstName: "John",

--- a/front/src/app/components/admin/conventions/ConventionManageContent.tsx
+++ b/front/src/app/components/admin/conventions/ConventionManageContent.tsx
@@ -3,6 +3,7 @@ import { Loader } from "react-design-system";
 import { useDispatch } from "react-redux";
 import {
   allAgencyRoles,
+  badSchemaErrorMessagePrefix,
   type ConventionJwtPayload,
   decodeMagicLinkJwtWithoutSignatureCheck,
   expiredJwtErrorMessage,
@@ -112,22 +113,26 @@ export const ConventionManageContent = ({
   ]);
 
   if (fetchConventionError) {
-    if (
-      !conventionFormFeedback?.message.includes(expiredJwtErrorMessage) &&
-      currentUser?.email
-    ) {
-      throw frontErrors.convention.noRightsOnConvention({
-        userEmail: currentUser.email,
-        conventionId: conventionId,
-      });
-    }
+    const message = conventionFormFeedback?.message ?? "";
 
-    return (
-      <ShowConventionErrorOrRenewExpiredJwt
-        errorMessage={conventionFormFeedback?.message}
-        jwt={jwtParams.jwt}
-      />
-    );
+    if (message.includes(expiredJwtErrorMessage))
+      return (
+        <ShowConventionErrorOrRenewExpiredJwt
+          errorMessage={message}
+          jwt={jwtParams.jwt}
+        />
+      );
+
+    if (message.includes(badSchemaErrorMessagePrefix))
+      throw frontErrors.convention.badSchema({
+        conventionId,
+        errorMessage: message,
+      });
+
+    throw frontErrors.convention.noRightsOnConvention({
+      userEmail: currentUser?.email ?? "INCONNU",
+      conventionId,
+    });
   }
 
   if (

--- a/front/src/app/pages/error/front-errors.tsx
+++ b/front/src/app/pages/error/front-errors.tsx
@@ -177,6 +177,46 @@ export const frontErrors = {
         buttons: [HomeButton, ContactUsButton()],
       });
     },
+    badSchema: ({
+      conventionId,
+      errorMessage,
+      issues,
+    }: {
+      conventionId: ConventionId;
+      errorMessage: string;
+      issues?: string[];
+    }) =>
+      new FrontSpecificError({
+        title: "Affichage de la convention impossible",
+        description: (
+          <>
+            <p>
+              Un incident technique empêche l'affichage de cette convention.
+              Cela peut être dû par exemple à une incohérence dans ses données
+              (ex : durée journalière, dates ou formats invalides).
+            </p>
+            <ul>
+              <li>ID de la convention : {conventionId}</li>
+              <li>Type d'erreur : {errorMessage}</li>
+              {issues && (
+                <>
+                  <li>Problèmes rencontrés :</li>
+                  <ul>
+                    {issues.map((issue) => (
+                      <li key={issue}>{issue}</li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </ul>
+            <p>
+              Pour corriger cette situation et accéder à nouveau à la
+              convention, veuillez contacter le support d'Immersion Facilitée.
+            </p>
+          </>
+        ),
+        buttons: [ContactUsButton()],
+      }),
     noRightsOnConvention: ({
       userEmail,
       conventionId,

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -65,6 +65,8 @@ import {
   UnavailableApiError,
 } from "./httpErrors";
 
+export const badSchemaErrorMessagePrefix = "Schema validation failed";
+
 export const errors = {
   fetch: {
     errorResponse: async (errorResponse: Response) => {
@@ -1170,7 +1172,7 @@ export const errors = {
       ),
     ) =>
       new BadRequestError(
-        `Schema validation failed ${"schemaName" in params ? `for schema ${params.schemaName}` : `in usecase ${params.useCaseName}`}${params.id ? ` for element with id ${params.id}` : ""}. See issues for details.`,
+        `${badSchemaErrorMessagePrefix} ${"schemaName" in params ? `for schema ${params.schemaName}` : `in usecase ${params.useCaseName}`}${params.id ? ` for element with id ${params.id}` : ""}. See issues for details.`,
         params.flattenErrors,
       ),
   },


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Closes #4759

Au pilotage d'une convention, on distingue désormais 3 cas d'erreur au lieu d'un seul :
- JWT expiré → page de renouvellement de lien
- Convention invalide au niveau du schéma → nouvelle page d'erreur dédiée (`frontErrors.convention.badSchema`)
- Problème de droits réel → page d'erreur de droits (conservée)

La discrimination se fait via le préfixe `badSchemaErrorMessagePrefix` exporté depuis `shared/src/errors/errors.ts`, comparé au message remonté côté front. Vérifier que la logique de fallback (`noRightsOnConvention`) reste pertinente quand `currentUser?.email` est absent (passé à `"INCONNU"`).