### PR TITLE
#4121 - Ajustement du message d'information sur les champs modifiables d'une convention validée

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/modals/EditConventionWithFinalStatusModalContent.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/modals/EditConventionWithFinalStatusModalContent.tsx
@@ -1,4 +1,5 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import Highlight from "@codegouvfr/react-dsfr/Highlight";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type SubmitHandler, useForm } from "react-hook-form";
@@ -141,7 +142,10 @@ export const EditConventionWithFinalStatusModalContent = ({
       <p className={fr.cx("fr-text--sm", "fr-mb-2w")}>
         <strong>ID :</strong> {convention.id}
       </p>
-
+      <Highlight className={fr.cx("fr-ml-0")} size="sm">
+        La convention étant déjà validée, seules certaines informations peuvent
+        encore être modifiées.
+      </Highlight>
       {canEditBeneficiary && (
         <div className={fr.cx("fr-card", "fr-p-2w", "fr-mb-3w")}>
           <h3 className={fr.cx("fr-h6", "fr-mb-2w")}>Personne en immersion</h3>


### PR DESCRIPTION
Fixes #4121

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant
