### PR TITLE
#5252 - Clotûrer les agences plutôt que needsReview si pas de valideur ou admin d'agence

### DIFF
--- a/back/src/domains/connected-users/use-cases/DeleteUser.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.ts
@@ -224,7 +224,7 @@ const updateAgency =
     return {
       ...agency,
       ...(!remainingValidators.length && !remainingAdmins.length
-        ? { status: remainingRightsList.length ? "needsReview" : "closed" }
+        ? { status: "closed" }
         : {}),
       usersRights: remainingRightsList.reduce<AgencyUsersRights>(
         (acc, { userId, ...agencyRight }) => ({

--- a/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
@@ -484,7 +484,7 @@ describe("DeleteUser", () => {
         ]);
       });
 
-      it("case P3 BIS - with last validator and no admins - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenPutOnHold", async () => {
+      it("case P3 BIS - with last validator and no admins - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenClosed", async () => {
         uow.agencyRepository.agencies = [
           toAgencyWithRights(agency, {
             [validator1.id]: {
@@ -514,7 +514,7 @@ describe("DeleteUser", () => {
 
         expectToEqual(uow.agencyRepository.agencies, [
           toAgencyWithRights(
-            new AgencyDtoBuilder(agency).withStatus("needsReview").build(),
+            new AgencyDtoBuilder(agency).withStatus("closed").build(),
             {
               [readOnlyAndCounsellor.id]: {
                 isNotifiedByEmail: false,
@@ -645,7 +645,7 @@ describe("DeleteUser", () => {
           },
         ]);
       });
-      it("case P5 ALT - with last admin + validator and another user with counsellor/readonly - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenPutOnHold ", async () => {
+      it("case P5 ALT - with last admin + validator and another user with counsellor/readonly - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenClosed ", async () => {
         uow.agencyRepository.agencies = [
           toAgencyWithRights(agency, {
             [admin1.id]: {
@@ -675,7 +675,7 @@ describe("DeleteUser", () => {
 
         expectToEqual(uow.agencyRepository.agencies, [
           toAgencyWithRights(
-            new AgencyDtoBuilder(agency).withStatus("needsReview").build(),
+            new AgencyDtoBuilder(agency).withStatus("closed").build(),
             {
               [readOnlyAndCounsellor.id]: {
                 isNotifiedByEmail: false,


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [ ] Commits propres (pas de WIP, squash si nécessaire)
- [ ] Relecture complète du diff effectuée
- [ ] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [ ] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [ ] Auteurs assignés sur la PR et l'issue liée
- [ ] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [ ] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
