### PR TITLE
#5062 - Tech - Ajout de la contrainte d'unicité sur les groupes / sirets

### DIFF
--- a/back/src/config/pg/migrations/1781000986402_add-unique-constraint-on-groups-sirets.ts
+++ b/back/src/config/pg/migrations/1781000986402_add-unique-constraint-on-groups-sirets.ts
@@ -1,0 +1,14 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+const constraintName = "unique_group_slug_siret";
+const groupsSiretsTableName = "groups__sirets";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addConstraint(groupsSiretsTableName, constraintName, {
+    unique: ["group_slug", "siret"],
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint(groupsSiretsTableName, constraintName);
+}


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant