### PR TITLE
#4443 - Appliquer le message de partage de convention par défaut défini avant la mise en place du brouillon de convention.

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -1056,6 +1056,12 @@ const ConventionFormContent = ({
                     conventionValues,
                   ) && (
                     <ShareConventionDraft
+                      firstName={
+                        conventionValues.signatories.beneficiary.firstName
+                      }
+                      lastName={
+                        conventionValues.signatories.beneficiary.lastName
+                      }
                       conventionFormData={{
                         ...conventionValues,
                         agencyKind: isAllAgencyKinds(

--- a/front/src/app/components/forms/convention/ShareConventionDraft.tsx
+++ b/front/src/app/components/forms/convention/ShareConventionDraft.tsx
@@ -2,15 +2,12 @@ import { Button, type ButtonProps } from "@codegouvfr/react-dsfr/Button";
 import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import { createPortal } from "react-dom";
 import { useDispatch } from "react-redux";
-import {
-  type CreateConventionPresentationInitialValues,
-  domElementIds,
-} from "shared";
+import { domElementIds } from "shared";
 import { useConventionTexts } from "src/app/contents/forms/convention/textSetup";
 import { useFeedbackTopic } from "src/app/hooks/feedback.hooks";
 import { createFormModal } from "src/app/utils/createFormModal";
 import { feedbackSlice } from "src/core-logic/domain/feedback/feedback.slice";
-import { ShareForm } from "./ShareForm";
+import { ShareForm, type ShareFormProps } from "./ShareForm";
 
 const shareConventionDraftModalProps = {
   isOpenedByDefault: false,
@@ -23,9 +20,9 @@ const shareConventionDraftModal = createFormModal(
 
 export const ShareConventionDraft = ({
   conventionFormData,
-}: {
-  conventionFormData: CreateConventionPresentationInitialValues;
-}) => {
+  firstName,
+  lastName,
+}: ShareFormProps) => {
   const dispatch = useDispatch();
   const t = useConventionTexts(conventionFormData.internshipKind);
   const shareLinkByEmail = t.shareConventionDraftByMail.share;
@@ -78,7 +75,11 @@ export const ShareConventionDraft = ({
             ...(!conventionDraftFeedback ? [submitConventionDraftButton] : []),
           ]}
         >
-          <ShareForm conventionFormData={conventionFormData} />
+          <ShareForm
+            conventionFormData={conventionFormData}
+            firstName={firstName}
+            lastName={lastName}
+          />
         </shareConventionDraftModal.Component>,
         document.body,
       )}

--- a/front/src/app/components/forms/convention/ShareForm.tsx
+++ b/front/src/app/components/forms/convention/ShareForm.tsx
@@ -22,20 +22,33 @@ import {
 } from "src/app/hooks/formContents.hooks";
 import { conventionDraftSlice } from "src/core-logic/domain/convention/convention-draft/conventionDraft.slice";
 
-type ShareFormProps = {
+export type ShareFormProps = {
   conventionFormData: CreateConventionPresentationInitialValues;
+  firstName: string;
+  lastName: string;
 };
 
 const makeInitialValues = ({
   conventionFormData,
+  firstName,
+  lastName,
 }: {
   conventionFormData: CreateConventionPresentationInitialValues;
+  firstName: string;
+  lastName: string;
 }): SaveConventionDraftFromConventionDto => ({
   senderEmail: "",
   conventionDraft: toConventionDraftDto({ convention: conventionFormData }),
+  details: `${firstName || "Prénom"} ${
+    lastName || "Nom"
+  } vous invite à prendre connaissance de cette demande de convention d’immersion déjà partiellement remplie afin que vous la complétiez.  Merci !`,
 });
 
-export const ShareForm = ({ conventionFormData }: ShareFormProps) => {
+export const ShareForm = ({
+  conventionFormData,
+  firstName,
+  lastName,
+}: ShareFormProps) => {
   const dispatch = useDispatch();
   const [isOnlyForSelf, setIsOnlyForSelf] = useState(false);
   const onSubmit = (values: SaveConventionDraftFromConventionDto) => {
@@ -48,7 +61,11 @@ export const ShareForm = ({ conventionFormData }: ShareFormProps) => {
   };
   const methods = useForm<SaveConventionDraftFromConventionDto>({
     mode: "onTouched",
-    defaultValues: makeInitialValues({ conventionFormData }),
+    defaultValues: makeInitialValues({
+      conventionFormData,
+      firstName,
+      lastName,
+    }),
     resolver: zodResolver(saveConventionDraftFromConventionSchema),
   });
   const { register, handleSubmit, formState, reset, setValue } = methods;
@@ -62,8 +79,8 @@ export const ShareForm = ({ conventionFormData }: ShareFormProps) => {
   );
 
   useEffect(() => {
-    reset(makeInitialValues({ conventionFormData }));
-  }, [conventionFormData, reset]);
+    reset(makeInitialValues({ conventionFormData, firstName, lastName }));
+  }, [conventionFormData, firstName, lastName, reset]);
 
   return (
     <WithFeedbackReplacer topic="convention-draft">


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
