### PR TITLE
#4674 - Notification de la décision de rattachement (entreprise)

### DIFF
--- a/back/src/domains/establishment/use-cases/UpdateEstablishmentAggregateFromFormEstablishement.ts
+++ b/back/src/domains/establishment/use-cases/UpdateEstablishmentAggregateFromFormEstablishement.ts
@@ -2,8 +2,10 @@ import { equals } from "ramda";
 import {
   type AbsoluteUrl,
   type ConnectedUserDomainJwtPayload,
+  type EstablishmentUserRightStatus,
   errors,
   onlyAdminUserRightsWithStatusAccepted,
+  onlyUserRightWithStatusAccepted,
   type WithFormEstablishmentDto,
   withFormEstablishmentSchema,
 } from "shared";
@@ -92,41 +94,53 @@ export const makeUpdateEstablishmentAggregateFromForm = useCaseBuilder(
       establishmentAggregate,
       initialEstablishmentAggregate,
     );
-    const userRightsUpdated = getUserRightsUpdated(
+    const userRightsUpdatedWithSameStatus = getUserRightsUpdatedWithSameStatus(
+      establishmentAggregate,
+      initialEstablishmentAggregate,
+    );
+    const userRightsUpdatedWithNewStatus = getUserRightsUpdatedWithNewStatus(
+      establishmentAggregate,
+      initialEstablishmentAggregate,
+    );
+    const pendingUserRightsRemoved = getPendingUserRightsRemoved(
       establishmentAggregate,
       initialEstablishmentAggregate,
     );
 
     const makeUserRightsAddedNotifications = () =>
-      userRightsAdded.map(async (userRight) => {
-        const user = await uow.userRepository.getById(userRight.userId);
-        if (!user) throw errors.user.notFound({ userId: userRight.userId });
-        return deps.saveNotificationAndRelatedEvent(uow, {
-          kind: "email",
-          templatedContent: {
-            kind: "ESTABLISHMENT_USER_RIGHTS_ADDED",
-            recipients: [user.email],
-            params: {
-              businessName:
-                establishmentAggregate.establishment.customizedName ??
-                establishmentAggregate.establishment.name,
-              firstName: user.firstName,
-              lastName: user.lastName,
-              triggeredByUserFirstName: triggeredByUser.firstName,
-              triggeredByUserLastName: triggeredByUser.lastName,
-              role: userRight.role,
-              immersionBaseUrl: deps.immersionBaseUrl,
+      userRightsAdded
+        .filter((userRight) =>
+          onlyUserRightWithStatusAccepted({ status: userRight.status }),
+        )
+        .map(async (userRight) => {
+          const user = await uow.userRepository.getById(userRight.userId);
+          if (!user) throw errors.user.notFound({ userId: userRight.userId });
+          return deps.saveNotificationAndRelatedEvent(uow, {
+            kind: "email",
+            templatedContent: {
+              kind: "ESTABLISHMENT_USER_RIGHTS_ADDED",
+              recipients: [user.email],
+              params: {
+                businessName:
+                  establishmentAggregate.establishment.customizedName ??
+                  establishmentAggregate.establishment.name,
+                firstName: user.firstName,
+                lastName: user.lastName,
+                triggeredByUserFirstName: triggeredByUser.firstName,
+                triggeredByUserLastName: triggeredByUser.lastName,
+                role: userRight.role,
+                immersionBaseUrl: deps.immersionBaseUrl,
+              },
             },
-          },
-          followedIds: {
-            userId: userRight.userId,
-            establishmentSiret: establishmentAggregate.establishment.siret,
-          },
+            followedIds: {
+              userId: userRight.userId,
+              establishmentSiret: establishmentAggregate.establishment.siret,
+            },
+          });
         });
-      });
 
-    const makeUserRightsUpdatedNotifications = () =>
-      userRightsUpdated.map(async (userRight) => {
+    const makeUserRightsUpdatedWithSameStatusNotifications = () =>
+      userRightsUpdatedWithSameStatus.map(async (userRight) => {
         const user = await uow.userRepository.getById(userRight.userId);
         if (!user) throw errors.user.notFound({ userId: userRight.userId });
         return deps.saveNotificationAndRelatedEvent(uow, {
@@ -152,9 +166,49 @@ export const makeUpdateEstablishmentAggregateFromForm = useCaseBuilder(
         });
       });
 
+    const businessNameForUserRightsEmails =
+      establishmentAggregate.establishment.customizedName ??
+      establishmentAggregate.establishment.name;
+
+    const notifyUserRightStatusChangeByEmail = async (
+      userId: string,
+      updatedStatus:
+        | Extract<EstablishmentUserRightStatus, "ACCEPTED">
+        | "REJECTED",
+    ) => {
+      const notifiedUser = await uow.userRepository.getById(userId);
+      if (!notifiedUser) throw errors.user.notFound({ userId });
+      return deps.saveNotificationAndRelatedEvent(uow, {
+        kind: "email",
+        templatedContent: {
+          kind: "ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED",
+          recipients: [notifiedUser.email],
+          params: {
+            businessName: businessNameForUserRightsEmails,
+            firstName: notifiedUser.firstName,
+            lastName: notifiedUser.lastName,
+            triggeredByUserFirstName: triggeredByUser.firstName,
+            triggeredByUserLastName: triggeredByUser.lastName,
+            updatedStatus,
+            immersionBaseUrl: deps.immersionBaseUrl,
+          },
+        },
+        followedIds: {
+          userId,
+          establishmentSiret: establishmentAggregate.establishment.siret,
+        },
+      });
+    };
+
     await Promise.all([
       ...makeUserRightsAddedNotifications(),
-      ...makeUserRightsUpdatedNotifications(),
+      ...makeUserRightsUpdatedWithSameStatusNotifications(),
+      ...userRightsUpdatedWithNewStatus.map((userRight) =>
+        notifyUserRightStatusChangeByEmail(userRight.userId, "ACCEPTED"),
+      ),
+      ...pendingUserRightsRemoved.map((removedUserRight) =>
+        notifyUserRightStatusChangeByEmail(removedUserRight.userId, "REJECTED"),
+      ),
     ]);
 
     await uow.establishmentAggregateRepository.updateEstablishmentAggregate(
@@ -188,7 +242,7 @@ const getUserRightsAdded = (
   );
 };
 
-const getUserRightsUpdated = (
+const getUserRightsUpdatedWithSameStatus = (
   updatedEstablishmentAggregate: EstablishmentAggregate,
   initialEstablishmentAggregate: EstablishmentAggregate,
 ): EstablishmentUserRight[] => {
@@ -196,7 +250,33 @@ const getUserRightsUpdated = (
     initialEstablishmentAggregate.userRights.some(
       (existingUserRight) =>
         existingUserRight.userId === userRight.userId &&
+        existingUserRight.status === userRight.status &&
         !equals(existingUserRight, userRight),
     ),
   );
 };
+
+const getUserRightsUpdatedWithNewStatus = (
+  updatedEstablishmentAggregate: EstablishmentAggregate,
+  initialEstablishmentAggregate: EstablishmentAggregate,
+): EstablishmentUserRight[] => {
+  return updatedEstablishmentAggregate.userRights.filter((userRight) =>
+    initialEstablishmentAggregate.userRights.some(
+      (existingUserRight) =>
+        existingUserRight.userId === userRight.userId &&
+        existingUserRight.status !== userRight.status,
+    ),
+  );
+};
+
+const getPendingUserRightsRemoved = (
+  updatedEstablishmentAggregate: EstablishmentAggregate,
+  initialEstablishmentAggregate: EstablishmentAggregate,
+): EstablishmentUserRight[] =>
+  initialEstablishmentAggregate.userRights.filter(
+    (existingUserRight) =>
+      existingUserRight.status === "PENDING" &&
+      !updatedEstablishmentAggregate.userRights.some(
+        ({ userId }) => userId === existingUserRight.userId,
+      ),
+  );

--- a/back/src/domains/establishment/use-cases/UpdateEstablishmentAggregateFromFormEstablishement.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/UpdateEstablishmentAggregateFromFormEstablishement.unit.test.ts
@@ -907,14 +907,73 @@ describe("Update Establishment aggregate from form data", () => {
       });
 
       it("sends a notification to added and updated user & update formEstablishment and userRights on repository with a IC payload with user with establishment-admin rights", async () => {
-        uow.userRepository.users = [user];
+        const pendingContactUserToAccept = new UserBuilder()
+          .withId("pending-contact-user")
+          .withEmail("pending.contact@mail.com")
+          .withFirstName("Pat")
+          .withLastName("Pending")
+          .build();
+
+        const pendingContactUserToReject = new UserBuilder()
+          .withId("rejected-pending-contact-user")
+          .withEmail("rejected.pending@mail.com")
+          .withFirstName("Rej")
+          .withLastName("Ected")
+          .build();
+
+        const existingAdminRight: EstablishmentAdminRight = {
+          role: "establishment-admin",
+          status: "ACCEPTED",
+          job: "",
+          phone: "",
+          userId: user.id,
+          shouldReceiveDiscussionNotifications: true,
+          isMainContactByPhone: false,
+        };
+
+        const initialPendingContactRight: EstablishmentContactRight = {
+          userId: pendingContactUserToAccept.id,
+          role: "establishment-contact",
+          status: "PENDING",
+          shouldReceiveDiscussionNotifications: true,
+        };
+
+        const initialRejectedPendingContactRight: EstablishmentContactRight = {
+          userId: pendingContactUserToReject.id,
+          role: "establishment-contact",
+          status: "PENDING",
+          shouldReceiveDiscussionNotifications: true,
+        };
+
+        uow.establishmentAggregateRepository.establishmentAggregates = [
+          {
+            ...existingEstablishmentAggregate,
+            userRights: [
+              existingAdminRight,
+              initialPendingContactRight,
+              initialRejectedPendingContactRight,
+            ],
+          },
+        ];
+
+        uow.userRepository.users = [
+          user,
+          pendingContactUserToAccept,
+          pendingContactUserToReject,
+        ];
+
         uuidGenerator.setNextUuids([
           "next-user-1",
           "notification-id-1",
           "event-id-1",
           "notification-id-2",
           "event-id-2",
+          "notification-id-3",
+          "event-id-3",
+          "notification-id-4",
+          "event-id-4",
         ]);
+
         const newAdminEmail = "new.admin@gmail.com";
         const newAdminRight: EstablishmentAdminRight = {
           role: "establishment-admin",
@@ -925,6 +984,7 @@ describe("Update Establishment aggregate from form data", () => {
           shouldReceiveDiscussionNotifications: true,
           isMainContactByPhone: true,
         };
+
         const updatedFormEstablishmentWithUserRights: FormEstablishmentDto = {
           ...updatedFormEstablishment,
           userRights: [
@@ -932,6 +992,12 @@ describe("Update Establishment aggregate from form data", () => {
               role: "establishment-contact",
               status: "ACCEPTED",
               email: user.email,
+              shouldReceiveDiscussionNotifications: true,
+            },
+            {
+              role: "establishment-contact",
+              status: "ACCEPTED",
+              email: pendingContactUserToAccept.email,
               shouldReceiveDiscussionNotifications: true,
             },
             {
@@ -945,6 +1011,7 @@ describe("Update Establishment aggregate from form data", () => {
             },
           ],
         };
+
         await updateEstablishmentAggregateFromFormUseCase.execute(
           { formEstablishment: updatedFormEstablishmentWithUserRights },
           {
@@ -964,6 +1031,12 @@ describe("Update Establishment aggregate from form data", () => {
                   status: "ACCEPTED",
                   shouldReceiveDiscussionNotifications: true,
                 },
+                {
+                  userId: pendingContactUserToAccept.id,
+                  role: "establishment-contact",
+                  status: "ACCEPTED",
+                  shouldReceiveDiscussionNotifications: true,
+                },
                 newAdminRight,
               ],
             },
@@ -972,6 +1045,8 @@ describe("Update Establishment aggregate from form data", () => {
 
         expectObjectsToMatch(uow.userRepository.users, [
           user,
+          pendingContactUserToAccept,
+          pendingContactUserToReject,
           {
             id: newAdminRight.userId,
             email: newAdminEmail,
@@ -991,10 +1066,9 @@ describe("Update Establishment aggregate from form data", () => {
                   updatedFormEstablishmentWithUserRights.businessNameCustomized ??
                   updatedFormEstablishmentWithUserRights.businessName,
                 firstName: "",
-                lastName: "", // User is not connected at this moment, can't have firstname / lastname
-                triggeredByUserFirstName:
-                  connectedBackofficeAdminUser.firstName,
-                triggeredByUserLastName: connectedBackofficeAdminUser.lastName,
+                lastName: "",
+                triggeredByUserFirstName: user.firstName,
+                triggeredByUserLastName: user.lastName,
                 role: "establishment-admin",
                 immersionBaseUrl,
               },
@@ -1008,12 +1082,41 @@ describe("Update Establishment aggregate from form data", () => {
                   updatedFormEstablishmentWithUserRights.businessName,
                 firstName: user.firstName,
                 lastName: user.lastName,
-                triggeredByUserFirstName:
-                  connectedBackofficeAdminUser.firstName,
-                triggeredByUserLastName: connectedBackofficeAdminUser.lastName,
+                triggeredByUserFirstName: user.firstName,
+                triggeredByUserLastName: user.lastName,
                 updatedRole: "establishment-contact",
               },
               recipients: [user.email],
+            },
+            {
+              kind: "ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED",
+              params: {
+                businessName:
+                  updatedFormEstablishmentWithUserRights.businessNameCustomized ??
+                  updatedFormEstablishmentWithUserRights.businessName,
+                firstName: pendingContactUserToAccept.firstName,
+                lastName: pendingContactUserToAccept.lastName,
+                triggeredByUserFirstName: user.firstName,
+                triggeredByUserLastName: user.lastName,
+                updatedStatus: "ACCEPTED",
+                immersionBaseUrl,
+              },
+              recipients: [pendingContactUserToAccept.email],
+            },
+            {
+              kind: "ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED",
+              params: {
+                businessName:
+                  updatedFormEstablishmentWithUserRights.businessNameCustomized ??
+                  updatedFormEstablishmentWithUserRights.businessName,
+                firstName: pendingContactUserToReject.firstName,
+                lastName: pendingContactUserToReject.lastName,
+                triggeredByUserFirstName: user.firstName,
+                triggeredByUserLastName: user.lastName,
+                updatedStatus: "REJECTED",
+                immersionBaseUrl,
+              },
+              recipients: [pendingContactUserToReject.email],
             },
           ],
         });

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -727,6 +727,15 @@ export const defaultEmailValueByEmailKind: {
     role: "establishment-admin",
     immersionBaseUrl: "http://some-base-url.com",
   },
+  ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED: {
+    businessName: "BUSINESS_NAME",
+    firstName: "FIRST_NAME",
+    lastName: "LAST_NAME",
+    triggeredByUserFirstName: "ADMIN_FIRST_NAME",
+    triggeredByUserLastName: "ADMIN_LAST_NAME",
+    updatedStatus: "ACCEPTED",
+    immersionBaseUrl: "http://some-base-url.com",
+  },
   DISCUSSION_DEPRECATED_NOTIFICATION_ESTABLISHMENT: {
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",
     beneficiaryLastName: "BENEFICIARY_LAST_NAME",

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -15,6 +15,7 @@ import type {
   DiscussionKind,
   ExchangeRole,
 } from "../discussion/discussion.dto";
+import type { EstablishmentUserRightStatus } from "../formEstablishment/FormEstablishment.dto";
 import type { AgencyRole, EstablishmentRole } from "../role/role.dto";
 import type { AppellationLabel } from "../romeAndAppellationDtos/romeAndAppellation.dto";
 import type { SiretDto } from "../siret/siret";
@@ -356,6 +357,17 @@ export type EmailParamsByEmailType = {
     triggeredByUserFirstName: string;
     triggeredByUserLastName: string;
     updatedRole: EstablishmentRole;
+  };
+  ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED: {
+    businessName: string;
+    firstName: string;
+    lastName: string;
+    triggeredByUserFirstName: string;
+    triggeredByUserLastName: string;
+    updatedStatus:
+      | Extract<EstablishmentUserRightStatus, "ACCEPTED">
+      | "REJECTED";
+    immersionBaseUrl: AbsoluteUrl;
   };
   FULL_PREVIEW_EMAIL: {
     agencyLogoUrl: AbsoluteUrl | undefined;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1796,6 +1796,43 @@ Tél : ${beneficiaryPhone}`,
         subContent: defaultSignature("immersion"),
       }),
     },
+    ESTABLISHMENT_USER_RIGHTS_STATUS_UPDATED: {
+      niceName: "Espace Entreprise - Entreprise - Statut demande rattachement",
+      tags: [
+        "template:compte_etablissement_statutRattachement",
+        "theme:espaceEntreprise",
+        "acteur:entreprise",
+        "role:admin",
+        "role:contact",
+      ],
+      createEmailVariables: ({
+        businessName,
+        firstName,
+        lastName,
+        updatedStatus,
+        immersionBaseUrl,
+      }) => ({
+        subject: `Mise à jour de votre accès à l'entreprise ${businessName}`,
+        greetings: `Bonjour ${firstName} ${lastName},`,
+        content: `
+          Un administrateur de l'entreprise ${businessName} a traité votre demande de rattachement
+          <strong>Statut de votre demande : </strong>${updatedStatus === "ACCEPTED" ? "Acceptée" : "Refusée"}
+         
+         ${updatedStatus === "ACCEPTED" ? "Félicitations ! Vous pouvez désormais accéder aux conventions et aux candidatures de l'espace de l'entreprise." : "Votre demande n'a pas été accepté. Si vous pensez qu'il s'agit d'une erreur, nous vous invitons à contacter directement l'administrateur de l'établissement au sein de votre structure."}
+        `,
+        buttons:
+          updatedStatus === "ACCEPTED"
+            ? [
+                {
+                  label: "Accéder à mon espace",
+                  url: `${immersionBaseUrl}/${frontRoutes.establishmentDashboard}`,
+                },
+              ]
+            : [],
+        subContent: defaultSignature("immersion"),
+      }),
+    },
+
     FULL_PREVIEW_EMAIL: {
       niceName: "Tech - Preview email complet (tous les blocs)",
       tags: [

--- a/shared/src/formEstablishment/FormEstablishment.schema.ts
+++ b/shared/src/formEstablishment/FormEstablishment.schema.ts
@@ -65,6 +65,12 @@ export const onlyAdminUserRightsWithStatusAccepted =
 export const onlyContactUserRightsWithStatusAccepted =
   makeOnlyTargetRoleAndAcceptedStatus("establishment-contact");
 
+export const onlyUserRightWithStatusAccepted = ({
+  status,
+}: {
+  status: EstablishmentUserRightStatus;
+}) => status === "ACCEPTED";
+
 const contactModesWithoutWelcomeAddress: NotEmptyArray<ContactMode> = [
   "EMAIL",
   "PHONE",


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### Points d'attention
- le statut `REJECTED` n'existe pas : c'est juste une possibilité pour distinguer les contenus à envoyer sur le mail de notification de décision de rattachement -> à voir si on doit le faire un jour (par exemple : s'il faut lister les rattachements refusés dans mon profil ?)
- le rejet, en fait, c'est juste une suppression de droit utilisateur qui était en `PENDING`