### PR TITLE
#4325 - Adapter la pop-in d'initiation de convention selon l'option de télétravail du métier choisi

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -43,6 +43,7 @@ import {
   domElementIds,
   type ExcludeFromExisting,
   errors as errorMessage,
+  establishmentFormOfferSchema,
   type InternshipKind,
   isBeneficiaryMinor,
   isCreateConventionPresentationInitialValues,
@@ -316,6 +317,13 @@ export const ConventionForm = ({
       return convention.signatories?.beneficiary?.[key];
     };
 
+    const immersionAppellationFromRoute = pickConventionValueFromRouteParams(
+      "immersionAppellation",
+    );
+    const parsedEstablishmentOffer = establishmentFormOfferSchema.safeParse(
+      immersionAppellationFromRoute,
+    );
+
     const conventionDefaultValues: CreateConventionPresentationInitialValues = {
       ...convention,
       status: "READY_TO_SIGN",
@@ -337,9 +345,10 @@ export const ConventionForm = ({
       agencyKind: pickConventionValueFromRouteParams("agencyKind"),
       siret: pickConventionValueFromRouteParams("siret"),
       immersionAddress: pickConventionValueFromRouteParams("immersionAddress"),
-      immersionAppellation: pickConventionValueFromRouteParams(
-        "immersionAppellation",
-      ),
+      immersionAppellation: immersionAppellationFromRoute,
+      remoteWorkMode: parsedEstablishmentOffer.success
+        ? parsedEstablishmentOffer.data.remoteWorkMode
+        : convention.remoteWorkMode,
       signatories: {
         ...convention.signatories,
         beneficiary: {

--- a/front/src/app/pages/establishment-dashboard/InitiateConventionButton.tsx
+++ b/front/src/app/pages/establishment-dashboard/InitiateConventionButton.tsx
@@ -371,7 +371,9 @@ export const InitiateConventionButton = () => {
                     }}
                     state={"siret" in formErrors ? "error" : "default"}
                     stateRelatedMessage={
-                      "siret" in formErrors && formErrors.siret?.message
+                      "siret" in formErrors &&
+                      formErrors.siret &&
+                      formErrors.siret.message
                     }
                   />
                   <Select
@@ -402,7 +404,8 @@ export const InitiateConventionButton = () => {
                     state={"appellation" in formErrors ? "error" : "default"}
                     stateRelatedMessage={
                       "appellation" in formErrors &&
-                      formErrors.appellation?.message
+                      formErrors.appellation &&
+                      formErrors.appellation.message
                     }
                   />
                   {shouldShowAddressSelect && (
@@ -429,7 +432,9 @@ export const InitiateConventionButton = () => {
                       }}
                       state={"location" in formErrors ? "error" : "default"}
                       stateRelatedMessage={
-                        "location" in formErrors && formErrors.location?.message
+                        "location" in formErrors &&
+                        formErrors.location &&
+                        formErrors.location.message
                       }
                     />
                   )}

--- a/front/src/app/pages/establishment-dashboard/InitiateConventionButton.tsx
+++ b/front/src/app/pages/establishment-dashboard/InitiateConventionButton.tsx
@@ -134,6 +134,20 @@ export const InitiateConventionButton = () => {
         >)
       : null;
 
+  const selectedOffer =
+    !isEstablishmentDefault && establishmentValues?.appellation
+      ? establishment.offers.find(
+          (offer) => offer.appellationCode === establishmentValues.appellation,
+        )
+      : undefined;
+
+  const isFullRemoteOffer = selectedOffer?.remoteWorkMode === "FULL_REMOTE";
+  const defaultEstablishmentAddress =
+    establishment.businessAddresses[0]?.rawAddress;
+
+  const shouldShowAddressSelect =
+    !!establishmentValues?.appellation && !isFullRemoteOffer;
+
   const onInitiateConventionFormSubmit = () => {
     if (initiateConventionSource === "establishment" && establishmentValues) {
       const appellation = establishment?.offers.find(
@@ -250,10 +264,14 @@ export const InitiateConventionButton = () => {
   if (
     initiateConventionSource === "establishment" &&
     !isEstablishmentDefault &&
-    establishment.businessAddresses.length === 1 &&
-    establishmentValues?.location === ""
+    defaultEstablishmentAddress &&
+    establishmentValues?.appellation &&
+    (isFullRemoteOffer ||
+      (shouldShowAddressSelect &&
+        establishment.businessAddresses.length === 1)) &&
+    establishmentValues.location !== defaultEstablishmentAddress
   )
-    setValue("location", establishment.businessAddresses[0].rawAddress);
+    setValue("location", defaultEstablishmentAddress);
 
   if (!currentUser || !connectedUserJwt) return null;
 
@@ -387,32 +405,34 @@ export const InitiateConventionButton = () => {
                       formErrors.appellation?.message
                     }
                   />
-                  <Select
-                    label={"Lieu d'immersion *"}
-                    placeholder="Sélectionnez un lieu d'immersion"
-                    className={fr.cx("fr-mt-2w")}
-                    disabled={
-                      isEstablishmentDefault ||
-                      establishment.businessAddresses.length === 1
-                    }
-                    options={
-                      establishment?.businessAddresses.map((location) => ({
-                        value: location.rawAddress,
-                        label: location.rawAddress,
-                      })) ?? []
-                    }
-                    nativeSelectProps={{
-                      id: domElementIds.establishmentDashboard
-                        .initiateConvention.addressSelect,
-                      value: establishmentValues?.location ?? "",
-                      onChange: (event) =>
-                        setValue("location", event.currentTarget.value),
-                    }}
-                    state={"location" in formErrors ? "error" : "default"}
-                    stateRelatedMessage={
-                      "location" in formErrors && formErrors.location?.message
-                    }
-                  />
+                  {shouldShowAddressSelect && (
+                    <Select
+                      label={"Lieu d'immersion *"}
+                      placeholder="Sélectionnez un lieu d'immersion"
+                      className={fr.cx("fr-mt-2w")}
+                      disabled={
+                        isEstablishmentDefault ||
+                        establishment.businessAddresses.length === 1
+                      }
+                      options={
+                        establishment?.businessAddresses.map((location) => ({
+                          value: location.rawAddress,
+                          label: location.rawAddress,
+                        })) ?? []
+                      }
+                      nativeSelectProps={{
+                        id: domElementIds.establishmentDashboard
+                          .initiateConvention.addressSelect,
+                        value: establishmentValues?.location ?? "",
+                        onChange: (event) =>
+                          setValue("location", event.currentTarget.value),
+                      }}
+                      state={"location" in formErrors ? "error" : "default"}
+                      stateRelatedMessage={
+                        "location" in formErrors && formErrors.location?.message
+                      }
+                    />
+                  )}
                 </>
               )}
             </SectionHighlight>

--- a/playwright/utils/dashboard.ts
+++ b/playwright/utils/dashboard.ts
@@ -158,7 +158,9 @@ const initiateConventionFromEstablishmentInformations = async ({
   const appellationSelectLocator = page.locator(
     `#${domElementIds.establishmentDashboard.initiateConvention.appellationSelect}`,
   );
-  await appellationSelectLocator.selectOption({ index: 1 });
+  await appellationSelectLocator.selectOption({
+    label: "Boucher-charcutier / Bouchère-charcutière",
+  });
   const selectedAppellation =
     (
       await appellationSelectLocator.locator("option:checked").textContent()
@@ -167,7 +169,14 @@ const initiateConventionFromEstablishmentInformations = async ({
   const addressSelectLocator = page.locator(
     `#${domElementIds.establishmentDashboard.initiateConvention.addressSelect}`,
   );
-  await addressSelectLocator.selectOption({ index: 1 });
+  await expect(addressSelectLocator).toBeVisible();
+
+  const addressOptionCount = await addressSelectLocator
+    .locator("option")
+    .count();
+  if (addressOptionCount > 1)
+    await addressSelectLocator.selectOption({ index: 1 });
+
   const selectedAddress = await addressSelectLocator.inputValue();
 
   await page.click(


### PR DESCRIPTION
Fixes #4325

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
