### PR TITLE
#3807 - Fix recette -  Le bouton de relance de signature ne doit jamais être grisé et ne doit pas apparaitre si le signataire a déjà signé

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -49,7 +49,6 @@ import {
   makeConventionSections,
   SendAssessmentLinkModalWrapper,
   SendSignatureLinkModalWrapper,
-  type SignatureLinkState,
   sendAssessmentLinkButtonProps,
   sendAssessmentLinkModal,
   sendSignatureLinkButtonProps,
@@ -91,14 +90,6 @@ export const ConventionValidation = ({
 
   const [signatoryToSendSignatureLink, setSignatoryToSendSignatureLink] =
     useState<Signatory | null>(null);
-
-  const [signatureLinksSent, setSignatureLinksSent] =
-    useState<SignatureLinkState>({
-      beneficiary: false,
-      "establishment-representative": false,
-      "beneficiary-representative": false,
-      "beneficiary-current-employer": false,
-    });
 
   const isSignatureModalOpen = useIsModalOpen(sendSignatureLinkModal);
 
@@ -149,11 +140,6 @@ export const ConventionValidation = ({
         feedbackTopic: "send-signature-link",
       }),
     );
-
-    setSignatureLinksSent((prev) => ({
-      ...prev,
-      [signatoryRole]: true,
-    }));
   };
 
   const onSubmitSendAssessmentLink = (notificationKind: NotificationKind) => {
@@ -244,7 +230,6 @@ export const ConventionValidation = ({
         summary={makeConventionSections(
           convention,
           sendSignatureLinkButtonProps({
-            signatureLinksSent,
             onClick: ({ signatoryRole, signatoryPhone, signatoryEmail }) => {
               const signatoryKey =
                 conventionSignatoryRoleBySignatoryKey[signatoryRole];

--- a/front/src/app/components/forms/convention/ConventionSignForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionSignForm.tsx
@@ -26,7 +26,6 @@ import { Feedback } from "src/app/components/feedback/Feedback";
 import {
   makeConventionSections,
   SendSignatureLinkModalWrapper,
-  type SignatureLinkState,
   sendSignatureLinkButtonProps,
   sendSignatureLinkModal,
 } from "src/app/contents/convention/conventionSummary.helpers";
@@ -70,14 +69,6 @@ export const ConventionSignForm = ({
   const [signatoryToSendSignatureLink, setSignatoryToSendSignatureLink] =
     useState<Signatory | null>(null);
 
-  const [signatureLinksSent, setSignatureLinksSent] =
-    useState<SignatureLinkState>({
-      beneficiary: false,
-      "establishment-representative": false,
-      "beneficiary-representative": false,
-      "beneficiary-current-employer": false,
-    });
-
   const [isModalClosedWithoutSignature, setIsModalClosedWithoutSignature] =
     useState<boolean>(false);
 
@@ -103,11 +94,6 @@ export const ConventionSignForm = ({
         feedbackTopic: "send-signature-link",
       }),
     );
-
-    setSignatureLinksSent((prev) => ({
-      ...prev,
-      [signatoryRole]: true,
-    }));
   };
   const feedbacks = useFeedbackTopics([
     "send-signature-link",
@@ -177,7 +163,6 @@ export const ConventionSignForm = ({
               convention,
               sendSignatureLinkButtonProps({
                 triggeredByRole: currentSignatory.role,
-                signatureLinksSent,
                 onClick: ({
                   signatoryRole,
                   signatoryPhone,
@@ -229,7 +214,6 @@ export const ConventionSignForm = ({
                   convention,
                   sendSignatureLinkButtonProps({
                     triggeredByRole: currentSignatory.role,
-                    signatureLinksSent,
                     onClick: ({
                       signatoryRole,
                       signatoryPhone,

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -1130,15 +1130,12 @@ export const SendAssessmentLinkModalWrapper = ({
   );
 };
 
-export type SignatureLinkState = Record<SignatoryRole, boolean>;
 export const sendSignatureLinkButtonProps =
   ({
     triggeredByRole,
-    signatureLinksSent,
     onClick,
   }: {
     triggeredByRole?: SignatoryRole;
-    signatureLinksSent: SignatureLinkState;
     onClick: (params: {
       signatoryRole: SignatoryRole;
       signatoryPhone: PhoneNumber;
@@ -1150,19 +1147,20 @@ export const sendSignatureLinkButtonProps =
     signatoryPhone: PhoneNumber,
     signatoryEmail: Email,
     signatoryAlreadySign: boolean,
-  ): ButtonProps | null =>
-    triggeredByRole && triggeredByRole === signatoryRole
-      ? null
-      : {
-          priority: "tertiary",
-          children: "Relancer pour signature",
-          disabled: signatoryAlreadySign || signatureLinksSent[signatoryRole],
-          onClick: () => {
-            onClick({ signatoryRole, signatoryPhone, signatoryEmail });
-          },
-          type: "button",
-          id: domElementIds.manageConvention.openSendSignatureLinkModal,
-        };
+  ): ButtonProps | null => {
+    if (signatoryAlreadySign) return null;
+    if (triggeredByRole && triggeredByRole === signatoryRole) return null;
+
+    return {
+      priority: "tertiary",
+      children: "Relancer pour signature",
+      onClick: () => {
+        onClick({ signatoryRole, signatoryPhone, signatoryEmail });
+      },
+      type: "button",
+      id: domElementIds.manageConvention.openSendSignatureLinkModal,
+    };
+  };
 
 export const sendAssessmentLinkButtonProps =
   ({


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant