### PR TITLE
#5290 - Mettre à jour les instructions d'erreur pour la modification de la date de naissance

### DIFF
--- a/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
+++ b/front/src/app/contents/broadcast-feedback/broadcastFeedback.tsx
@@ -250,27 +250,25 @@ export const broadcastFeedbackErrorMessageMap: Record<
     solution: (isConventionValidated) => (
       <>
         {isConventionValidated ? (
-          <ul>
-            <li>
-              Je contacte le centre d'aide d'Immersion Facilitée{" "}
-              <a
-                href="https://aide.immersion-facile.beta.gouv.fr/fr/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                ici
-              </a>{" "}
-              pour erreur date de naissance
-            </li>
-            <li>
-              Je communique la date de naissance à modifier et le numéro de
-              convention.
-            </li>
-            <li>
-              Immersion Facilitée procèdera à la modification et l'installation
-              de la convention dans vos applicatifs.
-            </li>
-          </ul>
+          <>
+            <p>
+              Je procède moi-même à la modification de la date de naissance sur
+              la convention.
+            </p>
+            <ul>
+              <li>
+                Depuis la convention : je clique sur « modifier la convention ».
+              </li>
+              <li>
+                Je modifie la convention, puis je clique sur sauvegarder.
+                Automatiquement la convention est installée dans vos
+                applicatifs.
+              </li>
+              <li>
+                J'actualise ma page, pour vérifier que l'erreur a disparu.
+              </li>
+            </ul>
+          </>
         ) : (
           <ul>
             <li>


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Changement de wording uniquement, sur le message d'aide affiché pour l'erreur de synchronisation « date de naissance » sur les conventions validées (accordéon « Détails des solutions possibles »). Aucun changement fonctionnel.

Closes #5290