### PR TITLE
#4655 - Interdire le passage d'une conventions au status IN REVIEW hors du parcours de signature

### DIFF
--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
@@ -100,28 +100,6 @@ describe("UpdateConventionStatus", () => {
     });
   });
 
-  describe("* -> IN_REVIEW transition", () => {
-    acceptStatusTransitionTests({
-      updateStatusParams: {
-        status: "IN_REVIEW",
-        conventionId: conventionWithAgencyOneStepValidationId,
-      },
-      expectedDomainTopic: "ConventionFullySigned",
-      allowedMagicLinkRoles: validSignatoryRoles,
-      allowedConnectedUsers: ["userWithRoleEstablishmentRepresentative"],
-      allowedInitialStatuses: ["PARTIALLY_SIGNED"],
-    });
-    rejectStatusTransitionTests({
-      updateStatusParams: {
-        status: "IN_REVIEW",
-        conventionId: conventionWithAgencyOneStepValidationId,
-      },
-      allowedMagicLinkRoles: validSignatoryRoles,
-      allowedConnectedUsers: ["userWithRoleEstablishmentRepresentative"],
-      allowedInitialStatuses: ["PARTIALLY_SIGNED"],
-    });
-  });
-
   describe("* -> ACCEPTED_BY_COUNSELLOR transition", () => {
     const dateApproval = new Date("2021-09-01T10:10:00.000Z");
     acceptStatusTransitionTests({

--- a/shared/src/convention/ConventionDto.unit.test.ts
+++ b/shared/src/convention/ConventionDto.unit.test.ts
@@ -42,6 +42,7 @@ import {
   conventionReadSchema,
   conventionSchema,
   editConventionWithFinalStatusRequestSchema,
+  updateConventionStatusRequestSchema,
 } from "./convention.schema";
 import {
   getConventionTooLongMessageAndPath,
@@ -1482,6 +1483,18 @@ describe("editConventionWithFinalStatusRequestSchema", () => {
         updatedBeneficiaryBirthDate: "",
       }),
     ).toThrow();
+  });
+});
+
+describe("updateConventionStatusRequestSchema", () => {
+  it("rejects IN_REVIEW", () => {
+    const conventionId = new ConventionDtoBuilder().build().id;
+    expect(() =>
+      updateConventionStatusRequestSchema.parse({
+        status: "IN_REVIEW",
+        conventionId,
+      }),
+    ).toThrow(ZodError);
   });
 });
 

--- a/shared/src/convention/convention.dto.ts
+++ b/shared/src/convention/convention.dto.ts
@@ -71,14 +71,19 @@ export const isBeneficiaryStudent = (
 ): beneficiary is Beneficiary<"mini-stage-cci"> =>
   "levelOfEducation" in beneficiary;
 
-type ConventionStatusWithoutJustificationNorValidator =
-  (typeof conventionStatusesWithoutJustificationNorValidator)[number];
-
 export const conventionStatusesWithoutJustificationNorValidator = [
   "READY_TO_SIGN",
   "PARTIALLY_SIGNED",
   "IN_REVIEW",
 ] as const;
+
+export const updateConventionStatusWithoutJustificationTargetStatuses = [
+  "READY_TO_SIGN",
+  "PARTIALLY_SIGNED",
+] as const;
+
+export type UpdateConventionStatusWithoutJustificationTargetStatus =
+  (typeof updateConventionStatusWithoutJustificationTargetStatuses)[number];
 
 export const isUnvalidatedConventionStatus = (
   status: ConventionStatus | null,
@@ -528,7 +533,7 @@ export type UpdateConventionStatusWithValidator = {
 };
 
 export type UpdateConventionStatusWithoutJustification = {
-  status: ConventionStatusWithoutJustificationNorValidator;
+  status: UpdateConventionStatusWithoutJustificationTargetStatus;
   conventionId: ConventionId;
 };
 

--- a/shared/src/convention/convention.schema.ts
+++ b/shared/src/convention/convention.schema.ts
@@ -91,7 +91,6 @@ import {
   type ConventionValidatorInputNames,
   conventionObjectiveOptions,
   conventionStatuses,
-  conventionStatusesWithoutJustificationNorValidator,
   conventionStatusesWithValidator,
   DATE_CONSIDERED_OLD,
   type EditConventionCounsellorNameRequestDto,
@@ -120,6 +119,7 @@ import {
   type UpdateConventionStatusWithoutJustification,
   type UpdateConventionStatusWithValidator,
   unvalidatedConventionStatuses,
+  updateConventionStatusWithoutJustificationTargetStatuses,
   type WithConventionDto,
   type WithConventionId,
   type WithConventionIdLegacy,
@@ -585,7 +585,7 @@ export const updateConventionRequestSchema: ZodSchemaWithInputMatchingOutput<Upd
 
 export const updateConventionStatusWithoutJustificationSchema: ZodSchemaWithInputMatchingOutput<UpdateConventionStatusWithoutJustification> =
   z.object({
-    status: z.enum(conventionStatusesWithoutJustificationNorValidator, {
+    status: z.enum(updateConventionStatusWithoutJustificationTargetStatuses, {
       error: localization.invalidEnum,
     }),
     conventionId: conventionIdSchema,


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant