### PR TITLE
#5236 - Aligner le libellé du mail de convention validée sur « déclarant une fin anticipée »

### DIFF
--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -2994,7 +2994,7 @@ L'équipe d'Immersion Facilitée`,
               content: `
               Un imprévu ?
 
-              Si l’immersion ne peut pas aller à son terme (abandon, arrêt anticipé, etc.), merci de nous le signaler dès que possible en <a href="${assessmentMagicLink}">déclarant un abandon</a> , pour assurer un bon suivi.`,
+              Si l’immersion ne peut pas aller à son terme (abandon, arrêt anticipé, etc.), merci de nous le signaler dès que possible en <a href="${assessmentMagicLink}">déclarant une fin anticipée</a> , pour assurer un bon suivi.`,
             }
           : undefined,
         agencyLogoUrl,


### PR DESCRIPTION
Fixes #5236

## Checklist avant RfR

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] Pipeline CI ✅

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

## Points d'attention pour le reviewer

Changement de wording uniquement dans le mail `VALIDATED_CONVENTION_FINAL_CONFIRMATION` (Convention - Finale validée) : le lien du bloc « Un imprévu ? » passe de « déclarant un abandon » à « déclarant une fin anticipée », en cohérence avec le renommage du bouton de pilotage (issue #5223, PR #5225).