### PR TITLE
#5036 - Limiter la recherche d'agence à 20 résultats uniquement dans le back-office admin

### DIFF
--- a/back/src/domains/agency/use-cases/ListAgenciesByFilter.ts
+++ b/back/src/domains/agency/use-cases/ListAgenciesByFilter.ts
@@ -5,7 +5,6 @@ import {
   type AgencyWithUsersRights,
   activeAgencyStatuses,
   listAgencyOptionsRequestSchema,
-  maxAgencyOptionsPerRequest,
   miniStageAgencyKinds,
   orderedAgencyKindList,
 } from "shared";
@@ -32,10 +31,14 @@ export const makeListAgencyOptionsByFilter = useCaseBuilder(
         sirets: siret ? [siret] : undefined,
         ...extraFilters,
       },
-      pagination: {
-        page: 1,
-        perPage: limit ?? maxAgencyOptionsPerRequest,
-      },
+      ...(limit
+        ? {
+            pagination: {
+              page: 1,
+              perPage: limit,
+            },
+          }
+        : {}),
     });
 
     return agencies.map(toAgencyOption);

--- a/back/src/domains/agency/use-cases/ListAgenciesByFilter.unit.test.ts
+++ b/back/src/domains/agency/use-cases/ListAgenciesByFilter.unit.test.ts
@@ -163,7 +163,7 @@ describe("Query: List agencies by filter", () => {
       );
     });
 
-    it("limits agency options by default", async () => {
+    it("returns all agencies when no limit is provided", async () => {
       const uow = createInMemoryUow();
       listAgencyOptionsByFilter = makeListAgencyOptionsByFilter({
         uowPerformer: new InMemoryUowPerformer(uow),
@@ -182,10 +182,7 @@ describe("Query: List agencies by filter", () => {
 
       const result = await listAgencyOptionsByFilter.execute({}, undefined);
 
-      expectToEqual(
-        result,
-        agencies.slice(0, maxAgencyOptionsPerRequest).map(toAgencyOption),
-      );
+      expectToEqual(result, agencies.map(toAgencyOption));
     });
 
     it("uses requested limit when provided", async () => {

--- a/front/src/core-logic/domain/admin/agenciesAdmin/fetch-agency-options/fetchAgencyOptions.epics.ts
+++ b/front/src/core-logic/domain/admin/agenciesAdmin/fetch-agency-options/fetchAgencyOptions.epics.ts
@@ -1,7 +1,11 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { debounceTime, distinctUntilChanged, filter } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
-import { allAgencyStatuses, looksLikeSiret } from "shared";
+import {
+  allAgencyStatuses,
+  looksLikeSiret,
+  maxAgencyOptionsPerRequest,
+} from "shared";
 import type {
   ActionOfSlice,
   AppEpic,
@@ -24,6 +28,7 @@ const agencyAdminGetByNameEpic: AgencyEpic = (
     switchMap((action: PayloadAction<string>) =>
       agencyGateway.listAgencyOptionsByFilter$({
         status: [...allAgencyStatuses],
+        limit: maxAgencyOptionsPerRequest,
         [looksLikeSiret(action.payload) ? "siret" : "nameIncludes"]:
           action.payload,
       }),


### PR DESCRIPTION
Fixes #5036

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant