### PR TITLE
#5138 - Tech - Rendre les checkbox du template Feature cliquables

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.md
@@ -20,7 +20,7 @@ type: feature
 ### ☑️ Checklist
 
 <!-- Questions à se poser systématiquer lors de la session de grooming -->
-- [] Effet de bord potentiel côté dev ou/et métier ? 
-- [] Impact potentiel au support
-- [] Communication bizdev à prévoir (si oui : label déploiement)
-- [] Quelles fonctionnalités d'Immersion Facilitée sont à créer/modifier/supprimer pour résoudre le problème
+- [ ] Effet de bord potentiel côté dev ou/et métier ?
+- [ ] Impact potentiel au support
+- [ ] Communication bizdev à prévoir (si oui : label déploiement)
+- [ ] Quelles fonctionnalités d'Immersion Facilitée sont à créer/modifier/supprimer pour résoudre le problème


### PR DESCRIPTION
Fixes #5138

## Résumé

Correction de la syntaxe Markdown de la checklist grooming dans le template « Fonctionnalité » : ajout de l'espace requis entre les crochets pour que GitHub affiche des cases à cocher interactives (task lists).

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Aucun — changement limité au fichier `.github/ISSUE_TEMPLATE/2-feature_request.md`.