### PR TITLE
#4965 - Ne plus afficher le badge de bilan sur les conventions non validées

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -15,6 +15,7 @@ import {
   type ConventionReadDto,
   getDaysBetween,
   isConventionRenewed,
+  isConventionValidated,
   type PhoneNumber,
   type Role,
   relativeTimeFormat,
@@ -127,6 +128,7 @@ export const ConventionValidation = ({
     intersection(roles, [...agencyModifierRoles, "back-office"]).length > 0 &&
     currentUser &&
     hasUserRightsOnAgencyBroadcast(currentUser);
+  const shouldShowAssessmentBadge = isConventionValidated(convention);
   const title = `${beneficiary.lastName.toUpperCase()} ${
     beneficiary.firstName
   } chez ${businessName} ${beforeAfterString(dateStart)}`;
@@ -176,20 +178,22 @@ export const ConventionValidation = ({
             Erreur de synchronisation
           </Badge>
         )}
-        <Badge
-          className={fr.cx("fr-mr-2w")}
-          severity={
-            getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
-              getAssessmentCompletionStatus(convention.assessment)
-            ].severity
-          }
-        >
-          {
-            getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
-              getAssessmentCompletionStatus(convention.assessment)
-            ].shortLabel
-          }
-        </Badge>
+        {shouldShowAssessmentBadge && (
+          <Badge
+            className={fr.cx("fr-mr-2w")}
+            severity={
+              getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
+                getAssessmentCompletionStatus(convention.assessment)
+              ].severity
+            }
+          >
+            {
+              getAssessmentLabelsAndSeverityByStatus({ isPlural: false })[
+                getAssessmentCompletionStatus(convention.assessment)
+              ].shortLabel
+            }
+          </Badge>
+        )}
       </div>
       <h1 className={fr.cx("fr-h3")}>{title}</h1>
       {convention.statusJustification && (


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant