### PR TITLE
#5286 - Modale édition données après validation - afficher le champ date de naissance pour les backoffice admin

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/modals/EditConventionWithFinalStatusModalContent.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/modals/EditConventionWithFinalStatusModalContent.tsx
@@ -120,7 +120,7 @@ export const EditConventionWithFinalStatusModalContent = ({
     hasAgencyAllowedRolesToUpdateBeneficiaryBirthdateWithFinalStatus({
       agencyRights: currentUser?.agencyRights ?? [],
       agencyId: convention.agencyId,
-    });
+    }) || isBackofficeAdmin;
   const canEditBeneficiary = isBackofficeAdmin || canEditBeneficiaryBirthdate;
 
   const { register, handleSubmit, formState } =


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
