### PR TITLE
#5161 - Corriger le pré-remplissage des champs lors de l'initiation d'une convention à partir d'un modèle

### DIFF
--- a/front/src/app/components/forms/convention/ConventionForm.tsx
+++ b/front/src/app/components/forms/convention/ConventionForm.tsx
@@ -92,6 +92,7 @@ import { useAppSelector } from "src/app/hooks/reduxHooks";
 import {
   conventionPresentationFromConventionDraft,
   makeConventionPresentationFromConventionTemplate,
+  makeConventionTemplatePresentationFromConventionTemplate,
   makeEmptyConventionInitialValues,
 } from "src/app/routes/routeParams/convention";
 import {
@@ -245,19 +246,22 @@ export const ConventionForm = ({
     [fetchedConventionDraft],
   );
 
-  const conventionPresentationFromConventionTemplate = useMemo(
-    () =>
-      fetchedConventionTemplate &&
-      makeConventionPresentationFromConventionTemplate(
-        fetchedConventionTemplate,
-      ),
-    [fetchedConventionTemplate],
-  );
-
   const isTemplateForm =
     ["create-convention-template", "edit-convention-template"].includes(mode) &&
     !!connectedUserJwt &&
     !!currentUser;
+
+  const conventionPresentationFromConventionTemplate = useMemo(() => {
+    if (!fetchedConventionTemplate) return undefined;
+
+    return isTemplateForm
+      ? makeConventionTemplatePresentationFromConventionTemplate(
+          fetchedConventionTemplate,
+        )
+      : makeConventionPresentationFromConventionTemplate(
+          fetchedConventionTemplate,
+        );
+  }, [fetchedConventionTemplate, isTemplateForm]);
 
   const defaultValues: ConventionFormInitialValues = useMemo(() => {
     const isCreationMode = creationFormModes.includes(
@@ -273,8 +277,19 @@ export const ConventionForm = ({
         : conventionPresentationFromConventionTemplate || initialValues;
     }
 
+    const conventionFromTemplate =
+      conventionPresentationFromConventionTemplate &&
+      isCreateConventionPresentationInitialValues(
+        conventionPresentationFromConventionTemplate,
+      )
+        ? conventionPresentationFromConventionTemplate
+        : undefined;
+
     const convention: CreateConventionPresentationInitialValues =
-      fetchedConvention || conventionPresentationFromDraft || initialValues;
+      fetchedConvention ||
+      conventionPresentationFromDraft ||
+      conventionFromTemplate ||
+      initialValues;
 
     const hasRouteParam = <
       TKey extends ConventionParamKey | FtConnectParamKey,

--- a/front/src/app/routes/routeParams/convention.ts
+++ b/front/src/app/routes/routeParams/convention.ts
@@ -497,7 +497,7 @@ export const conventionPresentationFromConventionDraft = (
   immersionSkills: conventionDraft.immersionSkills ?? "",
 });
 
-export const makeConventionPresentationFromConventionTemplate = (
+export const makeConventionTemplatePresentationFromConventionTemplate = (
   conventionTemplate: ConventionTemplate,
 ): CreateConventionTemplatePresentationInitialValues => {
   const { id, name, userId: _, ...conventionDraft } = conventionTemplate;
@@ -509,4 +509,19 @@ export const makeConventionPresentationFromConventionTemplate = (
     id,
     name,
   };
+};
+
+export const makeConventionPresentationFromConventionTemplate = (
+  conventionTemplate: ConventionTemplate,
+): CreateConventionPresentationInitialValues => {
+  const {
+    id: _id,
+    name: _name,
+    userId: _userId,
+    ...conventionDraft
+  } = conventionTemplate;
+  return conventionPresentationFromConventionDraft({
+    ...conventionDraft,
+    id: uuidV4(),
+  });
 };


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer