### PR TITLE
#4613 - Fix - Distinction du destinataire lors de l'envoi des échanges de candidature

### DIFF
--- a/back/src/adapters/primary/routers/establishment/createEstablishmentRouter.ts
+++ b/back/src/adapters/primary/routers/establishment/createEstablishmentRouter.ts
@@ -132,7 +132,6 @@ export const createEstablishmentRouter = (deps: AppDependencies) => {
                 {
                   ...req.body,
                   discussionId: req.params.discussionId,
-                  recipientRole: "potentialBeneficiary",
                   attachments: [],
                 },
               ],

--- a/back/src/adapters/primary/routers/establishment/discussion.e2e.test.ts
+++ b/back/src/adapters/primary/routers/establishment/discussion.e2e.test.ts
@@ -499,6 +499,7 @@ describe("discussion e2e", () => {
           urlParams: { discussionId: discussion.id },
           body: {
             message: expectedExchange.message,
+            recipientRole: "potentialBeneficiary",
           },
         }),
         {
@@ -534,6 +535,7 @@ describe("discussion e2e", () => {
           urlParams: { discussionId: discussion.id },
           body: {
             message: "My fake message",
+            recipientRole: "potentialBeneficiary",
           },
         }),
         {
@@ -546,6 +548,38 @@ describe("discussion e2e", () => {
       );
 
       expectToEqual(inMemoryUow.discussionRepository.discussions, [discussion]);
+    });
+
+    it("202 - returns sender based on recipientRole", async () => {
+      const discussion = new DiscussionBuilder()
+        .withSiret(establishment.establishment.siret)
+        .withStatus({ status: "REJECTED", rejectionKind: "NO_TIME" })
+        .build();
+
+      inMemoryUow.discussionRepository.discussions = [discussion];
+
+      expectHttpResponseToEqual(
+        await httpClient.replyToDiscussion({
+          headers: {
+            authorization: generateConnectedUserJwt({
+              userId: user.id,
+              version: currentJwtVersions.connectedUser,
+            }),
+          },
+          urlParams: { discussionId: discussion.id },
+          body: {
+            message: "My fake message",
+            recipientRole: "establishment",
+          },
+        }),
+        {
+          status: 202,
+          body: {
+            reason: "discussion_completed",
+            sender: "potentialBeneficiary",
+          },
+        },
+      );
     });
 
     it("200 - saves the exchange from a potential beneficiary connected user based on email", async () => {
@@ -581,6 +615,7 @@ describe("discussion e2e", () => {
           urlParams: { discussionId: discussion.id },
           body: {
             message: expectedExchange.message,
+            recipientRole: "establishment",
           },
         }),
         {

--- a/back/src/domains/establishment/use-cases/discussions/AddExchangeToDiscussion.ts
+++ b/back/src/domains/establishment/use-cases/discussions/AddExchangeToDiscussion.ts
@@ -39,7 +39,7 @@ type MessageInputCommonFields = {
 };
 
 type MessageInputFromDashboard = MessageInputCommonFields & {
-  recipientRole: Extract<ExchangeRole, "potentialBeneficiary">;
+  recipientRole: ExchangeRole;
   attachments: never[];
 };
 
@@ -71,7 +71,7 @@ const messageInputCommonFieldsSchema = z.object({
 });
 
 const messageInputFromDashboardSchema = messageInputCommonFieldsSchema.extend({
-  recipientRole: z.literal("potentialBeneficiary"),
+  recipientRole: exchangeRoleSchema,
   attachments: z.array(z.never()),
 });
 

--- a/front/src/app/components/establishment/establishment-dashboard/DiscussionManageContent.tsx
+++ b/front/src/app/components/establishment/establishment-dashboard/DiscussionManageContent.tsx
@@ -604,6 +604,8 @@ const DiscussionExchangeMessageForm = ({
       resolver: zodResolver(exchangeMessageFromDashboardSchema),
       defaultValues: {
         message: "",
+        recipientRole:
+          viewer === "establishment" ? "potentialBeneficiary" : "establishment",
       },
     });
   const getFieldError = makeFieldError(formState);
@@ -619,6 +621,7 @@ const DiscussionExchangeMessageForm = ({
             jwt: connectedUserJwt,
             discussionId,
             message: data.message,
+            recipientRole: data.recipientRole,
           },
           feedbackTopic: "beneficiary-dashboard-discussion-send-message",
         }),

--- a/front/src/core-logic/adapters/EstablishmentGateway/HttpEstablishmentGateway.ts
+++ b/front/src/core-logic/adapters/EstablishmentGateway/HttpEstablishmentGateway.ts
@@ -256,6 +256,7 @@ export class HttpEstablishmentGateway implements EstablishmentGateway {
           urlParams: { discussionId: payload.discussionId },
           body: {
             message: payload.message,
+            recipientRole: payload.recipientRole,
           },
         })
         .then((response) =>

--- a/front/src/core-logic/domain/discussion/discussion.test.ts
+++ b/front/src/core-logic/domain/discussion/discussion.test.ts
@@ -227,6 +227,7 @@ describe("Discussion slice", () => {
         jwt,
         discussionId: discussion.id,
         message: "My message",
+        recipientRole: "potentialBeneficiary",
       };
 
       const expectedExchange: Exchange = {
@@ -277,6 +278,7 @@ describe("Discussion slice", () => {
         jwt,
         discussionId: discussion.id,
         message: "My message",
+        recipientRole: "potentialBeneficiary",
       };
 
       store.dispatch(

--- a/shared/src/discussion/discussion.dto.ts
+++ b/shared/src/discussion/discussion.dto.ts
@@ -301,7 +301,9 @@ export type ExchangeRead = CommonExchange &
     | OmitFromExistingKeys<SpecificExchangeSender<"establishment">, "email">
   );
 
-export type ExchangeMessageFromDashboard = Pick<Exchange, "message">;
+export type ExchangeMessageFromDashboard = Pick<Exchange, "message"> & {
+  recipientRole: ExchangeRole;
+};
 
 export type ExchangeFromDashboard = ExchangeMessageFromDashboard &
   WithDiscussionId;

--- a/shared/src/discussion/discussion.schema.ts
+++ b/shared/src/discussion/discussion.schema.ts
@@ -223,9 +223,10 @@ export const discussionRejectedSchema: ZodSchemaWithInputMatchingOutput<WithDisc
     .and(discussionRejectionSchema);
 
 export const withExchangeMessageSchema: ZodSchemaWithInputMatchingOutput<
-  Pick<ExchangeFromDashboard, "message">
+  Pick<ExchangeFromDashboard, "message" | "recipientRole">
 > = z.object({
   message: messageSchema,
+  recipientRole: exchangeRoleSchema,
 });
 
 export const exchangeMessageFromDashboardSchema: ZodSchemaWithInputMatchingOutput<ExchangeFromDashboard> =


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
