### PR TITLE
#4930 - Migration Sentry vers une instance indépendante de la PDI

### DIFF
--- a/back/src/scripts/configureSentry.ts
+++ b/back/src/scripts/configureSentry.ts
@@ -12,7 +12,7 @@ export const configureSentry = (
     return;
   }
   Sentry.init({
-    dsn: "https://eb7a121cd835308163ca9966e5c82c98@o4508405260615680.ingest.de.sentry.io/4508999044038736",
+    dsn: "https://b2ec1b4e1c0b71ef7b919083f5422019@o4510900710146048.ingest.de.sentry.io/4511375925182544",
     integrations: [
       Sentry.httpIntegration(),
       Sentry.nativeNodeFetchIntegration(),

--- a/back/src/scripts/scheduledScripts/deleteInactiveUsers.ts
+++ b/back/src/scripts/scheduledScripts/deleteInactiveUsers.ts
@@ -1,4 +1,4 @@
-import "./instrumentSentryCron";
+import "../instrumentSentryCron";
 import { AppConfig } from "../../config/bootstrap/appConfig";
 import { createMakeProductionPgPool } from "../../config/pg/pgPool";
 import { inactiveUsersCleanupBatchSize } from "../../domains/core/authentication/connected-user/use-cases/inactiveUserConstants";

--- a/back/src/scripts/scheduledScripts/warnInactiveUsers.ts
+++ b/back/src/scripts/scheduledScripts/warnInactiveUsers.ts
@@ -1,4 +1,4 @@
-import "./instrumentSentryCron";
+import "../instrumentSentryCron";
 import { AppConfig } from "../../config/bootstrap/appConfig";
 import { createMakeProductionPgPool } from "../../config/pg/pgPool";
 import { inactiveUsersCleanupBatchSize } from "../../domains/core/authentication/connected-user/use-cases/inactiveUserConstants";

--- a/front/src/app/main.tsx
+++ b/front/src/app/main.tsx
@@ -40,7 +40,7 @@ createRoot(rootContainer).render(
 
 if (ENV.envType !== "local") {
   SentryInit({
-    dsn: "https://8bbb3df20b0910b08f2f435e46f6390f@o4508405260615680.ingest.de.sentry.io/4508999055507536",
+    dsn: "https://5800b3725ecb4a0cb8461afdb7f2374f@o4510900710146048.ingest.de.sentry.io/4511375917908048",
     integrations: [browserTracingIntegration(), replayIntegration()],
     release: import.meta.env.VITE_RELEASE_TAG,
     environment: ENV.envType,

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -58,10 +58,9 @@ export default defineConfig({
     process.env.SENTRY_AUTH_TOKEN
       ? [
           sentryVitePlugin({
-            url: "https://sentry.gip-inclusion.org/",
-            org: "gip-inclusion",
-            project: "immersion-facilitee-front",
-            // Auth tokens can be obtained from https://sentry.gip-inclusion.org/settings/account/api/auth-tokens/
+            org: "immersion-facilitee",
+            project: "if-front",
+            // Auth tokens can be obtained from https://sentry.io/settings/account/api/auth-tokens/
             // and need `project:releases` and `org:read` scopes
             authToken: process.env.SENTRY_AUTH_TOKEN,
             release: { name: process.env.VITE_RELEASE_TAG },


### PR DESCRIPTION
Fixes #4930

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Migration de l'instance Sentry depuis l'orga `gip-inclusion` (sur `sentry.gip-inclusion.org`) vers la nouvelle orga `immersion-facilitee` sur Sentry SaaS.

3 fichiers modifiés :
- `back/src/scripts/configureSentry.ts` — nouveau DSN backend
- `front/src/app/main.tsx` — nouveau DSN frontend
- `front/vite.config.ts` — `org` mis à jour, `url:` retiré (SaaS standard), commentaire des auth tokens mis à jour

**À faire en parallèle (hors code) :**
- Mettre à jour le secret GitHub `SENTRY_AUTH_TOKEN` avec un token généré sur la nouvelle orga (scopes `project:releases` + `org:read`)
- Côté Sentry, configurer les **Allowed Domains** du projet `immersion-facilitee-front` (`immersion-facile.beta.gouv.fr`, `staging.immersion-facile.beta.gouv.fr`, `localhost`)
- Vérifier que **Spike Protection** est activée sur les 2 projets

**Post-merge :** vérifier sur staging qu'une erreur volontaire remonte bien dans la nouvelle orga (front + back) et qu'une release avec sourcemaps est créée côté front.