### PR TITLE
#3807 - Fix recette - Le bouton de relance de bilan ne doit jamais être grisé après une relance

### DIFF
--- a/front/src/app/components/admin/conventions/ConventionValidation.tsx
+++ b/front/src/app/components/admin/conventions/ConventionValidation.tsx
@@ -77,8 +77,6 @@ export const ConventionValidation = ({
     partnersErroredConventionSelectors.lastBroadcastFeedback,
   );
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
-  const [isAssessmentLinkSent, setIsAssessmentLinkSent] =
-    useState<boolean>(false);
 
   useScrollTo(
     useFeedbackTopics([
@@ -143,8 +141,6 @@ export const ConventionValidation = ({
   };
 
   const onSubmitSendAssessmentLink = (notificationKind: NotificationKind) => {
-    setIsAssessmentLinkSent(true);
-
     dispatch(
       sendAssessmentLinkSlice.actions.sendAssessmentLinkRequested({
         conventionId: convention.id,
@@ -247,7 +243,6 @@ export const ConventionValidation = ({
           }),
           shouldShowAssessmentReminderButton
             ? sendAssessmentLinkButtonProps({
-                isAssessmentLinkSent,
                 onClick: () => {
                   sendAssessmentLinkModal.open();
                 },

--- a/front/src/app/contents/convention/conventionSummary.helpers.tsx
+++ b/front/src/app/contents/convention/conventionSummary.helpers.tsx
@@ -1163,17 +1163,10 @@ export const sendSignatureLinkButtonProps =
   };
 
 export const sendAssessmentLinkButtonProps =
-  ({
-    isAssessmentLinkSent,
-    onClick,
-  }: {
-    isAssessmentLinkSent: boolean;
-    onClick: (params: { phone: PhoneNumber }) => void;
-  }) =>
+  ({ onClick }: { onClick: (params: { phone: PhoneNumber }) => void }) =>
   (phone: PhoneNumber): ButtonProps => ({
     priority: "tertiary",
     children: "Relancer pour bilan",
-    disabled: isAssessmentLinkSent,
     onClick: () => {
       onClick({ phone });
     },


### PR DESCRIPTION
Fixes #3807

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
