### PR TITLE
#5223 - Harmoniser le wording « fin anticipée » (bouton + mail convention validée)

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
@@ -640,7 +640,7 @@ const createButtonPropsByVerificationAction = (
     DECLARE_ABANDONMENT: {
       props: getVerificationActionProps({
         verificationAction: "DECLARE_ABANDONMENT",
-        children: "Déclarer un abandon",
+        children: "Déclarer une fin anticipée",
         jwt,
         convention,
         buttonId: domElementIds.manageConvention.abandonAssessmentButton,

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -2994,7 +2994,7 @@ L'équipe d'Immersion Facilitée`,
               content: `
               Un imprévu ?
 
-              Si l’immersion ne peut pas aller à son terme (abandon, arrêt anticipé, etc.), merci de nous le signaler dès que possible en <a href="${assessmentMagicLink}">déclarant un abandon</a> , pour assurer un bon suivi.`,
+              Si l’immersion ne peut pas aller à son terme (abandon, arrêt anticipé, etc.), merci de nous le signaler dès que possible en <a href="${assessmentMagicLink}">déclarant une fin anticipée</a> , pour assurer un bon suivi.`,
             }
           : undefined,
         agencyLogoUrl,


### PR DESCRIPTION
Fixes #5223

## Summary
- Renomme le bouton de pilotage « Déclarer un abandon » en « Déclarer une fin anticipée »
- Aligne le lien du mail `VALIDATED_CONVENTION_FINAL_CONFIRMATION` sur « déclarant une fin anticipée »

## Test plan
- [ ] Vérifier le libellé du bouton sur la page de pilotage d'une convention éligible
- [ ] Prévisualiser le mail « Convention - Finale validée » dans l'admin (onglet emails) et contrôler le texte du lien dans le bloc « Un imprévu ? »


Made with [Cursor](https://cursor.com)