### PR TITLE
#4895 - Accélérer la page Erreurs de diffusion : étape de préparation (expand)

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -13,6 +13,7 @@
     "db:redo": "pnpm db:migrate redo",
     "db:seed": "ts-node src/scripts/seed.ts",
     "db:seed:bun": "bun src/scripts/seed.ts",
+    "backfill-broadcast-feedback-ids": "ts-node src/scripts/backfillBroadcastFeedbackIds.ts",
     "db:up": "pnpm db:migrate up",
     "deadcode": "ts-prune --ignore 'src/config/pg/migrations'",
     "dev": "NODE_ENV=local ts-node-dev src/scripts/startServer.ts",

--- a/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
@@ -189,6 +189,8 @@ describe("authenticatedConventionRoutes", () => {
         serviceName: broadcastToFtServiceName,
         consumerName: "France Travail",
         consumerId: null,
+        conventionId,
+        agencyId: agency.id,
         subscriberErrorFeedback: { message: "Some message" },
         requestParams: { conventionId },
         response: { httpStatus: 500 },
@@ -208,6 +210,8 @@ describe("authenticatedConventionRoutes", () => {
             serviceName: broadcastToFtServiceName,
             consumerName: "France Travail",
             consumerId: null,
+            conventionId,
+            agencyId: agency.id,
             subscriberErrorFeedback: {
               message: "Some message",
             },

--- a/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
@@ -191,6 +191,8 @@ describe("authenticatedConventionRoutes", () => {
         serviceName: broadcastToFtServiceName,
         consumerName: "France Travail",
         consumerId: null,
+        conventionId,
+        agencyId: agency.id,
         subscriberErrorFeedback: { message: "Some message" },
         requestParams: { conventionId },
         response: { httpStatus: 500 },
@@ -210,6 +212,8 @@ describe("authenticatedConventionRoutes", () => {
             serviceName: broadcastToFtServiceName,
             consumerName: "France Travail",
             consumerId: null,
+            conventionId,
+            agencyId: agency.id,
             subscriberErrorFeedback: {
               message: "Some message",
             },

--- a/back/src/config/bootstrap/appConfig.ts
+++ b/back/src/config/bootstrap/appConfig.ts
@@ -368,6 +368,13 @@ export class AppConfig {
     return parseInteger(this.env.MAX_API_CONSUMER_CALLS_PER_SECOND, 5);
   }
 
+  public get backfillBroadcastFeedbackMaxBatchesPerPhase(): number | undefined {
+    return parseOptionalPositiveInteger(
+      this.env.BACKFILL_MAX_BATCHES_PER_PHASE,
+      "BACKFILL_MAX_BATCHES_PER_PHASE",
+    );
+  }
+
   public get maxConventionsToSyncWithPe() {
     return Number.parseInt(
       this.#throwIfNotDefinedOrDefault("MAX_CONVENTIONS_TO_SYNC_WITH_PE", "50"),
@@ -634,6 +641,19 @@ export class AppConfig {
 
 const parseInteger = (str: string | undefined, defaultValue: number): number =>
   str ? Number.parseInt(str) : defaultValue;
+
+const parseOptionalPositiveInteger = (
+  str: string | undefined,
+  variableName: string,
+): number | undefined => {
+  if (!str) return undefined;
+  const parsed = Number(str);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(
+      `Invalid ${variableName}=${str} (expected a positive integer)`,
+    );
+  return parsed;
+};
 
 // Format: <string>,<string>,...
 const parseStringList = (str: string | undefined, separator = ","): string[] =>

--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -232,6 +232,8 @@ interface BroadcastFeedbacks {
   occurred_at: Timestamp;
   handled_by_agency: Generated<boolean>;
   response: JSONColumnType<BroadcastFeedbackResponse> | null;
+  convention_id: string | null;
+  agency_id: string | null;
 }
 
 type ConventionObjectiveType =

--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -239,6 +239,8 @@ interface BroadcastFeedbacks {
   occurred_at: Timestamp;
   handled_by_agency: Generated<boolean>;
   response: JSONColumnType<BroadcastFeedbackResponse> | null;
+  convention_id: string | null;
+  agency_id: string | null;
 }
 
 type ConventionObjectiveType =

--- a/back/src/config/pg/migrations/1777903937758_add-convention-agency-ids-to-broadcast-feedbacks.ts
+++ b/back/src/config/pg/migrations/1777903937758_add-convention-agency-ids-to-broadcast-feedbacks.ts
@@ -1,0 +1,32 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn("broadcast_feedbacks", {
+    convention_id: { type: "uuid", notNull: false },
+    agency_id: { type: "uuid", notNull: false },
+  });
+
+  // Overlaps with idx_broadcast_feedbacks_convention_id (expression index on
+  // request_params->>'conventionId') from migration 1771275715629 during the
+  // expand window; the old expression index is dropped in step 2 (#4896).
+  pgm.createIndex("broadcast_feedbacks", "convention_id", {
+    name: "idx_bf_convention_id",
+  });
+
+  pgm.createIndex(
+    "broadcast_feedbacks",
+    ["agency_id", { name: "occurred_at", sort: "DESC" }],
+    { name: "idx_bf_agency_id_occurred_at" },
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex("broadcast_feedbacks", ["agency_id", "occurred_at"], {
+    name: "idx_bf_agency_id_occurred_at",
+  });
+  pgm.dropIndex("broadcast_feedbacks", "convention_id", {
+    name: "idx_bf_convention_id",
+  });
+  pgm.dropColumn("broadcast_feedbacks", "agency_id");
+  pgm.dropColumn("broadcast_feedbacks", "convention_id");
+}

--- a/back/src/config/pg/migrations/1781000986500_add-convention-agency-ids-to-broadcast-feedbacks.ts
+++ b/back/src/config/pg/migrations/1781000986500_add-convention-agency-ids-to-broadcast-feedbacks.ts
@@ -1,6 +1,8 @@
 import type { MigrationBuilder } from "node-pg-migrate";
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+
   pgm.addColumn("broadcast_feedbacks", {
     convention_id: { type: "uuid", notNull: false },
     agency_id: { type: "uuid", notNull: false },
@@ -11,21 +13,26 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   // expand window; the old expression index is dropped in step 2 (#4896).
   pgm.createIndex("broadcast_feedbacks", "convention_id", {
     name: "idx_bf_convention_id",
+    concurrently: true,
   });
 
   pgm.createIndex(
     "broadcast_feedbacks",
     ["agency_id", { name: "occurred_at", sort: "DESC" }],
-    { name: "idx_bf_agency_id_occurred_at" },
+    { name: "idx_bf_agency_id_occurred_at", concurrently: true },
   );
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.noTransaction();
+
   pgm.dropIndex("broadcast_feedbacks", ["agency_id", "occurred_at"], {
     name: "idx_bf_agency_id_occurred_at",
+    concurrently: true,
   });
   pgm.dropIndex("broadcast_feedbacks", "convention_id", {
     name: "idx_bf_convention_id",
+    concurrently: true,
   });
   pgm.dropColumn("broadcast_feedbacks", "agency_id");
   pgm.dropColumn("broadcast_feedbacks", "convention_id");

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2193,6 +2193,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const firstBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionIdA,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2213,6 +2215,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const lastBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-30T00:00:00.000Z",
@@ -2286,6 +2290,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const firstBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionIdA,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2306,6 +2312,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const lastBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-30T00:00:00.000Z",
@@ -2361,6 +2369,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const errorBroadcast: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: cancelledConventionId,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2395,6 +2405,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const priorSuccessBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: cancelledConventionId,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-06-01T00:00:00.000Z",
@@ -2499,6 +2511,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const handledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionA.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2519,6 +2533,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const unhandledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionB.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-02T00:00:00.000Z",
@@ -2595,6 +2611,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const unhandledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2662,6 +2680,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const broadcast1: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: convention1.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2681,6 +2701,7 @@ describe("Pg implementation of ConventionQueries", () => {
       };
       const broadcast2: BroadcastFeedback = {
         ...broadcast1,
+        conventionId: convention2.id,
         occurredAt: "2024-07-02T00:00:00.000Z",
         requestParams: {
           conventionId: convention2.id,
@@ -2689,6 +2710,7 @@ describe("Pg implementation of ConventionQueries", () => {
       };
       const broadcast3: BroadcastFeedback = {
         ...broadcast1,
+        conventionId: convention3.id,
         occurredAt: "2024-07-03T00:00:00.000Z",
         requestParams: {
           conventionId: convention3.id,
@@ -2875,6 +2897,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const managedErrorFeedback: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: conventionWithManagedError.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2896,6 +2920,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const unmanagedErrorFeedback: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: conventionWithUnmanagedError.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-02T00:00:00.000Z",
@@ -2916,6 +2942,7 @@ describe("Pg implementation of ConventionQueries", () => {
 
       const managedErrorFeedbackInReview: BroadcastFeedback = {
         ...managedErrorFeedback,
+        conventionId: conventionInReviewWithManagedError.id,
         occurredAt: "2024-07-03T00:00:00.000Z",
         requestParams: {
           conventionId: conventionInReviewWithManagedError.id,
@@ -3271,6 +3298,8 @@ describe("Pg implementation of ConventionQueries", () => {
           {
             consumerId: null,
             consumerName: "any-consumer-name",
+            conventionId: conventionBefore2025.id,
+            agencyId: agencyIdA,
             serviceName:
               "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
             occurredAt: "2024-07-01T00:00:00.000Z",
@@ -3291,6 +3320,7 @@ describe("Pg implementation of ConventionQueries", () => {
 
         const errorFeedbackAfter2025: BroadcastFeedback = {
           ...errorFeedbackWithConventionSubmitedBefore2025,
+          conventionId: conventionAfter2025.id,
           occurredAt: "2025-07-01T00:00:00.000Z",
           requestParams: {
             conventionId: conventionAfter2025.id,

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2487,6 +2487,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const firstBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionIdA,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2507,6 +2509,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const lastBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-30T00:00:00.000Z",
@@ -2580,6 +2584,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const firstBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionIdA,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2600,6 +2606,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const lastBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-30T00:00:00.000Z",
@@ -2655,6 +2663,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const errorBroadcast: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: cancelledConventionId,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2689,6 +2699,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const priorSuccessBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: cancelledConventionId,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-06-01T00:00:00.000Z",
@@ -2793,6 +2805,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const handledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionA.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2813,6 +2827,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const unhandledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: conventionB.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-02T00:00:00.000Z",
@@ -2889,6 +2905,8 @@ describe("Pg implementation of ConventionQueries", () => {
         const unhandledErrorFeedback: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
+          conventionId: convention.id,
+          agencyId: agencyIdA,
           serviceName:
             "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
           occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2956,6 +2974,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const broadcast1: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: convention1.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -2975,6 +2995,7 @@ describe("Pg implementation of ConventionQueries", () => {
       };
       const broadcast2: BroadcastFeedback = {
         ...broadcast1,
+        conventionId: convention2.id,
         occurredAt: "2024-07-02T00:00:00.000Z",
         requestParams: {
           conventionId: convention2.id,
@@ -2983,6 +3004,7 @@ describe("Pg implementation of ConventionQueries", () => {
       };
       const broadcast3: BroadcastFeedback = {
         ...broadcast1,
+        conventionId: convention3.id,
         occurredAt: "2024-07-03T00:00:00.000Z",
         requestParams: {
           conventionId: convention3.id,
@@ -3169,6 +3191,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const managedErrorFeedback: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: conventionWithManagedError.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-01T00:00:00.000Z",
@@ -3190,6 +3214,8 @@ describe("Pg implementation of ConventionQueries", () => {
       const unmanagedErrorFeedback: BroadcastFeedback = {
         consumerId: null,
         consumerName: "any-consumer-name",
+        conventionId: conventionWithUnmanagedError.id,
+        agencyId: agencyIdA,
         serviceName:
           "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
         occurredAt: "2024-07-02T00:00:00.000Z",
@@ -3210,6 +3236,7 @@ describe("Pg implementation of ConventionQueries", () => {
 
       const managedErrorFeedbackInReview: BroadcastFeedback = {
         ...managedErrorFeedback,
+        conventionId: conventionInReviewWithManagedError.id,
         occurredAt: "2024-07-03T00:00:00.000Z",
         requestParams: {
           conventionId: conventionInReviewWithManagedError.id,
@@ -3565,6 +3592,8 @@ describe("Pg implementation of ConventionQueries", () => {
           {
             consumerId: null,
             consumerName: "any-consumer-name",
+            conventionId: conventionBefore2025.id,
+            agencyId: agencyIdA,
             serviceName:
               "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
             occurredAt: "2024-07-01T00:00:00.000Z",
@@ -3585,6 +3614,7 @@ describe("Pg implementation of ConventionQueries", () => {
 
         const errorFeedbackAfter2025: BroadcastFeedback = {
           ...errorFeedbackWithConventionSubmitedBefore2025,
+          conventionId: conventionAfter2025.id,
           occurredAt: "2025-07-01T00:00:00.000Z",
           requestParams: {
             conventionId: conventionAfter2025.id,

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -529,6 +529,8 @@ export class PgConventionQueries implements ConventionQueries {
             lastBroadcastFeedback: {
               consumerId: row.consumerId,
               consumerName: row.consumerName,
+              conventionId: row.conventionId,
+              agencyId: row.agencyId,
               handledByAgency: row.handledByAgency,
               occurredAt: row.occurredAt,
               requestParams: row.requestParams,

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -698,6 +698,8 @@ export class PgConventionQueries implements ConventionQueries {
             lastBroadcastFeedback: {
               consumerId: row.consumerId,
               consumerName: row.consumerName,
+              conventionId: row.conventionId,
+              agencyId: row.agencyId,
               handledByAgency: row.handledByAgency,
               occurredAt: row.occurredAt,
               requestParams: row.requestParams,

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -448,6 +448,7 @@ const createBroadcastFeedbackBaseBuilder = ({
         )
         .select((eb) => [
           eb.ref("c.id").as("conventionId"),
+          eb.ref("c.agency_id").as("agencyId"),
           eb.ref("c.status").as("status"),
           eb.ref("beneficiary.first_name").as("bFirstName"),
           eb.ref("beneficiary.last_name").as("bLastName"),

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -465,6 +465,7 @@ const createBroadcastFeedbackBaseBuilder = ({
         )
         .select((eb) => [
           eb.ref("c.id").as("conventionId"),
+          eb.ref("c.agency_id").as("agencyId"),
           eb.ref("c.status").as("status"),
           eb.ref("beneficiary.first_name").as("bFirstName"),
           eb.ref("beneficiary.last_name").as("bLastName"),

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
@@ -30,6 +30,8 @@ describe("GetLastBroadcastFeedback", () => {
     serviceName: "test-service",
     consumerId: "cccccc99-9c0b-1bbb-bb6d-6bb9bd38bbbb",
     consumerName: "Test Consumer",
+    conventionId: convention.id,
+    agencyId: agency.id,
     subscriberErrorFeedback: {
       message: "Test error message",
       error: { code: "TEST_ERROR" },
@@ -122,6 +124,8 @@ describe("GetLastBroadcastFeedback", () => {
         serviceName: "error-service",
         consumerId: "error-consumer",
         consumerName: "Error Consumer",
+        conventionId: convention.id,
+        agencyId: agency.id,
         subscriberErrorFeedback: {
           message: "Connection timeout",
           error: { timeout: 5000 },

--- a/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetLastBroadcastFeedback.unit.test.ts
@@ -84,6 +84,18 @@ describe("GetLastBroadcastFeedback", () => {
       expectToEqual(result, sampleBroadcastFeedback);
     });
 
+    it("rejects broadcast feedbacks with inconsistent convention ids", () => {
+      const parseResult = broadcastFeedbackSchema.safeParse({
+        ...sampleBroadcastFeedback,
+        requestParams: {
+          ...sampleBroadcastFeedback.requestParams,
+          conventionId: "11111111-1111-4111-8111-111111111111",
+        },
+      });
+
+      expect(parseResult.success).toBe(false);
+    });
+
     it("should return null when no broadcast feedback exists", async () => {
       const result = await getLastBroadcastFeedback.execute(
         convention.id,

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastConventionAgain.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastConventionAgain.unit.test.ts
@@ -138,6 +138,8 @@ describe("BroadcastConventionAgain", () => {
           serviceName: broadcastToFtServiceName,
           consumerId: "my-consumer-id",
           consumerName: "My consumer name",
+          conventionId: convention.id,
+          agencyId: agency.id,
           requestParams: {
             conventionId: convention.id,
           },
@@ -174,6 +176,8 @@ describe("BroadcastConventionAgain", () => {
           serviceName: broadcastToFtServiceName,
           consumerId: "my-consumer-id",
           consumerName: "My consumer name",
+          conventionId: convention.id,
+          agencyId: agency.id,
           requestParams: {
             conventionId: convention.id,
           },

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
@@ -94,6 +94,8 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
     await uow.broadcastFeedbacksRepository.save({
       consumerId: null,
       consumerName: "France Travail",
+      conventionId: inputParams.convention.id,
+      agencyId: inputParams.convention.agencyId,
       serviceName: broadcastToFtServiceName,
       requestParams: {
         conventionId: inputParams.convention.id,

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
@@ -272,6 +272,8 @@ describe("Broadcasts events to France Travail", () => {
       {
         consumerId: null,
         consumerName: "France Travail",
+        conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
+        agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,
         requestParams: {
           conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
@@ -313,6 +315,8 @@ describe("Broadcasts events to France Travail", () => {
       {
         consumerId: null,
         consumerName: "France Travail",
+        conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
+        agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,
         requestParams: {
           conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
@@ -273,6 +273,8 @@ describe("Broadcasts events to France Travail", () => {
       {
         consumerId: null,
         consumerName: "France Travail",
+        conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
+        agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,
         requestParams: {
           conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
@@ -314,6 +316,8 @@ describe("Broadcasts events to France Travail", () => {
       {
         consumerId: null,
         consumerName: "France Travail",
+        conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
+        agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,
         requestParams: {
           conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -54,6 +54,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
     serviceName: "test-service",
     consumerId: "consumer-id-1",
     consumerName: "Test Consumer",
+    conventionId: convention1.id,
+    agencyId: agencyId1,
     subscriberErrorFeedback: {
       message: "Aucun dossier trouvé pour les critères d'identité transmis",
     },
@@ -68,6 +70,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
     serviceName: "test-service",
     consumerId: "consumer-id-2",
     consumerName: "Test Consumer",
+    conventionId: convention2.id,
+    agencyId: agencyId1,
     subscriberErrorFeedback: {
       message: "Some unmanaged error message",
     },
@@ -218,6 +222,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
       serviceName: "test-service",
       consumerId: "consumer-id-3",
       consumerName: "Test Consumer",
+      conventionId: convention3.id,
+      agencyId: agencyId2,
       subscriberErrorFeedback: {
         message: "Some error message",
       },
@@ -365,6 +371,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
     const errorBroadcast: BroadcastFeedback = {
       consumerId: null,
       consumerName: "any-consumer-name",
+      conventionId: cancelledConventionId,
+      agencyId: agencyId1,
       serviceName:
         "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
       occurredAt: "2024-07-01T14:00:00.000Z",
@@ -386,6 +394,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
     const priorSuccessBroadcast: BroadcastFeedback = {
       consumerId: null,
       consumerName: "any-consumer-name",
+      conventionId: cancelledConventionId,
+      agencyId: agencyId1,
       serviceName:
         "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
       occurredAt: "2024-07-01T08:00:00.000Z",

--- a/back/src/domains/convention/use-cases/partners-errored-convention/MarkPartnersErroredConventionAsHandled.unit.test.ts
+++ b/back/src/domains/convention/use-cases/partners-errored-convention/MarkPartnersErroredConventionAsHandled.unit.test.ts
@@ -84,6 +84,8 @@ describe("mark partners errored convention as handled", () => {
       serviceName: broadcastToFtServiceName,
       consumerName: "Yolo",
       consumerId: "yolo-id",
+      conventionId,
+      agencyId: agency.id,
       requestParams: {
         conventionId,
       },
@@ -158,6 +160,8 @@ describe("mark partners errored convention as handled", () => {
       serviceName: broadcastToFtServiceName,
       consumerId: "my-consumer-id",
       consumerName: "My consumer name",
+      conventionId,
+      agencyId: agency.id,
       requestParams: {
         conventionId,
       },

--- a/back/src/domains/core/api-consumer/adapters/HttpSubscribersGateway.manual.test.ts
+++ b/back/src/domains/core/api-consumer/adapters/HttpSubscribersGateway.manual.test.ts
@@ -64,8 +64,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: conventionReadDto.id,
-      conventionStatus: conventionReadDto.status,
       callbackUrl,
       status: 201,
       title: "Partner subscription notified successfully",
@@ -84,8 +82,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: conventionReadDto.id,
-      conventionStatus: conventionReadDto.status,
       callbackUrl,
       status: undefined,
       title: "Partner subscription errored",
@@ -108,8 +104,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: conventionReadDto.id,
-      conventionStatus: conventionReadDto.status,
       callbackUrl,
       status: 500,
       title: "Partner subscription errored",
@@ -132,8 +126,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: conventionReadDto.id,
-      conventionStatus: conventionReadDto.status,
       callbackUrl,
       status: 500,
       title: "Partner subscription errored",
@@ -156,8 +148,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: subscriptionBody.payload.convention.id,
-      conventionStatus: subscriptionBody.payload.convention.status,
       callbackUrl,
       status: 500,
       title: "Partner subscription errored",
@@ -180,8 +170,6 @@ describe("HttpSubscribersGateway", () => {
     );
 
     expectToEqual(response, {
-      conventionId: subscriptionBody.payload.convention.id,
-      conventionStatus: subscriptionBody.payload.convention.status,
       callbackUrl,
       status: 500,
       title: "Partner subscription errored",

--- a/back/src/domains/core/api-consumer/adapters/HttpSubscribersGateway.ts
+++ b/back/src/domains/core/api-consumer/adapters/HttpSubscribersGateway.ts
@@ -38,8 +38,6 @@ export class HttpSubscribersGateway implements SubscribersGateway {
           title: "Partner subscription notified successfully",
           callbackUrl,
           status: response.status,
-          conventionId: payload.convention.id,
-          conventionStatus: payload.convention.status,
           body: response.data,
         }),
       )
@@ -49,8 +47,6 @@ export class HttpSubscribersGateway implements SubscribersGateway {
         return {
           title: "Partner subscription errored",
           callbackUrl,
-          conventionId: payload.convention.id,
-          conventionStatus: payload.convention.status,
           ...(isAxiosError(error)
             ? { ...makeFeedbackFromError(error), body: error.response?.data }
             : {

--- a/back/src/domains/core/api-consumer/adapters/InMemorySubscribersGateway.ts
+++ b/back/src/domains/core/api-consumer/adapters/InMemorySubscribersGateway.ts
@@ -16,8 +16,6 @@ export class InMemorySubscribersGateway implements SubscribersGateway {
   #simulatedResponse: SubscriberResponse = {
     title: "Partner subscription notified successfully",
     callbackUrl: "http://fake.com",
-    conventionStatus: "ACCEPTED_BY_VALIDATOR",
-    conventionId: "lala",
     status: 200,
     body: { success: true },
   };
@@ -31,6 +29,7 @@ export class InMemorySubscribersGateway implements SubscribersGateway {
     subscriptionParams: SubscriptionParams,
   ): Promise<SubscriberResponse> {
     this.#calls.push({ body, subscriptionParams });
+
     return this.#simulatedResponse;
   }
 

--- a/back/src/domains/core/api-consumer/ports/SubscribersGateway.ts
+++ b/back/src/domains/core/api-consumer/ports/SubscribersGateway.ts
@@ -1,8 +1,6 @@
 import type {
   AbsoluteUrl,
-  ConventionId,
   ConventionReadDto,
-  ConventionStatus,
   SubscriberErrorFeedback,
   SubscriptionParams,
 } from "shared";
@@ -16,8 +14,6 @@ export type ConventionUpdatedSubscriptionCallbackBody = {
 
 type NotifyResponseCommon = {
   callbackUrl: AbsoluteUrl;
-  conventionId: ConventionId;
-  conventionStatus: ConventionStatus;
   status: number | undefined;
   body: unknown;
 };

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
@@ -225,6 +225,8 @@ const notifySubscriber = ({
       await uow.broadcastFeedbacksRepository.save({
         consumerId: apiConsumer.id,
         consumerName: apiConsumer.name,
+        conventionId: convention.id,
+        agencyId: convention.agencyId,
         handledByAgency: false,
         subscriberErrorFeedback: response.subscriberErrorFeedback,
         occurredAt: deps.timeGateway.now().toISOString(),
@@ -245,6 +247,8 @@ const notifySubscriber = ({
     await uow.broadcastFeedbacksRepository.save({
       consumerId: apiConsumer.id,
       consumerName: apiConsumer.name,
+      conventionId: convention.id,
+      agencyId: convention.agencyId,
       handledByAgency: false,
       occurredAt: deps.timeGateway.now().toISOString(),
       requestParams: {

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
@@ -243,6 +243,8 @@ const notifySubscriber = ({
       await uow.broadcastFeedbacksRepository.save({
         consumerId: apiConsumer.id,
         consumerName: apiConsumer.name,
+        conventionId: convention.id,
+        agencyId: convention.agencyId,
         handledByAgency: false,
         subscriberErrorFeedback: response.subscriberErrorFeedback,
         occurredAt: deps.timeGateway.now().toISOString(),
@@ -263,6 +265,8 @@ const notifySubscriber = ({
     await uow.broadcastFeedbacksRepository.save({
       consumerId: apiConsumer.id,
       consumerName: apiConsumer.name,
+      conventionId: convention.id,
+      agencyId: convention.agencyId,
       handledByAgency: false,
       occurredAt: deps.timeGateway.now().toISOString(),
       requestParams: {

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.ts
@@ -250,8 +250,8 @@ const notifySubscriber = ({
         occurredAt: deps.timeGateway.now().toISOString(),
         requestParams: {
           callbackUrl: response.callbackUrl,
-          conventionId: response.conventionId,
-          conventionStatus: response.conventionStatus,
+          conventionId: convention.id,
+          conventionStatus: convention.status,
         },
         serviceName: broadcastToPartnersServiceName,
         ...(response.status
@@ -271,8 +271,8 @@ const notifySubscriber = ({
       occurredAt: deps.timeGateway.now().toISOString(),
       requestParams: {
         callbackUrl: response.callbackUrl,
-        conventionId: response.conventionId,
-        conventionStatus: response.conventionStatus,
+        conventionId: convention.id,
+        conventionStatus: convention.status,
       },
       ...(response.status
         ? { response: { httpStatus: response.status, body: response.body } }

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
@@ -343,6 +343,8 @@ describe("Broadcast to partners on updated convention", () => {
     const expectedBroadcastFeedback: BroadcastFeedback = {
       consumerId: apiConsumer1.id,
       consumerName: apiConsumer1.name,
+      conventionId: convention1.id,
+      agencyId: convention1.agencyId,
       handledByAgency: false,
       subscriberErrorFeedback: errorResponse.subscriberErrorFeedback,
       occurredAt: now.toISOString(),
@@ -390,6 +392,8 @@ describe("Broadcast to partners on updated convention", () => {
     const expectedBroadcastFeedback: BroadcastFeedback = {
       consumerId: apiConsumer1.id,
       consumerName: apiConsumer1.name,
+      conventionId: convention1.id,
+      agencyId: convention1.agencyId,
       handledByAgency: false,
       occurredAt: now.toISOString(),
       requestParams: {

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
@@ -332,8 +332,6 @@ describe("Broadcast to partners on updated convention", () => {
     const errorResponse: SubscriberResponse = {
       title: "Partner subscription errored",
       callbackUrl: "http://fake.com",
-      conventionStatus: "ACCEPTED_BY_VALIDATOR",
-      conventionId: "lala",
       status: 200,
       subscriberErrorFeedback: { message: "ca va très mal" },
       body: { success: true },
@@ -353,8 +351,8 @@ describe("Broadcast to partners on updated convention", () => {
       occurredAt: now.toISOString(),
       requestParams: {
         callbackUrl: errorResponse.callbackUrl,
-        conventionId: errorResponse.conventionId,
-        conventionStatus: errorResponse.conventionStatus,
+        conventionId: convention1.id,
+        conventionStatus: convention1.status,
       },
       ...(errorResponse.status
         ? {
@@ -382,8 +380,6 @@ describe("Broadcast to partners on updated convention", () => {
     const successResponse: SubscriberResponse = {
       title: "Partner subscription notified successfully",
       callbackUrl: "http://fake.com",
-      conventionStatus: "ACCEPTED_BY_VALIDATOR",
-      conventionId: "lala",
       status: 200,
       body: { success: true },
     };
@@ -401,8 +397,8 @@ describe("Broadcast to partners on updated convention", () => {
       occurredAt: now.toISOString(),
       requestParams: {
         callbackUrl: successResponse.callbackUrl,
-        conventionId: successResponse.conventionId,
-        conventionStatus: successResponse.conventionStatus,
+        conventionId: convention1.id,
+        conventionStatus: convention1.status,
       },
       ...(successResponse.status
         ? {

--- a/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/core/api-consumer/use-cases/BroadcastToPartnersOnConventionUpdates.unit.test.ts
@@ -346,6 +346,8 @@ describe("Broadcast to partners on updated convention", () => {
     const expectedBroadcastFeedback: BroadcastFeedback = {
       consumerId: apiConsumer1.id,
       consumerName: apiConsumer1.name,
+      conventionId: convention1.id,
+      agencyId: convention1.agencyId,
       handledByAgency: false,
       subscriberErrorFeedback: errorResponse.subscriberErrorFeedback,
       occurredAt: now.toISOString(),
@@ -393,6 +395,8 @@ describe("Broadcast to partners on updated convention", () => {
     const expectedBroadcastFeedback: BroadcastFeedback = {
       consumerId: apiConsumer1.id,
       consumerName: apiConsumer1.name,
+      conventionId: convention1.id,
+      agencyId: convention1.agencyId,
       handledByAgency: false,
       occurredAt: now.toISOString(),
       requestParams: {

--- a/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository.ts
@@ -45,6 +45,12 @@ export class InMemoryBroadcastFeedbacksRepository
   }
 
   public async save(broadcastFeedback: BroadcastFeedback): Promise<void> {
+    if (
+      broadcastFeedback.conventionId !==
+      broadcastFeedback.requestParams.conventionId
+    )
+      throw new Error("Broadcast feedback convention ids must match");
+
     this.#broadcastFeedbacks.push(broadcastFeedback);
   }
 

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
@@ -1,6 +1,7 @@
 import axios, { isAxiosError } from "axios";
 import type { Pool } from "pg";
 import {
+  type AgencyId,
   type BroadcastFeedback,
   type BroadcastFeedbackResponse,
   broadcastFeedbackSchema,
@@ -22,8 +23,10 @@ import { makeTestPgPool } from "../../../../config/pg/pgPool";
 import { broadcastToFtServiceName } from "../ports/BroadcastFeedbacksRepository";
 import { PgBroadcastFeedbacksRepository } from "./PgBroadcastFeedbacksRepository";
 
-const someConventionId = "a07af28e-9c7b-4845-91ee-71020860faa8";
-const anotherConventionId = "b07af28e-9c7b-4845-91ee-71020860faa8";
+const someConventionId: ConventionId = "a07af28e-9c7b-4845-91ee-71020860faa8";
+const anotherConventionId: ConventionId =
+  "b07af28e-9c7b-4845-91ee-71020860faa8";
+const someAgencyId: AgencyId = "11111111-1111-4111-8111-111111111111";
 
 describe("PgBroadcastFeedbacksRepository", () => {
   let pool: Pool;
@@ -105,6 +108,8 @@ describe("PgBroadcastFeedbacksRepository", () => {
         handled_by_agency: broadcastFeedback.handledByAgency,
         occurred_at: new Date(broadcastFeedback.occurredAt),
         request_params: broadcastFeedback.requestParams,
+        convention_id: broadcastFeedback.conventionId,
+        agency_id: broadcastFeedback.agencyId,
         ...(broadcastFeedback.response
           ? {
               response: {
@@ -118,6 +123,25 @@ describe("PgBroadcastFeedbacksRepository", () => {
         service_name: broadcastFeedback.serviceName,
       },
     ]);
+  });
+
+  it("writes convention_id and agency_id columns on save", async () => {
+    const conventionId = someConventionId;
+    const agencyId: AgencyId = "22222222-2222-4222-8222-222222222222";
+    const broadcastFeedback = await makeBroadcastFeedback({
+      conventionId,
+      agencyId,
+      serviceName: "osef",
+      kind: "success",
+    });
+    await pgBroadcastFeedbacksRepository.save(broadcastFeedback);
+
+    const rows = await kyselyDb
+      .selectFrom("broadcast_feedbacks")
+      .select(["convention_id", "agency_id"])
+      .execute();
+
+    expectToEqual(rows, [{ convention_id: conventionId, agency_id: agencyId }]);
   });
 
   it("saves an axios timeout error in the repository", async () => {
@@ -260,6 +284,8 @@ describe("PgBroadcastFeedbacksRepository", () => {
             handledByAgency: qb.ref("bf.handled_by_agency"),
             consumerName: qb.ref("bf.consumer_name"),
             consumerId: qb.ref("bf.consumer_id"),
+            conventionId: cast<ConventionId>(qb.ref("bf.convention_id")),
+            agencyId: cast<AgencyId>(qb.ref("bf.agency_id")),
           }).as("broacastFeedback"),
         )
         .orderBy("id")
@@ -269,6 +295,8 @@ describe("PgBroadcastFeedbacksRepository", () => {
         pgbroadcastFeedbacks.map(
           (pgBroadcastFeedback): BroadcastFeedback => ({
             serviceName: pgBroadcastFeedback.broacastFeedback.serviceName,
+            conventionId: pgBroadcastFeedback.broacastFeedback.conventionId,
+            agencyId: pgBroadcastFeedback.broacastFeedback.agencyId,
             subscriberErrorFeedback:
               pgBroadcastFeedback.broacastFeedback.subscriberErrorFeedback,
             requestParams: pgBroadcastFeedback.broacastFeedback.requestParams,
@@ -345,6 +373,34 @@ describe("PgBroadcastFeedbacksRepository", () => {
       expect(result).toBeNull();
     });
 
+    it("falls back to request_params.conventionId when convention_id column is null (legacy rows pre-backfill)", async () => {
+      const conventionId = someConventionId;
+
+      await kyselyDb
+        .insertInto("broadcast_feedbacks")
+        .values({
+          service_name: broadcastToFtServiceName,
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({ conventionId }),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        })
+        .execute();
+
+      const result =
+        await pgBroadcastFeedbacksRepository.getLastBroadcastFeedback(
+          conventionId,
+        );
+
+      expect(result).not.toBeNull();
+      expectToEqual(result?.conventionId, conventionId);
+      expectToEqual(result?.agencyId, null);
+    });
+
     it("retrieve a broadcast feedback", async () => {
       const conventionId = someConventionId;
 
@@ -390,10 +446,12 @@ const makeBroadcastFeedback = async (params: {
   kind: "error" | "success";
   serviceName: string;
   conventionId: ConventionId;
+  agencyId?: AgencyId;
   occurredAt?: Date;
   errorMode?: "timeout" | "response-error" | "not-axios-error";
   handledByAgency?: boolean;
 }): Promise<BroadcastFeedback> => {
+  const agencyId = params.agencyId ?? someAgencyId;
   if (params.kind === "error") {
     const error = await axios
       .get(
@@ -412,6 +470,8 @@ const makeBroadcastFeedback = async (params: {
     return {
       consumerId: null,
       consumerName: "my-consumer",
+      conventionId: params.conventionId,
+      agencyId,
       serviceName: params.serviceName,
       subscriberErrorFeedback: {
         message: "Some message",
@@ -432,6 +492,8 @@ const makeBroadcastFeedback = async (params: {
   return {
     consumerId: null,
     consumerName: "my-consumer",
+    conventionId: params.conventionId,
+    agencyId,
     serviceName: params.serviceName,
     requestParams: { conventionId: params.conventionId },
     response: { httpStatus: 200, body: { status: 200, title: "blabla" } },

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.integration.test.ts
@@ -1,11 +1,13 @@
 import axios, { isAxiosError } from "axios";
 import type { Pool } from "pg";
 import {
+  AgencyDtoBuilder,
   type AgencyId,
   type BroadcastFeedback,
   type BroadcastFeedbackResponse,
   broadcastFeedbackSchema,
   type ConventionBroadcastRequestParams,
+  ConventionDtoBuilder,
   type ConventionId,
   errors,
   expectObjectInArrayToMatch,
@@ -13,6 +15,7 @@ import {
   expectToEqual,
   type SubscriberErrorFeedback,
 } from "shared";
+import { v4 as uuid } from "uuid";
 import {
   cast,
   jsonBuildObject,
@@ -20,6 +23,11 @@ import {
   makeKyselyDb,
 } from "../../../../config/pg/kysely/kyselyUtils";
 import { makeTestPgPool } from "../../../../config/pg/pgPool";
+import { toAgencyWithRights } from "../../../../utils/agency";
+import { makeUniqueUserForTest } from "../../../../utils/user";
+import { PgAgencyRepository } from "../../../agency/adapters/PgAgencyRepository";
+import { PgConventionRepository } from "../../../convention/adapters/PgConventionRepository";
+import { PgUserRepository } from "../../../core/authentication/connected-user/adapters/PgUserRepository";
 import { broadcastToFtServiceName } from "../ports/BroadcastFeedbacksRepository";
 import { PgBroadcastFeedbacksRepository } from "./PgBroadcastFeedbacksRepository";
 
@@ -43,6 +51,10 @@ describe("PgBroadcastFeedbacksRepository", () => {
       kyselyDb,
     );
     await kyselyDb.deleteFrom("broadcast_feedbacks").execute();
+    await kyselyDb.deleteFrom("conventions").execute();
+    await kyselyDb.deleteFrom("actors").execute();
+    await kyselyDb.deleteFrom("users__agencies").execute();
+    await kyselyDb.deleteFrom("agencies").execute();
   });
 
   afterAll(async () => {
@@ -373,8 +385,22 @@ describe("PgBroadcastFeedbacksRepository", () => {
       expect(result).toBeNull();
     });
 
-    it("falls back to request_params.conventionId when convention_id column is null (legacy rows pre-backfill)", async () => {
+    it("falls back to legacy fields when columns are null (legacy rows pre-backfill)", async () => {
       const conventionId = someConventionId;
+      const agencyId = someAgencyId;
+      const validator = makeUniqueUserForTest(uuid());
+      await new PgUserRepository(kyselyDb).save(validator);
+      await new PgAgencyRepository(kyselyDb).insert(
+        toAgencyWithRights(new AgencyDtoBuilder().withId(agencyId).build(), {
+          [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+        }),
+      );
+      await new PgConventionRepository(kyselyDb).save(
+        new ConventionDtoBuilder()
+          .withId(conventionId)
+          .withAgencyId(agencyId)
+          .build(),
+      );
 
       await kyselyDb
         .insertInto("broadcast_feedbacks")
@@ -398,7 +424,7 @@ describe("PgBroadcastFeedbacksRepository", () => {
 
       expect(result).not.toBeNull();
       expectToEqual(result?.conventionId, conventionId);
-      expectToEqual(result?.agencyId, null);
+      expectToEqual(result?.agencyId, agencyId);
     });
 
     it("retrieve a broadcast feedback", async () => {

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
@@ -1,5 +1,6 @@
 import { sql } from "kysely";
 import {
+  type AgencyId,
   type BroadcastFeedback,
   type ConventionId,
   type ConventionLastBroadcastFeedbackResponse,
@@ -34,6 +35,8 @@ export class PgBroadcastFeedbacksRepository
             ),
             "bf.handled_by_agency as handledByAgency",
             "bf.response as response",
+            "bf.convention_id as conventionId",
+            "bf.agency_id as agencyId",
             sql<number>`
               ROW_NUMBER() OVER (
                 PARTITION BY (bf.request_params->>'conventionId')
@@ -52,6 +55,9 @@ export class PgBroadcastFeedbacksRepository
     return {
       consumerId: result.consumerId,
       consumerName: result.consumerName,
+      conventionId: (result.conventionId ??
+        result.requestParams.conventionId) as ConventionId,
+      agencyId: result.agencyId as AgencyId | null,
       handledByAgency: result.handledByAgency,
       occurredAt: result.occurredAt,
       requestParams: result.requestParams,
@@ -89,6 +95,8 @@ export class PgBroadcastFeedbacksRepository
       handledByAgency,
       consumerName,
       consumerId,
+      conventionId,
+      agencyId,
     } = broadcastFeedback;
 
     await this.transaction
@@ -97,6 +105,8 @@ export class PgBroadcastFeedbacksRepository
         service_name: serviceName,
         consumer_name: consumerName,
         consumer_id: consumerId,
+        convention_id: conventionId,
+        agency_id: agencyId,
         ...(subscriberErrorFeedback
           ? {
               subscriber_error_feedback: JSON.stringify({

--- a/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/adapters/PgBroadcastFeedbacksRepository.ts
@@ -52,12 +52,17 @@ export class PgBroadcastFeedbacksRepository
 
     if (!result) return null;
 
+    const conventionId = (result.conventionId ??
+      result.requestParams.conventionId) as ConventionId;
+    const agencyId = result.agencyId ?? (await this.#getAgencyId(conventionId));
+
+    if (!agencyId) return null;
+
     return {
       consumerId: result.consumerId,
       consumerName: result.consumerName,
-      conventionId: (result.conventionId ??
-        result.requestParams.conventionId) as ConventionId,
-      agencyId: result.agencyId as AgencyId | null,
+      conventionId,
+      agencyId,
       handledByAgency: result.handledByAgency,
       occurredAt: result.occurredAt,
       requestParams: result.requestParams,
@@ -67,6 +72,16 @@ export class PgBroadcastFeedbacksRepository
         ? result.subscriberErrorFeedback
         : undefined,
     };
+  }
+
+  async #getAgencyId(conventionId: ConventionId): Promise<AgencyId | null> {
+    const convention = await this.transaction
+      .selectFrom("conventions")
+      .select("agency_id")
+      .where("id", "=", conventionId)
+      .executeTakeFirst();
+
+    return (convention?.agency_id ?? null) as AgencyId | null;
   }
 
   public async markPartnersErroredConventionAsHandled(
@@ -98,6 +113,9 @@ export class PgBroadcastFeedbacksRepository
       conventionId,
       agencyId,
     } = broadcastFeedback;
+
+    if (conventionId !== requestParams.conventionId)
+      throw new Error("Broadcast feedback convention ids must match");
 
     await this.transaction
       .insertInto("broadcast_feedbacks")

--- a/back/src/scripts/backfillBroadcastFeedbackIds.integration.test.ts
+++ b/back/src/scripts/backfillBroadcastFeedbackIds.integration.test.ts
@@ -1,0 +1,118 @@
+import type { Pool } from "pg";
+import {
+  AgencyDtoBuilder,
+  ConventionDtoBuilder,
+  type ConventionId,
+  expectToEqual,
+} from "shared";
+import { v4 as uuid } from "uuid";
+import { type KyselyDb, makeKyselyDb } from "../config/pg/kysely/kyselyUtils";
+import { makeTestPgPool } from "../config/pg/pgPool";
+import { PgAgencyRepository } from "../domains/agency/adapters/PgAgencyRepository";
+import { PgConventionRepository } from "../domains/convention/adapters/PgConventionRepository";
+import { PgUserRepository } from "../domains/core/authentication/connected-user/adapters/PgUserRepository";
+import { toAgencyWithRights } from "../utils/agency";
+import { makeUniqueUserForTest } from "../utils/user";
+import { backfillBroadcastFeedbackIds } from "./backfillBroadcastFeedbackIds";
+
+describe("backfillBroadcastFeedbackIds", () => {
+  let pool: Pool;
+  let db: KyselyDb;
+
+  beforeAll(() => {
+    pool = makeTestPgPool();
+    db = makeKyselyDb(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom("broadcast_feedbacks").execute();
+    await db.deleteFrom("conventions").execute();
+    await db.deleteFrom("actors").execute();
+    await db.deleteFrom("users__agencies").execute();
+    await db.deleteFrom("agencies").execute();
+    await db.deleteFrom("users").execute();
+  });
+
+  it("backfills convention_id for all rows and agency_id only for rows whose convention still exists", async () => {
+    const agency = new AgencyDtoBuilder().withId(uuid()).build();
+    const validator = makeUniqueUserForTest(uuid());
+    await new PgUserRepository(db).save(validator);
+    await new PgAgencyRepository(db).insert(
+      toAgencyWithRights(agency, {
+        [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      }),
+    );
+
+    const existingConventionId: ConventionId =
+      "11111111-1111-4111-8111-111111111111";
+    const orphanConventionId: ConventionId =
+      "22222222-2222-4222-8222-222222222222";
+
+    const convention = new ConventionDtoBuilder()
+      .withId(existingConventionId)
+      .withAgencyId(agency.id)
+      .build();
+    await new PgConventionRepository(db).save(convention);
+
+    await db
+      .insertInto("broadcast_feedbacks")
+      .values([
+        {
+          service_name: "osef",
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({
+            conventionId: existingConventionId,
+          }),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        },
+        {
+          service_name: "osef",
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({
+            conventionId: orphanConventionId,
+          }),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        },
+      ])
+      .execute();
+
+    const summary = await backfillBroadcastFeedbackIds(db);
+
+    expectToEqual(summary, {
+      totalConventionIdUpdated: 2,
+      totalAgencyIdUpdated: 1,
+      remainingOrphanAgencyIds: 1,
+    });
+
+    const rows = await db
+      .selectFrom("broadcast_feedbacks")
+      .select(["request_params", "convention_id", "agency_id"])
+      .execute();
+
+    const existingRow = rows.find(
+      (r) => r.request_params.conventionId === existingConventionId,
+    );
+    const orphanRow = rows.find(
+      (r) => r.request_params.conventionId === orphanConventionId,
+    );
+
+    expectToEqual(existingRow?.convention_id, existingConventionId);
+    expectToEqual(existingRow?.agency_id, agency.id);
+    expectToEqual(orphanRow?.convention_id, orphanConventionId);
+    expectToEqual(orphanRow?.agency_id, null);
+  });
+});

--- a/back/src/scripts/backfillBroadcastFeedbackIds.integration.test.ts
+++ b/back/src/scripts/backfillBroadcastFeedbackIds.integration.test.ts
@@ -96,6 +96,9 @@ describe("backfillBroadcastFeedbackIds", () => {
       totalConventionIdUpdated: 2,
       totalAgencyIdUpdated: 1,
       remainingOrphanAgencyIds: 1,
+      invalidLegacyConventionIds: 0,
+      conventionIdStoppedByMaxBatches: false,
+      agencyIdStoppedByMaxBatches: false,
     });
 
     const rows = await db
@@ -114,5 +117,159 @@ describe("backfillBroadcastFeedbackIds", () => {
     expectToEqual(existingRow?.agency_id, agency.id);
     expectToEqual(orphanRow?.convention_id, orphanConventionId);
     expectToEqual(orphanRow?.agency_id, null);
+  });
+
+  it("continues backfilling agency_id when orphan rows are before valid rows", async () => {
+    const agency = new AgencyDtoBuilder().withId(uuid()).build();
+    const validator = makeUniqueUserForTest(uuid());
+    await new PgUserRepository(db).save(validator);
+    await new PgAgencyRepository(db).insert(
+      toAgencyWithRights(agency, {
+        [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      }),
+    );
+
+    const orphanConventionId: ConventionId =
+      "33333333-3333-4333-8333-333333333333";
+    const existingConventionId: ConventionId =
+      "44444444-4444-4444-8444-444444444444";
+
+    await new PgConventionRepository(db).save(
+      new ConventionDtoBuilder()
+        .withId(existingConventionId)
+        .withAgencyId(agency.id)
+        .build(),
+    );
+
+    await db
+      .insertInto("broadcast_feedbacks")
+      .values({
+        service_name: "osef",
+        consumer_name: "my-consumer",
+        consumer_id: null,
+        request_params: JSON.stringify({ conventionId: orphanConventionId }),
+        response: JSON.stringify({ httpStatus: 500 }),
+        occurred_at: new Date("2024-07-31").toISOString(),
+        handled_by_agency: false,
+        convention_id: null,
+        agency_id: null,
+      })
+      .execute();
+
+    await db
+      .insertInto("broadcast_feedbacks")
+      .values({
+        service_name: "osef",
+        consumer_name: "my-consumer",
+        consumer_id: null,
+        request_params: JSON.stringify({ conventionId: existingConventionId }),
+        response: JSON.stringify({ httpStatus: 500 }),
+        occurred_at: new Date("2024-07-31").toISOString(),
+        handled_by_agency: false,
+        convention_id: null,
+        agency_id: null,
+      })
+      .execute();
+
+    const summary = await backfillBroadcastFeedbackIds(db, { batchSize: 1 });
+
+    expectToEqual(summary, {
+      totalConventionIdUpdated: 2,
+      totalAgencyIdUpdated: 1,
+      remainingOrphanAgencyIds: 1,
+      invalidLegacyConventionIds: 0,
+      conventionIdStoppedByMaxBatches: false,
+      agencyIdStoppedByMaxBatches: false,
+    });
+
+    const validRow = await db
+      .selectFrom("broadcast_feedbacks")
+      .select(["agency_id"])
+      .where("convention_id", "=", existingConventionId)
+      .executeTakeFirstOrThrow();
+
+    expectToEqual(validRow.agency_id, agency.id);
+  });
+
+  it("skips legacy rows without convention ids instead of blocking valid rows", async () => {
+    const validConventionId: ConventionId =
+      "55555555-5555-4555-8555-555555555555";
+
+    await db
+      .insertInto("broadcast_feedbacks")
+      .values([
+        {
+          service_name: "osef",
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({}),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        },
+        {
+          service_name: "osef",
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({ conventionId: validConventionId }),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        },
+      ])
+      .execute();
+
+    const summary = await backfillBroadcastFeedbackIds(db, { batchSize: 1 });
+
+    expectToEqual(summary, {
+      totalConventionIdUpdated: 1,
+      totalAgencyIdUpdated: 0,
+      remainingOrphanAgencyIds: 1,
+      invalidLegacyConventionIds: 1,
+      conventionIdStoppedByMaxBatches: false,
+      agencyIdStoppedByMaxBatches: false,
+    });
+  });
+
+  it("reports when a phase stops because max batches is reached", async () => {
+    const firstConventionId: ConventionId =
+      "66666666-6666-4666-8666-666666666666";
+    const secondConventionId: ConventionId =
+      "77777777-7777-4777-8777-777777777777";
+
+    await db
+      .insertInto("broadcast_feedbacks")
+      .values(
+        [firstConventionId, secondConventionId].map((conventionId) => ({
+          service_name: "osef",
+          consumer_name: "my-consumer",
+          consumer_id: null,
+          request_params: JSON.stringify({ conventionId }),
+          response: JSON.stringify({ httpStatus: 500 }),
+          occurred_at: new Date("2024-07-31").toISOString(),
+          handled_by_agency: false,
+          convention_id: null,
+          agency_id: null,
+        })),
+      )
+      .execute();
+
+    const summary = await backfillBroadcastFeedbackIds(db, {
+      batchSize: 1,
+      maxBatchesPerPhase: 1,
+    });
+
+    expectToEqual(summary, {
+      totalConventionIdUpdated: 1,
+      totalAgencyIdUpdated: 0,
+      remainingOrphanAgencyIds: 1,
+      invalidLegacyConventionIds: 0,
+      conventionIdStoppedByMaxBatches: true,
+      agencyIdStoppedByMaxBatches: false,
+    });
   });
 });

--- a/back/src/scripts/backfillBroadcastFeedbackIds.ts
+++ b/back/src/scripts/backfillBroadcastFeedbackIds.ts
@@ -1,0 +1,156 @@
+import "./instrumentSentryCron";
+import { type SqlBool, sql } from "kysely";
+import { AppConfig } from "../config/bootstrap/appConfig";
+import { type KyselyDb, makeKyselyDb } from "../config/pg/kysely/kyselyUtils";
+import { createMakeScriptPgPool } from "../config/pg/pgPool";
+import { createLogger } from "../utils/logger";
+import { handleCRONScript } from "./handleCRONScript";
+
+const logger = createLogger(__filename);
+const config = AppConfig.createFromEnv();
+
+const batchSize = 10_000;
+
+const parseMaxBatchesPerPhase = (raw: string | undefined): number => {
+  if (!raw) return Number.POSITIVE_INFINITY;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    throw new Error(
+      `Invalid BACKFILL_MAX_BATCHES_PER_PHASE=${raw} (expected a positive integer)`,
+    );
+  return parsed;
+};
+
+const maxBatchesPerPhase = parseMaxBatchesPerPhase(
+  process.env.BACKFILL_MAX_BATCHES_PER_PHASE,
+);
+
+const fillConventionIdBatch = async (kysely: KyselyDb): Promise<number> => {
+  const res = await kysely
+    .updateTable("broadcast_feedbacks")
+    .set({
+      convention_id: sql<string>`(broadcast_feedbacks.request_params ->> 'conventionId')::uuid`,
+    })
+    .where(
+      sql<SqlBool>`broadcast_feedbacks.id = ANY(ARRAY(
+        SELECT id
+        FROM broadcast_feedbacks
+        WHERE convention_id IS NULL
+        ORDER BY id
+        LIMIT ${batchSize}
+      ))`,
+    )
+    .executeTakeFirst();
+  return Number(res.numUpdatedRows);
+};
+
+const fillAgencyIdBatch = async (kysely: KyselyDb): Promise<number> => {
+  const res = await kysely
+    .updateTable("broadcast_feedbacks")
+    .from("conventions")
+    .set((eb) => ({ agency_id: eb.ref("conventions.agency_id") }))
+    .whereRef("broadcast_feedbacks.convention_id", "=", "conventions.id")
+    .where(
+      sql<SqlBool>`broadcast_feedbacks.id = ANY(ARRAY(
+        SELECT id
+        FROM broadcast_feedbacks
+        WHERE agency_id IS NULL
+          AND convention_id IS NOT NULL
+        ORDER BY id
+        LIMIT ${batchSize}
+      ))`,
+    )
+    .executeTakeFirst();
+  return Number(res.numUpdatedRows);
+};
+
+const countRemainingOrphanAgencyIds = async (
+  kysely: KyselyDb,
+): Promise<number> => {
+  const row = await kysely
+    .selectFrom("broadcast_feedbacks")
+    .select((eb) => eb.fn.countAll<string>().as("count"))
+    .where("agency_id", "is", null)
+    .where("convention_id", "is not", null)
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+};
+
+export const backfillBroadcastFeedbackIds = async (kysely: KyselyDb) => {
+  let totalConventionIdUpdated = 0;
+  let conventionIdBatches = 0;
+  for (;;) {
+    const n = await fillConventionIdBatch(kysely);
+    totalConventionIdUpdated += n;
+    conventionIdBatches += 1;
+    logger.info({
+      message: JSON.stringify({
+        phase: "convention_id",
+        batchRows: n,
+        totalSoFar: totalConventionIdUpdated,
+      }),
+    });
+    if (n === 0) break;
+    if (conventionIdBatches >= maxBatchesPerPhase) break;
+  }
+
+  let totalAgencyIdUpdated = 0;
+  let agencyIdBatches = 0;
+  for (;;) {
+    const n = await fillAgencyIdBatch(kysely);
+    totalAgencyIdUpdated += n;
+    agencyIdBatches += 1;
+    logger.info({
+      message: JSON.stringify({
+        phase: "agency_id",
+        batchRows: n,
+        totalSoFar: totalAgencyIdUpdated,
+      }),
+    });
+    if (n === 0) break;
+    if (agencyIdBatches >= maxBatchesPerPhase) break;
+  }
+
+  const remainingOrphanAgencyIds = await countRemainingOrphanAgencyIds(kysely);
+  logger.info({
+    message: JSON.stringify({
+      phase: "summary",
+      remainingOrphanAgencyIds,
+    }),
+  });
+
+  return {
+    totalConventionIdUpdated,
+    totalAgencyIdUpdated,
+    remainingOrphanAgencyIds,
+  };
+};
+
+const runScript = async () => {
+  const pool = createMakeScriptPgPool(config)();
+  const kysely = makeKyselyDb(pool);
+  try {
+    return await backfillBroadcastFeedbackIds(kysely);
+  } finally {
+    await pool.end();
+  }
+};
+
+if (require.main === module) {
+  handleCRONScript({
+    name: "backfillBroadcastFeedbackIds",
+    config,
+    script: runScript,
+    handleResults: ({
+      totalConventionIdUpdated,
+      totalAgencyIdUpdated,
+      remainingOrphanAgencyIds,
+    }) =>
+      [
+        `convention_id filled: ${totalConventionIdUpdated}`,
+        `agency_id filled: ${totalAgencyIdUpdated}`,
+        `remaining orphan agency_id (rows with convention_id but no matching convention): ${remainingOrphanAgencyIds}`,
+      ].join("\n"),
+    logger,
+  });
+}

--- a/back/src/scripts/backfillBroadcastFeedbackIds.ts
+++ b/back/src/scripts/backfillBroadcastFeedbackIds.ts
@@ -9,23 +9,39 @@ import { handleCRONScript } from "./handleCRONScript";
 const logger = createLogger(__filename);
 const config = AppConfig.createFromEnv();
 
-const batchSize = 10_000;
+const defaultBatchSize = 10_000;
+const uuidRegexp =
+  "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
 
-const parseMaxBatchesPerPhase = (raw: string | undefined): number => {
-  if (!raw) return Number.POSITIVE_INFINITY;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0)
-    throw new Error(
-      `Invalid BACKFILL_MAX_BATCHES_PER_PHASE=${raw} (expected a positive integer)`,
-    );
-  return parsed;
+type BackfillBroadcastFeedbackIdsOptions = {
+  batchSize?: number;
+  maxBatchesPerPhase?: number;
 };
 
-const maxBatchesPerPhase = parseMaxBatchesPerPhase(
-  process.env.BACKFILL_MAX_BATCHES_PER_PHASE,
-);
+type BackfillBroadcastFeedbackIdsResult = {
+  totalConventionIdUpdated: number;
+  totalAgencyIdUpdated: number;
+  remainingOrphanAgencyIds: number;
+  invalidLegacyConventionIds: number;
+  conventionIdStoppedByMaxBatches: boolean;
+  agencyIdStoppedByMaxBatches: boolean;
+};
 
-const fillConventionIdBatch = async (kysely: KyselyDb): Promise<number> => {
+type BackfillPhase = "convention_id" | "agency_id";
+
+type BackfillPhaseResult = {
+  totalUpdated: number;
+  stoppedByMaxBatches: boolean;
+};
+
+const defaultMaxBatchesPerPhase =
+  config.backfillBroadcastFeedbackMaxBatchesPerPhase ??
+  Number.POSITIVE_INFINITY;
+
+const fillConventionIdBatch = async (
+  kysely: KyselyDb,
+  batchSize: number,
+): Promise<number> => {
   const res = await kysely
     .updateTable("broadcast_feedbacks")
     .set({
@@ -36,6 +52,7 @@ const fillConventionIdBatch = async (kysely: KyselyDb): Promise<number> => {
         SELECT id
         FROM broadcast_feedbacks
         WHERE convention_id IS NULL
+          AND request_params ->> 'conventionId' ~* ${uuidRegexp}
         ORDER BY id
         LIMIT ${batchSize}
       ))`,
@@ -44,7 +61,10 @@ const fillConventionIdBatch = async (kysely: KyselyDb): Promise<number> => {
   return Number(res.numUpdatedRows);
 };
 
-const fillAgencyIdBatch = async (kysely: KyselyDb): Promise<number> => {
+const fillAgencyIdBatch = async (
+  kysely: KyselyDb,
+  batchSize: number,
+): Promise<number> => {
   const res = await kysely
     .updateTable("broadcast_feedbacks")
     .from("conventions")
@@ -52,16 +72,49 @@ const fillAgencyIdBatch = async (kysely: KyselyDb): Promise<number> => {
     .whereRef("broadcast_feedbacks.convention_id", "=", "conventions.id")
     .where(
       sql<SqlBool>`broadcast_feedbacks.id = ANY(ARRAY(
-        SELECT id
-        FROM broadcast_feedbacks
-        WHERE agency_id IS NULL
-          AND convention_id IS NOT NULL
-        ORDER BY id
+        SELECT bf.id
+        FROM broadcast_feedbacks AS bf
+        INNER JOIN conventions AS c ON c.id = bf.convention_id
+        WHERE bf.agency_id IS NULL
+          AND bf.convention_id IS NOT NULL
+        ORDER BY bf.id
         LIMIT ${batchSize}
       ))`,
     )
     .executeTakeFirst();
   return Number(res.numUpdatedRows);
+};
+
+const runBackfillPhase = async ({
+  phase,
+  maxBatchesPerPhase,
+  updateNextBatch,
+}: {
+  phase: BackfillPhase;
+  maxBatchesPerPhase: number;
+  updateNextBatch: () => Promise<number>;
+}): Promise<BackfillPhaseResult> => {
+  let totalUpdated = 0;
+  let batchesRun = 0;
+  let lastBatchUpdatedRows = 1;
+
+  while (lastBatchUpdatedRows > 0 && batchesRun < maxBatchesPerPhase) {
+    lastBatchUpdatedRows = await updateNextBatch();
+    totalUpdated += lastBatchUpdatedRows;
+    batchesRun += 1;
+    logger.info({
+      message: JSON.stringify({
+        phase,
+        batchRows: lastBatchUpdatedRows,
+        totalSoFar: totalUpdated,
+      }),
+    });
+  }
+
+  return {
+    totalUpdated,
+    stoppedByMaxBatches: lastBatchUpdatedRows > 0,
+  };
 };
 
 const countRemainingOrphanAgencyIds = async (
@@ -72,58 +125,60 @@ const countRemainingOrphanAgencyIds = async (
     .select((eb) => eb.fn.countAll<string>().as("count"))
     .where("agency_id", "is", null)
     .where("convention_id", "is not", null)
+    .where(
+      sql<SqlBool>`NOT EXISTS (
+        SELECT 1
+        FROM conventions
+        WHERE conventions.id = broadcast_feedbacks.convention_id
+      )`,
+    )
     .executeTakeFirstOrThrow();
   return Number(row.count);
 };
 
-export const backfillBroadcastFeedbackIds = async (kysely: KyselyDb) => {
-  let totalConventionIdUpdated = 0;
-  let conventionIdBatches = 0;
-  for (;;) {
-    const n = await fillConventionIdBatch(kysely);
-    totalConventionIdUpdated += n;
-    conventionIdBatches += 1;
-    logger.info({
-      message: JSON.stringify({
-        phase: "convention_id",
-        batchRows: n,
-        totalSoFar: totalConventionIdUpdated,
-      }),
-    });
-    if (n === 0) break;
-    if (conventionIdBatches >= maxBatchesPerPhase) break;
-  }
+const countInvalidLegacyConventionIds = async (
+  kysely: KyselyDb,
+): Promise<number> => {
+  const row = await kysely
+    .selectFrom("broadcast_feedbacks")
+    .select((eb) => eb.fn.countAll<string>().as("count"))
+    .where("convention_id", "is", null)
+    .where(
+      sql<SqlBool>`COALESCE(request_params ->> 'conventionId', '') !~* ${uuidRegexp}`,
+    )
+    .executeTakeFirstOrThrow();
+  return Number(row.count);
+};
 
-  let totalAgencyIdUpdated = 0;
-  let agencyIdBatches = 0;
-  for (;;) {
-    const n = await fillAgencyIdBatch(kysely);
-    totalAgencyIdUpdated += n;
-    agencyIdBatches += 1;
-    logger.info({
-      message: JSON.stringify({
-        phase: "agency_id",
-        batchRows: n,
-        totalSoFar: totalAgencyIdUpdated,
-      }),
-    });
-    if (n === 0) break;
-    if (agencyIdBatches >= maxBatchesPerPhase) break;
-  }
-
-  const remainingOrphanAgencyIds = await countRemainingOrphanAgencyIds(kysely);
-  logger.info({
-    message: JSON.stringify({
-      phase: "summary",
-      remainingOrphanAgencyIds,
-    }),
+export const backfillBroadcastFeedbackIds = async (
+  kysely: KyselyDb,
+  {
+    batchSize = defaultBatchSize,
+    maxBatchesPerPhase = defaultMaxBatchesPerPhase,
+  }: BackfillBroadcastFeedbackIdsOptions = {},
+): Promise<BackfillBroadcastFeedbackIdsResult> => {
+  const conventionIdPhase = await runBackfillPhase({
+    phase: "convention_id",
+    maxBatchesPerPhase,
+    updateNextBatch: () => fillConventionIdBatch(kysely, batchSize),
   });
 
-  return {
-    totalConventionIdUpdated,
-    totalAgencyIdUpdated,
-    remainingOrphanAgencyIds,
+  const agencyIdPhase = await runBackfillPhase({
+    phase: "agency_id",
+    maxBatchesPerPhase,
+    updateNextBatch: () => fillAgencyIdBatch(kysely, batchSize),
+  });
+
+  const summary = {
+    totalConventionIdUpdated: conventionIdPhase.totalUpdated,
+    totalAgencyIdUpdated: agencyIdPhase.totalUpdated,
+    remainingOrphanAgencyIds: await countRemainingOrphanAgencyIds(kysely),
+    invalidLegacyConventionIds: await countInvalidLegacyConventionIds(kysely),
+    conventionIdStoppedByMaxBatches: conventionIdPhase.stoppedByMaxBatches,
+    agencyIdStoppedByMaxBatches: agencyIdPhase.stoppedByMaxBatches,
   };
+
+  return summary;
 };
 
 const runScript = async () => {
@@ -145,11 +200,17 @@ if (require.main === module) {
       totalConventionIdUpdated,
       totalAgencyIdUpdated,
       remainingOrphanAgencyIds,
+      invalidLegacyConventionIds,
+      conventionIdStoppedByMaxBatches,
+      agencyIdStoppedByMaxBatches,
     }) =>
       [
         `convention_id filled: ${totalConventionIdUpdated}`,
         `agency_id filled: ${totalAgencyIdUpdated}`,
         `remaining orphan agency_id (rows with convention_id but no matching convention): ${remainingOrphanAgencyIds}`,
+        `invalid legacy convention_id rows skipped: ${invalidLegacyConventionIds}`,
+        `convention_id phase stopped by max batches: ${conventionIdStoppedByMaxBatches}`,
+        `agency_id phase stopped by max batches: ${agencyIdStoppedByMaxBatches}`,
       ].join("\n"),
     logger,
   });

--- a/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
+++ b/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
@@ -37,6 +37,8 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
             serviceName: "any-service-name",
             consumerId: null,
             consumerName: "any-consumer-name",
+            conventionId: "1",
+            agencyId: "any-agency-id",
             occurredAt: "2024-07-01T00:00:00.000Z",
             handledByAgency: true,
             requestParams: {
@@ -161,6 +163,8 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
             serviceName: "any-service-name",
             consumerId: null,
             consumerName: "any-consumer-name",
+            conventionId: "1",
+            agencyId: "any-agency-id",
             occurredAt: "2024-07-01T00:00:00.000Z",
             handledByAgency: true,
             requestParams: {

--- a/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
+++ b/front/src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.test.ts
@@ -108,6 +108,8 @@ describe("Broadcast feedback in store", () => {
       serviceName: "test-service",
       consumerId: "consumer-1",
       consumerName: "Test Consumer",
+      conventionId: fakeConventionId,
+      agencyId: "any-agency-id",
       requestParams: {
         conventionId: fakeConventionId,
       },
@@ -179,6 +181,8 @@ describe("Broadcast feedback in store", () => {
       serviceName: "test-service",
       consumerId: "consumer-1",
       consumerName: "Test Consumer",
+      conventionId: fakeConventionId,
+      agencyId: "any-agency-id",
       requestParams: {
         conventionId: fakeConventionId,
       },

--- a/shared/src/broadcast/broadcastFeedback.dto.ts
+++ b/shared/src/broadcast/broadcastFeedback.dto.ts
@@ -1,4 +1,5 @@
 import type {
+  AgencyId,
   ApiConsumerId,
   ApiConsumerName,
   ConventionId,
@@ -26,6 +27,8 @@ export type BroadcastFeedback = {
   serviceName: string;
   consumerId: ApiConsumerId | null;
   consumerName: ApiConsumerName;
+  conventionId: ConventionId;
+  agencyId: AgencyId | null;
   subscriberErrorFeedback?: SubscriberErrorFeedback;
   requestParams: ConventionBroadcastRequestParams;
   response?: BroadcastFeedbackResponse;

--- a/shared/src/broadcast/broadcastFeedback.dto.ts
+++ b/shared/src/broadcast/broadcastFeedback.dto.ts
@@ -28,7 +28,7 @@ export type BroadcastFeedback = {
   consumerId: ApiConsumerId | null;
   consumerName: ApiConsumerName;
   conventionId: ConventionId;
-  agencyId: AgencyId | null;
+  agencyId: AgencyId;
   subscriberErrorFeedback?: SubscriberErrorFeedback;
   requestParams: ConventionBroadcastRequestParams;
   response?: BroadcastFeedbackResponse;

--- a/shared/src/broadcast/broadcastFeedback.schema.ts
+++ b/shared/src/broadcast/broadcastFeedback.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { absoluteUrlSchema } from "../AbsoluteUrl";
+import { agencyIdSchema } from "../agency/agency.schema";
 import {
   apiConsumerIdSchema,
   apiConsumerNameSchema,
@@ -42,6 +43,8 @@ export const broadcastFeedbackSchema: ZodSchemaWithInputMatchingOutput<Conventio
       serviceName: z.string(),
       consumerId: apiConsumerIdSchema.nullable(),
       consumerName: apiConsumerNameSchema,
+      conventionId: conventionIdSchema,
+      agencyId: agencyIdSchema.nullable(),
       subscriberErrorFeedback: subscriberErrorFeedbackSchema.optional(),
       requestParams: conventionBroadcastRequestParamsSchema,
       response: broadcastFeedbackResponseSchema.optional(),

--- a/shared/src/broadcast/broadcastFeedback.schema.ts
+++ b/shared/src/broadcast/broadcastFeedback.schema.ts
@@ -37,18 +37,27 @@ const conventionBroadcastRequestParamsSchema: ZodSchemaWithInputMatchingOutput<C
     conventionStatus: z.enum(conventionStatuses).optional(),
   });
 
+const nonNullableBroadcastFeedbackSchema = z
+  .object({
+    serviceName: z.string(),
+    consumerId: apiConsumerIdSchema.nullable(),
+    consumerName: apiConsumerNameSchema,
+    conventionId: conventionIdSchema,
+    agencyId: agencyIdSchema,
+    subscriberErrorFeedback: subscriberErrorFeedbackSchema.optional(),
+    requestParams: conventionBroadcastRequestParamsSchema,
+    response: broadcastFeedbackResponseSchema.optional(),
+    occurredAt: dateTimeIsoStringSchema,
+    handledByAgency: z.boolean(),
+  })
+  .refine(
+    ({ conventionId, requestParams }) =>
+      conventionId === requestParams.conventionId,
+    {
+      message: "conventionId must match requestParams.conventionId",
+      path: ["requestParams", "conventionId"],
+    },
+  );
+
 export const broadcastFeedbackSchema: ZodSchemaWithInputMatchingOutput<ConventionLastBroadcastFeedbackResponse> =
-  z
-    .object({
-      serviceName: z.string(),
-      consumerId: apiConsumerIdSchema.nullable(),
-      consumerName: apiConsumerNameSchema,
-      conventionId: conventionIdSchema,
-      agencyId: agencyIdSchema.nullable(),
-      subscriberErrorFeedback: subscriberErrorFeedbackSchema.optional(),
-      requestParams: conventionBroadcastRequestParamsSchema,
-      response: broadcastFeedbackResponseSchema.optional(),
-      occurredAt: dateTimeIsoStringSchema,
-      handledByAgency: z.boolean(),
-    })
-    .nullable();
+  nonNullableBroadcastFeedbackSchema.nullable();


### PR DESCRIPTION
Étape 1 (expand) de la migration en deux étapes pour accélérer la page « Erreurs de diffusion » (issue #4895, étape 2 dans #4896).

Ajoute les colonnes `convention_id` / `agency_id` (uuid nullable) sur `broadcast_feedbacks`, met en place le double-write, et fournit un script de backfill pour les ~2,9 M de lignes existantes. La bascule de la requête de la page vers le nouvel index aura lieu en étape 2 (#4896).

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

- **Aucun changement visible côté utilisateur** dans cette PR : la requête de la page « Erreurs de diffusion » continue d'utiliser l'index expression existant. Le gain de performance arrive en étape 2 (#4896).
- **Migration** : ajoute deux colonnes nullables + deux index (`idx_bf_convention_id`, `idx_bf_agency_id_occurred_at`). L'ancien index expression `idx_broadcast_feedbacks_convention_id` reste en place pendant la fenêtre expand (annoté en commentaire).
- **`PgBroadcastFeedbacksRepository.save`** : double-write des deux nouvelles colonnes. `getLastBroadcastFeedback` conserve son fallback `?? requestParams.conventionId` pour les lignes legacy non encore backfilled.
- **DTO** : `agencyId` devient nullable pour accommoder les lignes orphelines (conventions supprimées avant le backfill — ~3 397 d'après diagnostic).
- **Script de backfill** (`backfillBroadcastFeedbackIds.ts`) :
  - Updates batchés stables : `id = ANY(ARRAY(SELECT id ... ORDER BY id LIMIT N))`, batch 10 k pour limiter la durée des locks.
  - Phase 1 : `convention_id` (cast inconditionnel — vérifié sur la replica prod : 100 % des lignes ont un UUID valide).
  - Phase 2 : `agency_id` via inner join sur `conventions` ; les ~3 397 orphelins restent à `agency_id IS NULL`.
  - Logs structurés et résumé final avec compte d'orphelins.
- **Séquence pour sortir de la fenêtre intermédiaire** :
  1. Merge + déploiement de cette PR.
  2. Lancer le script `backfillBroadcastFeedbackIds` en prod jusqu'à `batchRows=0` pour les deux phases.
  3. Vérifier : `convention_id IS NULL` = 0, `agency_id IS NULL AND convention_id IS NOT NULL` ≈ 3 397.
  4. Ouvrir #4896 : bascule de la requête de la page, drop de l'ancien index expression, `NOT NULL` sur `convention_id`.
- **Tests** :
  - Régression sur le fallback `request_params.conventionId` quand `convention_id` est NULL (lignes legacy).
  - Test d'intégration du script de backfill couvrant convention existante + orphelin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)