### PR TITLE
#5379 - Arrêt des checks de CI sur les PR en brouillon

### DIFF
--- a/.github/workflows/fullcheck.yml
+++ b/.github/workflows/fullcheck.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   validation:
+    if: ${{ !github.event.pull_request.draft }}
     name: ""
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/fullcheck.yml
+++ b/.github/workflows/fullcheck.yml
@@ -26,7 +26,6 @@ on:
 
 jobs:
   validation:
-    if: ${{ !github.event.pull_request.draft }}
     name: ""
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/validation-pr.yml
+++ b/.github/workflows/validation-pr.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   fullcheck:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: ./.github/workflows/fullcheck.yml
     secrets:
       API_KEY_OPEN_CAGE_DATA_GEOCODING: ${{ secrets.API_KEY_OPEN_CAGE_DATA_GEOCODING }}

--- a/.github/workflows/validation-pr.yml
+++ b/.github/workflows/validation-pr.yml
@@ -27,6 +27,7 @@ jobs:
 
   verify-migration-order:
     name: "Verify migration order"
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

- CodeQL est configuré "par défaut" depuis les settings du projet; en l'état pas possible de lui dire de ne pas regarder les PR en draft : il faudrait faire un job CodeQL de notre côté (pas sûr que ça vaille le coup ?)
- l'état des checks en bas montre bien le comportement attendu