### PR TITLE
#4987 - Fix Réactiver le choix de la structure d’accompagnement lorsque le type sélectionné est « Toutes »

### DIFF
--- a/front/src/app/components/forms/commons/AgencySelector.tsx
+++ b/front/src/app/components/forms/commons/AgencySelector.tsx
@@ -119,16 +119,22 @@ export const AgencySelector = ({
     control,
   });
 
-  const allowedAgencyKinds = useMemo(
-    (): AllowedAgencyKindToAdd[] =>
+  const allowedAgencyKinds = useMemo((): AllowedAgencyKindToAdd[] => {
+    if (
+      !isAllAgencyKinds(agencyKindValue) &&
       isSelectableAgencyKind(
         agencyKindValue,
         shouldFilterDelegationPrescriptionAgencyKind,
       )
-        ? [agencyKindValue]
-        : initialAgencyKinds,
-    [agencyKindValue, initialAgencyKinds],
-  );
+    )
+      return [agencyKindValue];
+
+    return initialAgencyKinds;
+  }, [
+    agencyKindValue,
+    initialAgencyKinds,
+    shouldFilterDelegationPrescriptionAgencyKind,
+  ]);
 
   const agencyPlaceholder = getAgencyPlaceholder(
     agencyDepartment,


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant