### PR TITLE
#4970 - Ne plus mettre le tag "bilan à compléter" sur les conventions dont le bilan nest pas encore disponible à la complétion

### DIFF
--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -16,6 +16,7 @@ import {
   type DataWithPagination,
   errors,
   type GetPaginatedConventionsFilters,
+  isConventionEndingInOneDayOrMore,
   isFunctionalBroadcastFeedbackError,
   isUnvalidatedConventionStatus,
   NotFoundError,
@@ -741,7 +742,9 @@ const makeApplyAssessmentCompletionStatusFilterConventionsRead =
       !isAssessmentSigned &&
       isAssessementAfterSignatureRelease &&
       assessment.status !== "DID_NOT_SHOW";
-    const isAssessmentToBeCompleted = convention.assessment === null;
+    const isAssessmentToBeCompleted =
+      convention.assessment === null &&
+      !isConventionEndingInOneDayOrMore(convention);
 
     return (
       (hasFinalizedFilter && isAssessmentFinalized) ||

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1876,8 +1876,23 @@ describe("Pg implementation of ConventionQueries", () => {
             .withUpdatedAt(anyConventionUpdatedAt)
             .build();
 
+          const conventionWithAssessmentToComplete = new ConventionDtoBuilder()
+            .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb5")
+            .withSiret("12345678901238")
+            .withAgencyId(agencyId)
+            .withStatus("ACCEPTED_BY_VALIDATOR")
+            .withDateStart(subDays(now, 5).toISOString())
+            .withDateEnd(subDays(now, 1).toISOString())
+            .withSchedule(reasonableSchedule)
+            .withUpdatedAt(anyConventionUpdatedAt)
+            .build();
+
           await conventionRepository.save(
             conventionEndingInMoreThanOneDay,
+            anyConventionUpdatedAt,
+          );
+          await conventionRepository.save(
+            conventionWithAssessmentToComplete,
             anyConventionUpdatedAt,
           );
 
@@ -1892,7 +1907,14 @@ describe("Pg implementation of ConventionQueries", () => {
               },
             });
 
-          expectToEqual(result.data, []);
+          expectToEqual(result.data, [
+            {
+              ...conventionWithAssessmentToComplete,
+              ...agencyFields,
+              assessment: null,
+              isEstablishmentBanned: false,
+            },
+          ]);
         });
 
         it("should return convention without assessment when dateEnd is within one day", async () => {
@@ -1902,7 +1924,7 @@ describe("Pg implementation of ConventionQueries", () => {
             .withSiret("12345678901237")
             .withAgencyId(agencyId)
             .withStatus("ACCEPTED_BY_VALIDATOR")
-            .withDateStart(subDays(now, 10).toISOString())
+            .withDateStart(subDays(now, 5).toISOString())
             .withDateEnd(addDays(now, 1).toISOString())
             .withSchedule(reasonableSchedule)
             .withUpdatedAt(anyConventionUpdatedAt)

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1862,6 +1862,77 @@ describe("Pg implementation of ConventionQueries", () => {
 
           expectToEqual(result.data, []);
         });
+
+        it("should exclude convention without assessment when dateEnd is in more than one day", async () => {
+          const now = new Date();
+          const conventionEndingInMoreThanOneDay = new ConventionDtoBuilder()
+            .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb3")
+            .withSiret("12345678901236")
+            .withAgencyId(agencyId)
+            .withStatus("ACCEPTED_BY_VALIDATOR")
+            .withDateStart(subDays(now, 10).toISOString())
+            .withDateEnd(addDays(now, 5).toISOString())
+            .withSchedule(reasonableSchedule)
+            .withUpdatedAt(anyConventionUpdatedAt)
+            .build();
+
+          await conventionRepository.save(
+            conventionEndingInMoreThanOneDay,
+            anyConventionUpdatedAt,
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["to-complete"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, []);
+        });
+
+        it("should return convention without assessment when dateEnd is within one day", async () => {
+          const now = new Date();
+          const conventionEndingWithinOneDay = new ConventionDtoBuilder()
+            .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb4")
+            .withSiret("12345678901237")
+            .withAgencyId(agencyId)
+            .withStatus("ACCEPTED_BY_VALIDATOR")
+            .withDateStart(subDays(now, 10).toISOString())
+            .withDateEnd(addDays(now, 1).toISOString())
+            .withSchedule(reasonableSchedule)
+            .withUpdatedAt(anyConventionUpdatedAt)
+            .build();
+
+          await conventionRepository.save(
+            conventionEndingWithinOneDay,
+            anyConventionUpdatedAt,
+          );
+
+          const result =
+            await conventionQueries.getPaginatedConventionsForAgencyUser({
+              agencyUserId: validator.id,
+              pagination: { page: 1, perPage: 10 },
+              filters: { assessmentCompletionStatus: ["to-complete"] },
+              sort: {
+                by: "dateSubmission",
+                direction: "desc",
+              },
+            });
+
+          expectToEqual(result.data, [
+            {
+              ...conventionEndingWithinOneDay,
+              ...agencyFields,
+              assessment: null,
+              isEstablishmentBanned: false,
+            },
+          ]);
+        });
       });
 
       describe("when multiple filters", () => {

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -836,7 +836,12 @@ const filterByAssessmentCompletionStatus =
             );
         }
         if (hasToBeCompletedFilter)
-          conditions.push(eb("ia.convention_id", "is", null));
+          conditions.push(
+            eb.and([
+              eb("ia.convention_id", "is", null),
+              eb("conventions.date_end", "<=", addDays(new Date(), 1)),
+            ]),
+          );
 
         return eb.or(conditions);
       });

--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -16,6 +16,7 @@ import {
   type ConventionReadDto,
   conventionSignatoryRoleBySignatoryKey,
   getDaysBetween,
+  isConventionEndingInOneDayOrMore,
   isConventionRenewed,
   isConventionValidated,
   type NotificationKind,
@@ -39,10 +40,7 @@ import {
 import { commonIllustrations } from "src/assets/img/illustrations";
 import { sendAssessmentLinkSlice } from "src/core-logic/domain/assessment/send-assessment-link/sendAssessmentLink.slice";
 import { connectedUserSelectors } from "src/core-logic/domain/connected-user/connectedUser.selectors";
-import {
-  canAssessmentBeFilled,
-  isConventionEndingInOneDayOrMore,
-} from "src/core-logic/domain/convention/convention.utils";
+import { canAssessmentBeFilled } from "src/core-logic/domain/convention/convention.utils";
 import { sendSignatureLinkSlice } from "src/core-logic/domain/convention/send-signature-link/sendSignatureLink.slice";
 import { partnersErroredConventionSelectors } from "src/core-logic/domain/partnersErroredConvention/partnersErroredConvention.selectors";
 import {

--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -115,7 +115,9 @@ export const ConventionValidation = ({
     intersection(roles, [...agencyModifierRoles, "back-office"]).length > 0 &&
     currentUser &&
     hasUserRightsOnAgencyBroadcast(currentUser);
-  const shouldShowAssessmentBadge = isConventionValidated(convention);
+  const shouldShowAssessmentBadge =
+    isConventionValidated(convention) &&
+    !isConventionEndingInOneDayOrMore(convention);
   const title = `${beneficiary.lastName.toUpperCase()} ${
     beneficiary.firstName
   } chez ${businessName} ${beforeAfterString(dateStart)}`;

--- a/front/src/app/components/agency/agency-dashboard/ConventionList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionList.tsx
@@ -18,6 +18,8 @@ import {
   domElementIds,
   type FlatGetConventionsForAgencyUserParams,
   getFormattedFirstnameAndLastname,
+  isConventionEndingInOneDayOrMore,
+  isConventionValidated,
   isNotEmptyArray,
   toDisplayedDate,
 } from "shared";
@@ -362,24 +364,27 @@ export const ConventionList = () => {
                   </Badge>
                 </Fragment>,
                 <Fragment key={`${convention.id}-assessment`}>
-                  {convention.status === "ACCEPTED_BY_VALIDATOR" && (
-                    <Badge
-                      small
-                      severity={
-                        getAssessmentLabelsAndSeverityByStatus({
-                          isPlural: false,
-                        })[getAssessmentCompletionStatus(convention.assessment)]
-                          .severity
-                      }
-                    >
-                      {
-                        getAssessmentLabelsAndSeverityByStatus({
-                          isPlural: false,
-                        })[getAssessmentCompletionStatus(convention.assessment)]
-                          .shortLabel
-                      }
-                    </Badge>
-                  )}
+                  {isConventionValidated(convention) &&
+                    !isConventionEndingInOneDayOrMore(convention) && (
+                      <Badge
+                        small
+                        severity={
+                          getAssessmentLabelsAndSeverityByStatus({
+                            isPlural: false,
+                          })[
+                            getAssessmentCompletionStatus(convention.assessment)
+                          ].severity
+                        }
+                      >
+                        {
+                          getAssessmentLabelsAndSeverityByStatus({
+                            isPlural: false,
+                          })[
+                            getAssessmentCompletionStatus(convention.assessment)
+                          ].shortLabel
+                        }
+                      </Badge>
+                    )}
                 </Fragment>,
 
                 <Fragment key={`${convention.id}-beneficiary`}>

--- a/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
@@ -15,6 +15,7 @@ import {
   establishmentsRoles,
   hasAllowedRole,
   hasAllowedRoleOnAssessment,
+  isConventionEndingInOneDayOrMore,
   isConventionRenewed,
   isConventionValidated,
   type MarkPartnersErroredConventionAsHandledRequest,
@@ -36,10 +37,7 @@ import { useConventionTexts } from "src/app/contents/forms/convention/textSetup"
 import { useFeedbackTopic } from "src/app/hooks/feedback.hooks";
 import { getConventionSubStatus } from "src/app/utils/conventionSubStatus";
 import { isAllowedConventionTransition } from "src/app/utils/IsAllowedConventionTransition";
-import {
-  canAssessmentBeFilled,
-  isConventionEndingInOneDayOrMore,
-} from "src/core-logic/domain/convention/convention.utils";
+import { canAssessmentBeFilled } from "src/core-logic/domain/convention/convention.utils";
 import { conventionDraftSlice } from "src/core-logic/domain/convention/convention-draft/conventionDraft.slice";
 import { match, P } from "ts-pattern";
 export type ButtonConfiguration = {

--- a/front/src/app/utils/conventionSubStatus.ts
+++ b/front/src/app/utils/conventionSubStatus.ts
@@ -1,8 +1,9 @@
-import type { ConventionReadDto, ConventionStatus } from "shared";
 import {
-  isConventionAlreadyStarted,
+  type ConventionReadDto,
+  type ConventionStatus,
   isConventionEndingInOneDayOrMore,
-} from "src/core-logic/domain/convention/convention.utils";
+} from "shared";
+import { isConventionAlreadyStarted } from "src/core-logic/domain/convention/convention.utils";
 import { match } from "ts-pattern";
 
 const subStatusesByStatus = {

--- a/front/src/core-logic/domain/convention/convention.utils.ts
+++ b/front/src/core-logic/domain/convention/convention.utils.ts
@@ -1,9 +1,5 @@
-import { addDays, isAfter, isBefore } from "date-fns";
+import { isBefore } from "date-fns";
 import type { ConventionReadDto } from "shared";
-
-export const isConventionEndingInOneDayOrMore = (
-  convention: ConventionReadDto,
-) => isAfter(new Date(convention.dateEnd), addDays(new Date(), 1));
 
 export const isConventionAlreadyStarted = (convention: ConventionReadDto) =>
   isBefore(new Date(convention.dateStart), new Date());

--- a/shared/src/convention/convention.ts
+++ b/shared/src/convention/convention.ts
@@ -1,4 +1,4 @@
-import { differenceInISOWeekYears } from "date-fns";
+import { addDays, differenceInISOWeekYears, isAfter } from "date-fns";
 import { keys, mapObjIndexed, values } from "ramda";
 import { agencyRoleIsNotToReview } from "../agency/agency.utils";
 import {
@@ -18,6 +18,7 @@ import type {
 import type { DateString } from "../utils/date";
 import type {
   ConventionDto,
+  ConventionReadDto,
   ConventionRenewed,
   ConventionStatus,
   FlatGetConventionsForAgencyUserParams,
@@ -319,3 +320,7 @@ export const getConventionManageAllowedRoles = (
   if (establishmentRights) roles.push(establishmentRights.role);
   return roles;
 };
+
+export const isConventionEndingInOneDayOrMore = (
+  convention: ConventionReadDto,
+) => isAfter(new Date(convention.dateEnd), addDays(new Date(), 1));


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
