### PR TITLE
#5005 - Messages d'erreurs plus explicites sur le formulaire d'ajout d'utilisateur entreprise

### DIFF
--- a/front/src/app/pages/establishment-dashboard/EstablishmentUserForm.tsx
+++ b/front/src/app/pages/establishment-dashboard/EstablishmentUserForm.tsx
@@ -10,10 +10,10 @@ import {
   establishmentsRoles,
   type FormEstablishmentUserRight,
   formEstablishmentUserRightSchema,
-  localization,
   type OmitFromExistingKeys,
   type SiretDto,
 } from "shared";
+import { PhoneInput } from "src/app/components/forms/commons/PhoneInput";
 import { userRolesToDisplay } from "src/app/contents/userRolesToDisplay";
 import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { mergeUserRights } from "src/app/pages/establishment-dashboard/EstablishmentUsersList";
@@ -159,14 +159,21 @@ export const EstablishmentUserForm = ({
             }}
           />
         )}
-        <Input
+        <PhoneInput
           label="Téléphone *"
-          nativeInputProps={{
-            ...register("phone"),
+          inputProps={{
+            label: "Téléphone *",
+            nativeInputProps: {
+              ...register("phone"),
+              type: "phone",
+            },
+          }}
+          onPhoneNumberChange={(phoneNumber) => {
+            setValue("phone", phoneNumber);
           }}
           {...(errors.phone && {
             state: "error",
-            stateRelatedMessage: localization.required,
+            stateRelatedMessage: errors.phone.message,
           })}
         />
         <Input
@@ -176,7 +183,7 @@ export const EstablishmentUserForm = ({
           }}
           {...(errors.job && {
             state: "error",
-            stateRelatedMessage: localization.required,
+            stateRelatedMessage: errors.job.message,
           })}
         />
         <RadioButtons


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
