### PR TITLE
#5223 - Renommer le bouton « Déclarer un abandon » en « Déclarer une fin anticipée »

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
@@ -640,7 +640,7 @@ const createButtonPropsByVerificationAction = (
     DECLARE_ABANDONMENT: {
       props: getVerificationActionProps({
         verificationAction: "DECLARE_ABANDONMENT",
-        children: "Déclarer un abandon",
+        children: "Déclarer une fin anticipée",
         jwt,
         convention,
         buttonId: domElementIds.manageConvention.abandonAssessmentButton,


### PR DESCRIPTION
Fixes #5223

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Changement de wording uniquement sur le bouton de pilotage « Déclarer un abandon » → « Déclarer une fin anticipée ».