### PR TITLE
#5168 - Considérer la date de création de l'utilisateur pour détecter son inactivité quand il ne s'est jamais connecté

### DIFF
--- a/back/src/domains/core/authentication/connected-user/adapters/InMemoryUserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/InMemoryUserRepository.ts
@@ -8,7 +8,7 @@ import {
   type UserWithNumberOfAgenciesAndEstablishments,
 } from "shared";
 import type {
-  GetUserIdsLoggedInLongAgoParams,
+  GetUserIdsLoggedInAndCreatedLongAgoParams,
   UserRepository,
 } from "../port/UserRepository";
 
@@ -140,7 +140,7 @@ export class InMemoryUserRepository implements UserRepository {
     since,
     limit,
     offset,
-  }: GetUserIdsLoggedInLongAgoParams): Promise<UserId[]> {
+  }: GetUserIdsLoggedInAndCreatedLongAgoParams): Promise<UserId[]> {
     return values(this.#usersById)
       .filter((user) =>
         !user.lastLoginAt

--- a/back/src/domains/core/authentication/connected-user/adapters/InMemoryUserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/InMemoryUserRepository.ts
@@ -136,13 +136,17 @@ export class InMemoryUserRepository implements UserRepository {
     return values(this.#usersById);
   }
 
-  public async getUserIdsLoggedInLongAgo({
+  public async getUserIdsLoggedInAndCreatedLongAgo({
     since,
     limit,
     offset,
   }: GetUserIdsLoggedInLongAgoParams): Promise<UserId[]> {
     return values(this.#usersById)
-      .filter((user) => !user.lastLoginAt || new Date(user.lastLoginAt) < since)
+      .filter((user) =>
+        !user.lastLoginAt
+          ? new Date(user.createdAt) < since
+          : new Date(user.lastLoginAt) < since,
+      )
       .sort((a, b) => a.id.localeCompare(b.id))
       .slice(offset, offset + limit)
       .map((u) => u.id);

--- a/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.integration.test.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.integration.test.ts
@@ -426,8 +426,8 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       lastLoginAt: overrides.lastLoginAt,
     });
 
-    it("returns never-logged-in users when last_login_at is null", async () => {
-      const neverLoggedIn = makeUserWithOldLogin({
+    it("returns users never logged after since param", async () => {
+      const logged3yrAgo = makeUserWithOldLogin({
         id: uuid(),
         email: "never-logged@test.fr",
         lastLoginAt: threeYearsAgoIso,
@@ -438,7 +438,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
         lastLoginAt: oneYearAgo.toISOString(),
       });
 
-      await userRepository.save(neverLoggedIn);
+      await userRepository.save(logged3yrAgo);
       await userRepository.save(recentlyActiveUser);
 
       const result = await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
@@ -447,7 +447,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
         offset: 0,
       });
 
-      expectArraysToEqualIgnoringOrder(result, [neverLoggedIn.id]);
+      expectArraysToEqualIgnoringOrder(result, [logged3yrAgo.id]);
     });
 
     it("returns users with old login", async () => {

--- a/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.integration.test.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.integration.test.ts
@@ -1,4 +1,4 @@
-import { subYears } from "date-fns";
+import { subMilliseconds, subYears } from "date-fns";
 import type { Pool } from "pg";
 import {
   AgencyDtoBuilder,
@@ -406,7 +406,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
     });
   });
 
-  describe("getUserIdsLoggedInLongAgo()", () => {
+  describe("getUserIdsLoggedInAndCreatedLongAgo()", () => {
     const now = new Date("2026-01-15T10:00:00.000Z");
     const twoYearsAgo = subYears(now, 2);
     const oneYearAgo = subYears(now, 1);
@@ -419,16 +419,18 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       email: overrides.email,
       firstName: overrides.firstName ?? "Jean",
       lastName: overrides.lastName ?? "Dupont",
-      createdAt: new Date("2024-04-28T12:00:00.000Z").toISOString(),
+      createdAt:
+        overrides.createdAt ??
+        new Date("2024-04-28T12:00:00.000Z").toISOString(),
       proConnect: null,
-      lastLoginAt: overrides.lastLoginAt ?? threeYearsAgoIso,
+      lastLoginAt: overrides.lastLoginAt,
     });
 
     it("returns never-logged-in users when last_login_at is null", async () => {
       const neverLoggedIn = makeUserWithOldLogin({
         id: uuid(),
         email: "never-logged@test.fr",
-        lastLoginAt: undefined,
+        lastLoginAt: threeYearsAgoIso,
       });
       const recentlyActiveUser = makeUserWithOldLogin({
         id: uuid(),
@@ -439,7 +441,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       await userRepository.save(neverLoggedIn);
       await userRepository.save(recentlyActiveUser);
 
-      const result = await userRepository.getUserIdsLoggedInLongAgo({
+      const result = await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
         since: twoYearsAgo,
         limit: 100,
         offset: 0,
@@ -452,6 +454,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       const inactiveUser = makeUserWithOldLogin({
         id: uuid(),
         email: "inactive@test.fr",
+        lastLoginAt: threeYearsAgoIso,
       });
       const recentlyActiveUser = makeUserWithOldLogin({
         id: uuid(),
@@ -461,7 +464,7 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       await userRepository.save(inactiveUser);
       await userRepository.save(recentlyActiveUser);
 
-      const result = await userRepository.getUserIdsLoggedInLongAgo({
+      const result = await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
         since: twoYearsAgo,
         limit: 100,
         offset: 0,
@@ -474,14 +477,17 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
       const inactiveUserA = makeUserWithOldLogin({
         id: "11111111-1111-4111-9111-111111111111",
         email: "inactive-a@test.fr",
+        lastLoginAt: threeYearsAgoIso,
       });
       const inactiveUserB = makeUserWithOldLogin({
         id: "22222222-2222-4222-9222-222222222222",
         email: "inactive-b@test.fr",
+        lastLoginAt: threeYearsAgoIso,
       });
       const inactiveUserC = makeUserWithOldLogin({
         id: "33333333-3333-4333-9333-333333333333",
         email: "inactive-c@test.fr",
+        lastLoginAt: threeYearsAgoIso,
       });
       await Promise.all([
         userRepository.save(inactiveUserC),
@@ -489,19 +495,75 @@ describe.each(adapters)("%s UserRepository", (adapter) => {
         userRepository.save(inactiveUserB),
       ]);
 
-      const firstPage = await userRepository.getUserIdsLoggedInLongAgo({
-        since: twoYearsAgo,
-        limit: 2,
-        offset: 0,
-      });
-      const secondPage = await userRepository.getUserIdsLoggedInLongAgo({
-        since: twoYearsAgo,
-        limit: 2,
-        offset: 2,
-      });
+      const firstPage =
+        await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
+          since: twoYearsAgo,
+          limit: 2,
+          offset: 0,
+        });
+      const secondPage =
+        await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
+          since: twoYearsAgo,
+          limit: 2,
+          offset: 2,
+        });
 
       expectToEqual(firstPage, [inactiveUserA.id, inactiveUserB.id]);
       expectToEqual(secondPage, [inactiveUserC.id]);
+    });
+
+    it("returns user that are created since expected date", async () => {
+      const moreThanTwoYearsAgo = subMilliseconds(twoYearsAgo, 1).toISOString();
+
+      const notLoggedInAndCreatedNow = makeUserWithOldLogin({
+        id: "11111111-1111-4111-9111-111111111111",
+        email: "created-now@test.fr",
+        lastLoginAt: undefined,
+        createdAt: now.toISOString(),
+      });
+      const loggedInNowAndCreatedMoreThan2YrAgo = makeUserWithOldLogin({
+        id: "33333333-3333-4333-9333-333333333333",
+        email: "active-now@test.fr",
+        createdAt: twoYearsAgo.toISOString(),
+        lastLoginAt: now.toISOString(),
+      });
+      const notLoggedInAndCreatedMoreThan2YrAgo = makeUserWithOldLogin({
+        id: "22222222-2222-4222-9222-222222222222",
+        email: "inactive-not-loggedin@test.fr",
+        lastLoginAt: undefined,
+        createdAt: moreThanTwoYearsAgo,
+      });
+      const loggedInAndCreatedMoreThan2YrAgo = makeUserWithOldLogin({
+        id: "44444444-4444-4444-4444-444444444444",
+        email: "inactive-@test.fr",
+        createdAt: moreThanTwoYearsAgo,
+        lastLoginAt: moreThanTwoYearsAgo,
+      });
+      await Promise.all([
+        userRepository.save(loggedInNowAndCreatedMoreThan2YrAgo),
+        userRepository.save(notLoggedInAndCreatedNow),
+        userRepository.save(notLoggedInAndCreatedMoreThan2YrAgo),
+        userRepository.save(loggedInAndCreatedMoreThan2YrAgo),
+      ]);
+
+      const firstPage =
+        await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
+          since: twoYearsAgo,
+          limit: 2,
+          offset: 0,
+        });
+      const secondPage =
+        await userRepository.getUserIdsLoggedInAndCreatedLongAgo({
+          since: twoYearsAgo,
+          limit: 1,
+          offset: 1,
+        });
+
+      expectToEqual(firstPage, [
+        notLoggedInAndCreatedMoreThan2YrAgo.id,
+        loggedInAndCreatedMoreThan2YrAgo.id,
+      ]);
+      expectToEqual(secondPage, [loggedInAndCreatedMoreThan2YrAgo.id]);
     });
   });
 });

--- a/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.ts
@@ -195,7 +195,7 @@ export class PgUserRepository implements UserRepository {
     return usersInDb;
   }
 
-  public async getUserIdsLoggedInLongAgo({
+  public async getUserIdsLoggedInAndCreatedLongAgo({
     since,
     limit,
     offset,
@@ -203,10 +203,13 @@ export class PgUserRepository implements UserRepository {
     const rows = await this.transaction
       .selectFrom("users")
       .select("users.id")
-      .where(({ eb, or }) =>
+      .where(({ eb, or, and }) =>
         or([
           eb("users.last_login_at", "<", since),
-          eb("users.last_login_at", "is", null),
+          and([
+            eb("users.last_login_at", "is", null),
+            eb("users.created_at", "<", since.toISOString()),
+          ]),
         ]),
       )
       .orderBy("users.id")

--- a/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/adapters/PgUserRepository.ts
@@ -15,7 +15,7 @@ import {
   type KyselyDb,
 } from "../../../../../config/pg/kysely/kyselyUtils";
 import type {
-  GetUserIdsLoggedInLongAgoParams,
+  GetUserIdsLoggedInAndCreatedLongAgoParams,
   UserRepository,
 } from "../port/UserRepository";
 
@@ -199,7 +199,7 @@ export class PgUserRepository implements UserRepository {
     since,
     limit,
     offset,
-  }: GetUserIdsLoggedInLongAgoParams): Promise<UserId[]> {
+  }: GetUserIdsLoggedInAndCreatedLongAgoParams): Promise<UserId[]> {
     const rows = await this.transaction
       .selectFrom("users")
       .select("users.id")

--- a/back/src/domains/core/authentication/connected-user/port/UserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/port/UserRepository.ts
@@ -25,7 +25,7 @@ export interface UserRepository {
     externalId: string,
   ): Promise<UserWithAdminRights | undefined>;
   findByEmail(email: Email): Promise<UserWithAdminRights | undefined>;
-  getUserIdsLoggedInLongAgo(
+  getUserIdsLoggedInAndCreatedLongAgo(
     params: GetUserIdsLoggedInLongAgoParams,
   ): Promise<UserId[]>;
 }

--- a/back/src/domains/core/authentication/connected-user/port/UserRepository.ts
+++ b/back/src/domains/core/authentication/connected-user/port/UserRepository.ts
@@ -6,7 +6,7 @@ import type {
   UserWithNumberOfAgenciesAndEstablishments,
 } from "shared";
 
-export type GetUserIdsLoggedInLongAgoParams = {
+export type GetUserIdsLoggedInAndCreatedLongAgoParams = {
   since: Date;
   limit: number;
   offset: number;
@@ -26,6 +26,6 @@ export interface UserRepository {
   ): Promise<UserWithAdminRights | undefined>;
   findByEmail(email: Email): Promise<UserWithAdminRights | undefined>;
   getUserIdsLoggedInAndCreatedLongAgo(
-    params: GetUserIdsLoggedInLongAgoParams,
+    params: GetUserIdsLoggedInAndCreatedLongAgoParams,
   ): Promise<UserId[]>;
 }

--- a/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.ts
@@ -56,7 +56,7 @@ export const makeTriggerEventsToDeleteInactiveUsers = useCaseBuilder(
     while (true) {
       const batchResult = await deps.uowPerformer.perform(async (uow) => {
         const loggedInLongAgoUserIds =
-          await uow.userRepository.getUserIdsLoggedInLongAgo({
+          await uow.userRepository.getUserIdsLoggedInAndCreatedLongAgo({
             since: twoYearsAgo,
             limit: deps.batchSize,
             offset,

--- a/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.unit.test.ts
@@ -1,4 +1,4 @@
-import { subDays, subYears } from "date-fns";
+import { subDays, subMilliseconds, subYears } from "date-fns";
 import { expectToEqual, makeBooleanFeatureFlag } from "shared";
 import { makeCreateNewEvent } from "../../../events/ports/EventBus";
 import { CustomTimeGateway } from "../../../time-gateway/adapters/CustomTimeGateway";
@@ -22,11 +22,11 @@ import {
   type TriggerEventsToDeleteInactiveUsers,
 } from "./TriggerEventsToDeleteInactiveUsers";
 
-const now = new Date("2026-01-15T10:00:00.000Z");
-const twoYearsAgo = subYears(now, 2);
-const inactiveLastLoginAt = subDays(twoYearsAgo, 1).toISOString();
-
 describe("TriggerEventsToDeleteInactiveUsers", () => {
+  const now = new Date("2026-01-15T10:00:00.000Z");
+  const twoYearsAgo = subYears(now, 2);
+  const inactiveLastLoginAt = subDays(twoYearsAgo, 1).toISOString();
+
   let uow: InMemoryUnitOfWork;
   let triggerEventsToDeleteInactiveUsers: TriggerEventsToDeleteInactiveUsers;
   let timeGateway: CustomTimeGateway;
@@ -154,6 +154,72 @@ describe("TriggerEventsToDeleteInactiveUsers", () => {
 
     expectToEqual(result, { numberOfDeletionsTriggered: 0 });
     expectToEqual(uow.outboxRepository.events.length, 0);
+  });
+
+  it("does not trigger deletion for warned user not logged in and created 2 years ago", async () => {
+    const userNotLoggedAndCreatedTwoYearsAgo = makeUser({
+      id: "user",
+      email: "inactive@test.fr",
+      lastLoginAt: undefined,
+      createdAt: twoYearsAgo.toISOString(),
+    });
+
+    uow.userRepository.users = [userNotLoggedAndCreatedTwoYearsAgo];
+
+    saveDeletionWarningNotification({
+      uow,
+      userId: userNotLoggedAndCreatedTwoYearsAgo.id,
+      createdAt: subDays(now, 8),
+    });
+
+    const result = await triggerEventsToDeleteInactiveUsers.execute();
+
+    expectToEqual(result, { numberOfDeletionsTriggered: 0 });
+    expectToEqual(uow.outboxRepository.events.length, 0);
+  });
+
+  it("does not trigger deletion for warned user logged in and created 2 years ago", async () => {
+    const userLoggedAndCreatedTwoYearsAgo = makeUser({
+      id: "user",
+      email: "inactive@test.fr",
+      lastLoginAt: twoYearsAgo.toISOString(),
+      createdAt: twoYearsAgo.toISOString(),
+    });
+
+    uow.userRepository.users = [userLoggedAndCreatedTwoYearsAgo];
+
+    saveDeletionWarningNotification({
+      uow,
+      userId: userLoggedAndCreatedTwoYearsAgo.id,
+      createdAt: subDays(now, 8),
+    });
+
+    const result = await triggerEventsToDeleteInactiveUsers.execute();
+
+    expectToEqual(result, { numberOfDeletionsTriggered: 0 });
+    expectToEqual(uow.outboxRepository.events.length, 0);
+  });
+
+  it("not trigger deletion for warned user not logged in and created more than 2 years ago", async () => {
+    const userNotLoggedAndCreatedMoreThanTwoYearsAgo = makeUser({
+      id: "user",
+      email: "inactive@test.fr",
+      lastLoginAt: undefined,
+      createdAt: subMilliseconds(twoYearsAgo, 1).toISOString(),
+    });
+
+    uow.userRepository.users = [userNotLoggedAndCreatedMoreThanTwoYearsAgo];
+
+    saveDeletionWarningNotification({
+      uow,
+      userId: userNotLoggedAndCreatedMoreThanTwoYearsAgo.id,
+      createdAt: subDays(now, 8),
+    });
+
+    const result = await triggerEventsToDeleteInactiveUsers.execute();
+
+    expectToEqual(result, { numberOfDeletionsTriggered: 1 });
+    expectToEqual(uow.outboxRepository.events.length, 1);
   });
 
   it("does not trigger deletion for user who sent a recent exchange as establishment (30 days ago or 23 months ago)", async () => {
@@ -299,26 +365,26 @@ describe("TriggerEventsToDeleteInactiveUsers", () => {
     );
     expectToEqual(countingUowPerformer.getCount(), 4);
   });
-});
 
-const makeInactiveUsers = (count: number) =>
-  Array.from({ length: count }, (_, index) =>
-    makeUser({
-      id: `00000000-0000-4000-9000-${String(index + 1).padStart(12, "0")}`,
-      email: `inactive-${index + 1}@test.fr`,
-      lastLoginAt: inactiveLastLoginAt,
-    }),
-  );
+  const makeInactiveUsers = (count: number) =>
+    Array.from({ length: count }, (_, index) =>
+      makeUser({
+        id: `00000000-0000-4000-9000-${String(index + 1).padStart(12, "0")}`,
+        email: `inactive-${index + 1}@test.fr`,
+        lastLoginAt: inactiveLastLoginAt,
+      }),
+    );
 
-const makeCountingUowPerformer = (
-  uow: UnitOfWork,
-): UnitOfWorkPerformer & { getCount: () => number } => {
-  let count = 0;
-  return {
-    perform: async (cb) => {
-      count++;
-      return cb(uow);
-    },
-    getCount: () => count,
+  const makeCountingUowPerformer = (
+    uow: UnitOfWork,
+  ): UnitOfWorkPerformer & { getCount: () => number } => {
+    let count = 0;
+    return {
+      perform: async (cb) => {
+        count++;
+        return cb(uow);
+      },
+      getCount: () => count,
+    };
   };
-};
+});

--- a/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/TriggerEventsToDeleteInactiveUsers.unit.test.ts
@@ -200,7 +200,7 @@ describe("TriggerEventsToDeleteInactiveUsers", () => {
     expectToEqual(uow.outboxRepository.events.length, 0);
   });
 
-  it("not trigger deletion for warned user not logged in and created more than 2 years ago", async () => {
+  it("trigger deletion for warned user that never logged in and created more than 2 years ago", async () => {
     const userNotLoggedAndCreatedMoreThanTwoYearsAgo = makeUser({
       id: "user",
       email: "inactive@test.fr",

--- a/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.ts
@@ -50,7 +50,7 @@ export const makeWarnInactiveUsers = useCaseBuilder("WarnInactiveUsers")
     while (true) {
       const batchResult = await deps.uowPerformer.perform(async (uow) => {
         const loggedInLongAgoUserIds =
-          await uow.userRepository.getUserIdsLoggedInLongAgo({
+          await uow.userRepository.getUserIdsLoggedInAndCreatedLongAgo({
             since: twoYearsAgo,
             limit: deps.batchSize,
             offset,

--- a/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.ts
@@ -49,14 +49,14 @@ export const makeWarnInactiveUsers = useCaseBuilder("WarnInactiveUsers")
 
     while (true) {
       const batchResult = await deps.uowPerformer.perform(async (uow) => {
-        const loggedInLongAgoUserIds =
+        const userIdsLoggedInAndCreatedLongAgo =
           await uow.userRepository.getUserIdsLoggedInAndCreatedLongAgo({
             since: twoYearsAgo,
             limit: deps.batchSize,
             offset,
           });
 
-        if (loggedInLongAgoUserIds.length === 0)
+        if (userIdsLoggedInAndCreatedLongAgo.length === 0)
           return {
             hasMore: false,
             numberOfWarningsSent: 0,
@@ -65,13 +65,13 @@ export const makeWarnInactiveUsers = useCaseBuilder("WarnInactiveUsers")
         const alreadyWarnedUserIds =
           await uow.notificationRepository.filterUserDeletionWarningNotifications(
             {
-              userIds: loggedInLongAgoUserIds,
+              userIds: userIdsLoggedInAndCreatedLongAgo,
               excludeWarnedSince: warningCutoff,
             },
           );
 
         const alreadyWarned = new Set(alreadyWarnedUserIds);
-        const notYetWarnedUserIds = loggedInLongAgoUserIds.filter(
+        const notYetWarnedUserIds = userIdsLoggedInAndCreatedLongAgo.filter(
           (id) => !alreadyWarned.has(id),
         );
 

--- a/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/WarnInactiveUsers.unit.test.ts
@@ -1,4 +1,10 @@
-import { addDays, subDays, subYears } from "date-fns";
+import {
+  addDays,
+  subDays,
+  subMilliseconds,
+  subMonths,
+  subYears,
+} from "date-fns";
 import {
   type AbsoluteUrl,
   ConventionDtoBuilder,
@@ -33,13 +39,13 @@ import {
   type WarnInactiveUsers,
 } from "./WarnInactiveUsers";
 
-const immersionBaseUrl: AbsoluteUrl = "https://immersion-facile.test";
-
-const now = new Date("2026-01-15T10:00:00.000Z");
-const twoYearsAgo = subYears(now, 2);
-const inactiveLastLoginAt = subDays(twoYearsAgo, 1).toISOString();
-
 describe("WarnInactiveUsers", () => {
+  const immersionBaseUrl: AbsoluteUrl = "https://immersion-facile.test";
+
+  const now = new Date("2026-01-15T10:00:00.000Z");
+  const twoYearsAgo = subYears(now, 2);
+  const inactiveLastLoginAt = subDays(twoYearsAgo, 1).toISOString();
+
   let uow: InMemoryUnitOfWork;
   let warnInactiveUsers: WarnInactiveUsers;
   let expectSavedNotificationsBatchAndEvent: ExpectSavedNotificationsBatchAndEvent;
@@ -104,16 +110,34 @@ describe("WarnInactiveUsers", () => {
       email: "boundary@test.fr",
       lastLoginAt: twoYearsAgo.toISOString(),
     });
-    const neverLoggedInUser = makeUser({
-      id: "never-logged-id",
-      email: "never@test.fr",
+    const neverLoggedInUserAndCreatedMoreThan2YearsAgo = makeUser({
+      id: "never-logged-id-26",
+      email: "never-26@test.fr",
       firstName: "Paul",
       lastName: "Durand",
+      createdAt: subMilliseconds(twoYearsAgo, 1).toISOString(),
     });
+    const neverLoggedInUserAndCreated2YearsAgo = makeUser({
+      id: "never-logged-id-25",
+      email: "never-25@test.fr",
+      firstName: "Paul",
+      lastName: "Durand",
+      createdAt: twoYearsAgo.toISOString(),
+    });
+    const neverLoggedInUserAndCreated1MonthAgo = makeUser({
+      id: "never-logged-id-1",
+      email: "never-1@test.fr",
+      firstName: "Paul",
+      lastName: "Durand",
+      createdAt: subMonths(now, 1).toISOString(),
+    });
+
     uow.userRepository.users = [
       inactiveUser,
       boundaryActiveUser,
-      neverLoggedInUser,
+      neverLoggedInUserAndCreatedMoreThan2YearsAgo,
+      neverLoggedInUserAndCreated2YearsAgo,
+      neverLoggedInUserAndCreated1MonthAgo,
     ];
 
     const result = await warnInactiveUsers.execute();
@@ -132,9 +156,9 @@ describe("WarnInactiveUsers", () => {
         },
         {
           kind: "ACCOUNT_DELETION_WARNING",
-          recipients: [neverLoggedInUser.email],
+          recipients: [neverLoggedInUserAndCreatedMoreThan2YearsAgo.email],
           params: {
-            fullName: `${neverLoggedInUser.firstName} ${neverLoggedInUser.lastName}`,
+            fullName: `${neverLoggedInUserAndCreatedMoreThan2YearsAgo.firstName} ${neverLoggedInUserAndCreatedMoreThan2YearsAgo.lastName}`,
             deletionDate: "22 janvier 2026",
             loginUrl: `${immersionBaseUrl}/${frontRoutes.profile}`,
           },
@@ -337,26 +361,26 @@ describe("WarnInactiveUsers", () => {
     );
     expectToEqual(countingUowPerformer.getCount(), 4);
   });
-});
 
-const makeInactiveUsers = (count: number) =>
-  Array.from({ length: count }, (_, index) =>
-    makeUser({
-      id: `00000000-0000-4000-9000-${String(index + 1).padStart(12, "0")}`,
-      email: `inactive-${index + 1}@test.fr`,
-      lastLoginAt: inactiveLastLoginAt,
-    }),
-  );
+  const makeInactiveUsers = (count: number) =>
+    Array.from({ length: count }, (_, index) =>
+      makeUser({
+        id: `00000000-0000-4000-9000-${String(index + 1).padStart(12, "0")}`,
+        email: `inactive-${index + 1}@test.fr`,
+        lastLoginAt: inactiveLastLoginAt,
+      }),
+    );
 
-const makeCountingUowPerformer = (
-  uow: UnitOfWork,
-): UnitOfWorkPerformer & { getCount: () => number } => {
-  let count = 0;
-  return {
-    perform: async (cb) => {
-      count++;
-      return cb(uow);
-    },
-    getCount: () => count,
+  const makeCountingUowPerformer = (
+    uow: UnitOfWork,
+  ): UnitOfWorkPerformer & { getCount: () => number } => {
+    let count = 0;
+    return {
+      perform: async (cb) => {
+        count++;
+        return cb(uow);
+      },
+      getCount: () => count,
+    };
   };
-};
+});

--- a/back/src/domains/core/authentication/connected-user/use-cases/inactiveUsersTest.helpers.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/inactiveUsersTest.helpers.ts
@@ -16,6 +16,7 @@ export const makeUser = (
     .withEmail(overrides.email)
     .withFirstName(overrides.firstName ?? "Jean")
     .withLastName(overrides.lastName ?? "Dupont")
+    .withCreatedAt(overrides.createdAt && new Date(overrides.createdAt))
     .buildUser(),
   lastLoginAt: overrides.lastLoginAt,
 });

--- a/shared/src/user/user.builder.ts
+++ b/shared/src/user/user.builder.ts
@@ -107,10 +107,10 @@ export class ConnectedUserBuilder implements Builder<ConnectedUser> {
     return this.#dto.agencyRights;
   }
 
-  withCreatedAt(createdAt: Date): ConnectedUserBuilder {
+  withCreatedAt(createdAt: Date | undefined): ConnectedUserBuilder {
     return new ConnectedUserBuilder({
       ...this.#dto,
-      createdAt: createdAt.toISOString(),
+      ...(createdAt ? { createdAt: createdAt.toISOString() } : {}),
     });
   }
 


### PR DESCRIPTION
## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
