### PR TITLE
#5020 - Ajout de l'identifiant de convention dans le mail « bilan prêt à être signé »

### DIFF
--- a/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
@@ -1204,6 +1204,7 @@ describe("convention e2e", () => {
               conventionWithAssessment.signatories.beneficiary.email,
             ],
             params: {
+              conventionId: conventionWithAssessment.id,
               beneficiaryFirstName: "Jean",
               beneficiaryLastName: "Dupont",
               businessName: conventionWithAssessment.businessName,

--- a/back/src/domains/convention/use-cases/SendAssessmentSignatureReminder.ts
+++ b/back/src/domains/convention/use-cases/SendAssessmentSignatureReminder.ts
@@ -216,6 +216,7 @@ const sendAssessmentSignatureReminderEmail = async ({
       kind: "ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION",
       recipients: [beneficiary.email],
       params: {
+        conventionId: convention.id,
         beneficiaryFirstName: getFormattedFirstnameAndLastname({
           firstname: beneficiary.firstName,
         }),

--- a/back/src/domains/convention/use-cases/SendAssessmentSignatureReminder.unit.test.ts
+++ b/back/src/domains/convention/use-cases/SendAssessmentSignatureReminder.unit.test.ts
@@ -142,6 +142,7 @@ describe("SendAssessmentSignatureReminder", () => {
           kind: "ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION",
           recipients: [convention.signatories.beneficiary.email],
           params: {
+            conventionId: convention.id,
             beneficiaryFirstName: getFormattedFirstnameAndLastname({
               firstname: convention.signatories.beneficiary.firstName,
             }),
@@ -281,6 +282,7 @@ describe("SendAssessmentSignatureReminder", () => {
           kind: "ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION",
           recipients: [convention.signatories.beneficiary.email],
           params: {
+            conventionId: convention.id,
             beneficiaryFirstName: "Jean",
             beneficiaryLastName: "Dupont",
             businessName: convention.businessName,

--- a/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentNeedsSignature.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentNeedsSignature.ts
@@ -84,6 +84,7 @@ export const makeNotifyBeneficiaryThatAssessmentNeedsSignature = useCaseBuilder(
         kind: "ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION",
         recipients: [beneficiary.email],
         params: {
+          conventionId: convention.id,
           beneficiaryFirstName: getFormattedFirstnameAndLastname({
             firstname: beneficiary.firstName,
           }),

--- a/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentNeedsSignature.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyBeneficiaryThatAssessmentNeedsSignature.unit.test.ts
@@ -155,6 +155,7 @@ describe("NotifyBeneficiaryThatAssessmentNeedsSignature", () => {
         {
           kind: "ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION",
           params: {
+            conventionId: convention.id,
             beneficiaryFirstName: getFormattedFirstnameAndLastname({
               firstname: convention.signatories.beneficiary.firstName,
             }),

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -556,6 +556,7 @@ export const defaultEmailValueByEmailKind: {
     magicLink: "http://MAGIC_LINK",
   },
   ASSESSMENT_NEEDS_SIGNATURE_BENEFICIARY_NOTIFICATION: {
+    conventionId: "CONVENTION_ID",
     beneficiaryFirstName: "BENEFICIARY_FIRST_NAME",
     beneficiaryLastName: "BENEFICIARY_LAST_NAME",
     businessName: "BUSINESS_NAME",

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -119,6 +119,7 @@ export type EmailParamsByEmailType = {
     businessName: string;
     internshipKind: InternshipKind;
     assessmentSignatureLink: string;
+    conventionId: ConventionId;
   };
   ASSESSMENT_CREATED_BENEFICIARY_NOTIFICATION: {
     internshipKind: InternshipKind;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -585,9 +585,13 @@ Pour toute question concernant ce rejet, il est possible de nous contacter : con
         businessName,
         internshipKind,
         assessmentSignatureLink,
+        conventionId,
       }) => ({
         subject: `Votre bilan d'immersion est prêt à être signé`,
-        greetings: `Bonjour ${beneficiaryFirstName} ${beneficiaryLastName},`,
+        greetings: greetingsWithConventionId(
+          conventionId,
+          `${beneficiaryFirstName} ${beneficiaryLastName}`,
+        ),
 
         content: `
         <strong>Nous espérons que votre ${


### PR DESCRIPTION
Fixes #5020

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

