### PR TITLE
#5011 - Supprimer la version dupliquée du 24/06/2026 des CGU

### DIFF
--- a/front/src/app/contents/standard/cgu.tsx
+++ b/front/src/app/contents/standard/cgu.tsx
@@ -18,10 +18,6 @@ export default {
     title: "Conditions générales d'utilisation d'Immersion Facilitée",
     content: () => <Version20260319CguContent />,
   },
-  "2026-06-24": {
-    title: "Conditions générales d'utilisation d'Immersion Facilitée",
-    content: () => <Version20260624CguContent />,
-  },
   latest: {
     title: "Conditions générales d'utilisation d'Immersion Facilitée",
     content: () => <Version20260624CguContent />,


### PR DESCRIPTION
Closes #5011

Lors de la mise à jour des CGU, « Version du 24/06/2026 » et « Version actuelle » affichaient le même contenu. La version dupliquée a été retirée de la liste en bas de page ; le texte mis à jour reste accessible via « Version actuelle ».

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

- Correction de contenu uniquement sur la page CGU (`/pages/cgu`), sans impact fonctionnel.
- Les versions historiques (02/12/2022, 17/03/2023, 19/11/2024, 19/03/2026) restent accessibles.