### PR TITLE
#5252 - Cloturer les agences sans valideurs plutôt que les mettre en attente de validation + modification de schéma pour pouvoir afficher les infos des agences cloturées/rejetées sans valideurs

### DIFF
--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -32,7 +32,7 @@ import {
   type AgencyWithNumberOfUsersToReview,
   type GetAgenciesFilters,
   type PartialAgencyWithUsersRights,
-  throwIfAgencyHasNoUsersWhileNotClosed,
+  throwIfAgencyHasNoUsersWhileNotClosedOrRejected,
 } from "../ports/AgencyRepository";
 
 type AgencyById = Partial<Record<AgencyId, AgencyWithUsersRights>>;
@@ -72,7 +72,7 @@ export class InMemoryAgencyRepository implements AgencyRepository {
     _updatedAt?: DateString,
   ): Promise<void> {
     if (this.#agencies[agency.id]) throw errors.agency.alreadyExist(agency.id);
-    throwIfAgencyHasNoUsersWhileNotClosed(agency);
+    throwIfAgencyHasNoUsersWhileNotClosedOrRejected(agency);
     this.#agencies[agency.id] = agency;
   }
 
@@ -84,7 +84,7 @@ export class InMemoryAgencyRepository implements AgencyRepository {
 
     const updatedAgency = { ...agencyToUdpate, ...agency };
     if (agency.usersRights !== undefined)
-      throwIfAgencyHasNoUsersWhileNotClosed(updatedAgency);
+      throwIfAgencyHasNoUsersWhileNotClosedOrRejected(updatedAgency);
     this.#agencies[agency.id] = updatedAgency;
   }
 

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -43,7 +43,7 @@ import {
   type AgencyWithNumberOfUsersToReview,
   type GetAgenciesFilters,
   type PartialAgencyWithUsersRights,
-  throwIfAgencyHasNoUsersWhileNotClosed,
+  throwIfAgencyHasNoUsersWhileNotClosedOrRejected,
 } from "../ports/AgencyRepository";
 
 const logger = createLogger(__filename);
@@ -607,7 +607,8 @@ export class PgAgencyRepository implements AgencyRepository {
       )
       .filter(isTruthy);
 
-    if (!newRights.length) throwIfAgencyHasNoUsersWhileNotClosed(agency);
+    if (!newRights.length)
+      throwIfAgencyHasNoUsersWhileNotClosedOrRejected(agency);
 
     await this.#deleteAgencyRights(agency.id);
 

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -1,23 +1,24 @@
 import { values } from "ramda";
-import type {
-  AddressDto,
-  AgencyDto,
-  AgencyId,
-  AgencyKind,
-  AgencyPositionFilter,
-  AgencyRight,
-  AgencyStatus,
-  AgencyWithUsersRights,
-  DataWithPagination,
-  DateString,
-  DepartmentCode,
-  OmitFromExistingKeys,
-  PaginationQueryParams,
-  SiretDto,
-  UserId,
-  WithUserFilters,
+import {
+  type AddressDto,
+  type AgencyDto,
+  type AgencyId,
+  type AgencyKind,
+  type AgencyPositionFilter,
+  type AgencyRight,
+  type AgencyStatus,
+  type AgencyWithUsersRights,
+  closedOrRejectedAgencyStatuses,
+  type DataWithPagination,
+  type DateString,
+  type DepartmentCode,
+  errors,
+  type OmitFromExistingKeys,
+  type PaginationQueryParams,
+  type SiretDto,
+  type UserId,
+  type WithUserFilters,
 } from "shared";
-import { errors } from "shared";
 import type { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
 
 export type GetAgenciesFilters = {
@@ -51,12 +52,15 @@ export type AgencyWithNumberOfUsersToReview = {
   numberOfUsersToReview: number;
 };
 
-export const throwIfAgencyHasNoUsersWhileNotClosed = ({
+export const throwIfAgencyHasNoUsersWhileNotClosedOrRejected = ({
   id,
   status,
   usersRights,
 }: Pick<AgencyWithUsersRights, "id" | "status" | "usersRights">): void => {
-  if (!values(usersRights).length && status !== "closed")
+  if (
+    !values(usersRights).length &&
+    !closedOrRejectedAgencyStatuses.includes(status)
+  )
     throw errors.agency.noUsers(id);
 };
 

--- a/back/src/domains/connected-users/use-cases/DeleteUser.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.ts
@@ -227,12 +227,15 @@ const updateAgency =
     return {
       ...agency,
       ...(!remainingValidators.length && !remainingAdmins.length
-        ? await getAgencyStatusWhenNoRemainingAdminOrValidator({
-            uow,
-            agencyId: agency.id,
-            agencyStatus: agency.status,
-            remainingRightsList,
-          })
+        ? {
+            status: await getAgencyStatusWhenNoRemainingAdminOrValidator({
+              uow,
+              agencyId: agency.id,
+              agencyStatus: agency.status,
+              remainingRightsList,
+            }),
+            statusJustification: "Aucun utilisateur actif",
+          }
         : {}),
       usersRights: remainingRightsList.reduce<AgencyUsersRights>(
         (acc, { userId, ...agencyRight }) => ({
@@ -258,22 +261,13 @@ const getAgencyStatusWhenNoRemainingAdminOrValidator = async ({
   agencyId: AgencyId;
   agencyStatus: AgencyStatus;
   remainingRightsList: AgencyRightList;
-}): Promise<{
-  status: ExtractFromExisting<AgencyStatus, "closed" | "rejected">;
-  statusJustification: string;
-}> => {
+}): Promise<ExtractFromExisting<AgencyStatus, "closed" | "rejected">> => {
   if (agencyStatus === "rejected") {
-    return {
-      status: "rejected",
-      statusJustification: "Aucun utilisateur actif",
-    };
+    return "rejected";
   }
 
   if (!remainingRightsList.length) {
-    return {
-      status: "closed",
-      statusJustification: "Aucun utilisateur actif",
-    };
+    return "closed";
   }
 
   const acceptedConventions = await uow.conventionQueries.getConventions({
@@ -284,10 +278,7 @@ const getAgencyStatusWhenNoRemainingAdminOrValidator = async ({
     sortBy: "dateStart",
   });
 
-  return {
-    status: acceptedConventions.length ? "closed" : "rejected",
-    statusJustification: "Aucun utilisateur actif",
-  };
+  return acceptedConventions.length ? "closed" : "rejected";
 };
 
 const getMostActiveUserId = (

--- a/back/src/domains/connected-users/use-cases/DeleteUser.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.ts
@@ -1,9 +1,12 @@
 import { keys, toPairs, uniq, values } from "ramda";
 import {
+  type AgencyId,
   type AgencyRole,
+  type AgencyStatus,
   type AgencyUserRight,
   type AgencyUsersRights,
   type AgencyWithUsersRights,
+  type ExtractFromExisting,
   errors,
   executeInSequence,
   isNotEmptyArray,
@@ -224,7 +227,11 @@ const updateAgency =
     return {
       ...agency,
       ...(!remainingValidators.length && !remainingAdmins.length
-        ? { status: remainingRightsList.length ? "needsReview" : "closed" }
+        ? await getAgencyStatusWhenNoRemainingAdminOrValidator({
+            uow,
+            agencyId: agency.id,
+            remainingRightsList,
+          })
         : {}),
       usersRights: remainingRightsList.reduce<AgencyUsersRights>(
         (acc, { userId, ...agencyRight }) => ({
@@ -239,6 +246,39 @@ const updateAgency =
       ),
     };
   };
+
+const getAgencyStatusWhenNoRemainingAdminOrValidator = async ({
+  uow,
+  agencyId,
+  remainingRightsList,
+}: {
+  uow: UnitOfWork;
+  agencyId: AgencyId;
+  remainingRightsList: AgencyRightList;
+}): Promise<{
+  status: ExtractFromExisting<AgencyStatus, "closed" | "rejected">;
+  statusJustification: string;
+}> => {
+  if (!remainingRightsList.length) {
+    return {
+      status: "closed",
+      statusJustification: "Aucun utilisateur actif",
+    };
+  }
+
+  const acceptedConventions = await uow.conventionQueries.getConventions({
+    filters: {
+      agencyIds: [agencyId],
+      withStatuses: ["ACCEPTED_BY_VALIDATOR"],
+    },
+    sortBy: "dateStart",
+  });
+
+  return {
+    status: acceptedConventions.length ? "closed" : "rejected",
+    statusJustification: "Aucun utilisateur actif",
+  };
+};
 
 const getMostActiveUserId = (
   uow: UnitOfWork,

--- a/back/src/domains/connected-users/use-cases/DeleteUser.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.ts
@@ -230,6 +230,7 @@ const updateAgency =
         ? await getAgencyStatusWhenNoRemainingAdminOrValidator({
             uow,
             agencyId: agency.id,
+            agencyStatus: agency.status,
             remainingRightsList,
           })
         : {}),
@@ -250,15 +251,24 @@ const updateAgency =
 const getAgencyStatusWhenNoRemainingAdminOrValidator = async ({
   uow,
   agencyId,
+  agencyStatus,
   remainingRightsList,
 }: {
   uow: UnitOfWork;
   agencyId: AgencyId;
+  agencyStatus: AgencyStatus;
   remainingRightsList: AgencyRightList;
 }): Promise<{
   status: ExtractFromExisting<AgencyStatus, "closed" | "rejected">;
   statusJustification: string;
 }> => {
+  if (agencyStatus === "rejected") {
+    return {
+      status: "rejected",
+      statusJustification: "Aucun utilisateur actif",
+    };
+  }
+
   if (!remainingRightsList.length) {
     return {
       status: "closed",

--- a/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
@@ -821,6 +821,56 @@ describe("DeleteUser", () => {
           },
         ]);
       });
+
+      it("case P8 - with rejected agency, last validator and validated convention - agency stays rejected + user deleted + keep agency rejected + event UserDeleted + event AgencyHasBeenPutOnHold", async () => {
+        const rejectedAgency = new AgencyDtoBuilder(agency)
+          .withStatus("rejected")
+          .withStatusJustification("Doublon détecté")
+          .build();
+
+        uow.agencyRepository.agencies = [
+          toAgencyWithRights(rejectedAgency, {
+            [validator1.id]: {
+              isNotifiedByEmail: true,
+              roles: ["validator"],
+            },
+          }),
+        ];
+
+        await deleteUser.execute({
+          userId: validator1.id,
+          triggeredBy: { kind: "crawler" },
+        });
+
+        expectToEqual(uow.userRepository.users, [
+          admin1,
+          admin2,
+          contactMostActive,
+          contactLessActive,
+          readOnlyAndCounsellor,
+          validator2,
+        ]);
+
+        expectToEqual(uow.agencyRepository.agencies, [
+          toAgencyWithRights(
+            {
+              ...rejectedAgency,
+              statusJustification: "Aucun utilisateur actif",
+            },
+            {},
+          ),
+        ]);
+
+        expectArraysToMatch(uow.outboxRepository.events, [
+          {
+            topic: "UserDeleted",
+            payload: {
+              triggeredBy: { kind: "crawler" },
+              userId: validator1.id,
+            },
+          },
+        ]);
+      });
     });
 
     describe("Hybrid cases", () => {

--- a/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
@@ -1,5 +1,6 @@
 import {
   AgencyDtoBuilder,
+  ConventionDtoBuilder,
   errors,
   expectArraysToMatch,
   expectPromiseToFailWithError,
@@ -484,7 +485,7 @@ describe("DeleteUser", () => {
         ]);
       });
 
-      it("case P3 BIS - with last validator and no admins - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenPutOnHold", async () => {
+      it("case P3 BIS - with last validator and no admins and no convention - remove agency right  + user deleted + agency rejected + event UserDeleted + event AgencyHasBeenPutOnHold", async () => {
         uow.agencyRepository.agencies = [
           toAgencyWithRights(agency, {
             [validator1.id]: {
@@ -514,7 +515,10 @@ describe("DeleteUser", () => {
 
         expectToEqual(uow.agencyRepository.agencies, [
           toAgencyWithRights(
-            new AgencyDtoBuilder(agency).withStatus("needsReview").build(),
+            new AgencyDtoBuilder(agency)
+              .withStatus("rejected")
+              .withStatusJustification("Aucun utilisateur actif")
+              .build(),
             {
               [readOnlyAndCounsellor.id]: {
                 isNotifiedByEmail: false,
@@ -645,7 +649,7 @@ describe("DeleteUser", () => {
           },
         ]);
       });
-      it("case P5 ALT - with last admin + validator and another user with counsellor/readonly - remove agency right  + user deleted + agency to review + event UserDeleted + event AgencyHasBeenPutOnHold ", async () => {
+      it("case P5 ALT - with last admin + validator and another user with counsellor/readonly + no convention - remove agency right  + user deleted + agency rejected + event UserDeleted + event AgencyHasBeenPutOnHold ", async () => {
         uow.agencyRepository.agencies = [
           toAgencyWithRights(agency, {
             [admin1.id]: {
@@ -675,7 +679,10 @@ describe("DeleteUser", () => {
 
         expectToEqual(uow.agencyRepository.agencies, [
           toAgencyWithRights(
-            new AgencyDtoBuilder(agency).withStatus("needsReview").build(),
+            new AgencyDtoBuilder(agency)
+              .withStatus("rejected")
+              .withStatusJustification("Aucun utilisateur actif")
+              .build(),
             {
               [readOnlyAndCounsellor.id]: {
                 isNotifiedByEmail: false,
@@ -729,7 +736,10 @@ describe("DeleteUser", () => {
 
         expectToEqual(uow.agencyRepository.agencies, [
           toAgencyWithRights(
-            new AgencyDtoBuilder(agency).withStatus("closed").build(),
+            new AgencyDtoBuilder(agency)
+              .withStatus("closed")
+              .withStatusJustification("Aucun utilisateur actif")
+              .build(),
             {},
           ),
         ]);
@@ -740,6 +750,73 @@ describe("DeleteUser", () => {
             payload: {
               triggeredBy: { kind: "crawler" },
               userId: admin1.id,
+            },
+          },
+        ]);
+      });
+
+      it("case P7 - with last admin + validator, another user and validated convention - remove agency right + user deleted + agency closed + event UserDeleted + event AgencyHasBeenPutOnHold", async () => {
+        uow.agencyRepository.agencies = [
+          toAgencyWithRights(agency, {
+            [admin1.id]: {
+              isNotifiedByEmail: true,
+              roles: ["agency-admin", "validator"],
+            },
+            [readOnlyAndCounsellor.id]: {
+              isNotifiedByEmail: false,
+              roles: ["counsellor"],
+            },
+          }),
+        ];
+        uow.conventionRepository.setConventions([
+          new ConventionDtoBuilder()
+            .withAgencyId(agency.id)
+            .withStatus("ACCEPTED_BY_VALIDATOR")
+            .build(),
+        ]);
+
+        await deleteUser.execute({
+          userId: admin1.id,
+          triggeredBy: { kind: "crawler" },
+        });
+
+        expectToEqual(uow.userRepository.users, [
+          admin2,
+          contactMostActive,
+          contactLessActive,
+          readOnlyAndCounsellor,
+          validator1,
+          validator2,
+        ]);
+
+        expectToEqual(uow.agencyRepository.agencies, [
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withStatus("closed")
+              .withStatusJustification("Aucun utilisateur actif")
+              .build(),
+            {
+              [readOnlyAndCounsellor.id]: {
+                isNotifiedByEmail: false,
+                roles: ["counsellor"],
+              },
+            },
+          ),
+        ]);
+
+        expectArraysToMatch(uow.outboxRepository.events, [
+          {
+            topic: "UserDeleted",
+            payload: {
+              triggeredBy: { kind: "crawler" },
+              userId: admin1.id,
+            },
+          },
+          {
+            topic: "AgencyHasBeenPutOnHold",
+            payload: {
+              triggeredBy: { kind: "crawler" },
+              agencyId: agency.id,
             },
           },
         ]);

--- a/front/src/app/components/agency/AgencyUsersTable.tsx
+++ b/front/src/app/components/agency/AgencyUsersTable.tsx
@@ -62,31 +62,35 @@ export const AgencyUsersTable = ({
 
   return (
     <>
-      <Table
-        fixed
-        id={tableId}
-        headers={[
-          "Utilisateurs",
-          "Préférence de communication",
-          "Rôles",
-          "Actions",
-        ]}
-        data={agencyUsers.map((agencyUser, index) =>
-          TableLine({
-            agency,
-            agencyUser,
-            currentUser,
-            index,
-            isLocationAdmin,
-            onDeleteClicked: (userRightToRemove) => {
-              setUserRightToRemove(userRightToRemove);
-              dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
-              removeUserModal.open();
-            },
-            onModifyClicked,
-          }),
-        )}
-      />
+      {agencyUsers.length > 0 ? (
+        <Table
+          fixed
+          id={tableId}
+          headers={[
+            "Utilisateurs",
+            "Préférence de communication",
+            "Rôles",
+            "Actions",
+          ]}
+          data={agencyUsers.map((agencyUser, index) =>
+            TableLine({
+              agency,
+              agencyUser,
+              currentUser,index,
+              isLocationAdmin,
+              onDeleteClicked: (userRightToRemove) => {
+                setUserRightToRemove(userRightToRemove);
+                dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
+                removeUserModal.open();
+              },
+              onModifyClicked,
+
+            }),
+          )}
+        />
+      ) : (
+        <p>Aucun utilisateur trouvé</p>
+      )}
       {createPortal(
         <removeUserModal.Component
           {...(userRightToRemove

--- a/front/src/app/components/agency/AgencyUsersTable.tsx
+++ b/front/src/app/components/agency/AgencyUsersTable.tsx
@@ -76,7 +76,8 @@ export const AgencyUsersTable = ({
             TableLine({
               agency,
               agencyUser,
-              currentUser,index,
+              currentUser,
+              index,
               isLocationAdmin,
               onDeleteClicked: (userRightToRemove) => {
                 setUserRightToRemove(userRightToRemove);
@@ -84,7 +85,6 @@ export const AgencyUsersTable = ({
                 removeUserModal.open();
               },
               onModifyClicked,
-
             }),
           )}
         />

--- a/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/HttpAgencyGateway.ts
@@ -58,24 +58,6 @@ export class HttpAgencyGateway implements AgencyGateway {
     );
   }
 
-  public getAgencyAdminById$(
-    agencyId: AgencyId,
-    adminToken: ConnectedUserJwt,
-  ): Observable<AgencyDto> {
-    return from(
-      this.httpClient
-        .getAgencyById({
-          urlParams: { agencyId },
-          headers: { authorization: adminToken },
-        })
-        .then((response) =>
-          match(response)
-            .with({ status: 200 }, ({ body }) => body)
-            .otherwise(otherwiseThrow),
-        ),
-    );
-  }
-
   getAgencyById$(
     agencyId: AgencyId,
     token: ConnectedUserJwt,

--- a/shared/src/agency/agency.schema.test.ts
+++ b/shared/src/agency/agency.schema.test.ts
@@ -11,7 +11,7 @@ describe("agencySchema", () => {
     it.each([
       ...activeAgencyStatuses,
       "needsReview",
-    ] as AgencyStatus[])("is null if the agency is %s", (status) => {
+    ] satisfies AgencyStatus[])("is null if the agency is %s", (status) => {
       const agency = new AgencyDtoBuilder()
         .withValidatorEmails(["validator@mail.com"])
         .withStatus(status)
@@ -43,6 +43,34 @@ describe("agencySchema", () => {
         statusJustification: "test",
       });
       expect(retryResult.success).toBe(true);
+    });
+  });
+
+  describe("validatorEmails", () => {
+    it.each([
+      ...activeAgencyStatuses,
+      "needsReview",
+    ] satisfies AgencyStatus[])("should have at least one validator email if the agency is %s", (status) => {
+      const agency = new AgencyDtoBuilder()
+        .withValidatorEmails(["validator@mail.com"])
+        .withStatus(status)
+        .build();
+
+      const result = agencySchema.safeParse(agency);
+      expect(result.success).toBe(true);
+    });
+
+    it.each(
+      closedOrRejectedAgencyStatuses,
+    )("can have no validator email if the agency is %s", (status) => {
+      const agency = new AgencyDtoBuilder()
+        .withValidatorEmails([])
+        .withStatus(status)
+        .withStatusJustification("test")
+        .build();
+
+      const result = agencySchema.safeParse(agency);
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/shared/src/agency/agency.schema.test.ts
+++ b/shared/src/agency/agency.schema.test.ts
@@ -60,6 +60,19 @@ describe("agencySchema", () => {
       expect(result.success).toBe(true);
     });
 
+    it.each([
+      ...activeAgencyStatuses,
+      "needsReview",
+    ] satisfies AgencyStatus[])("should throw an error if the agency is %s and has no validator email", (status) => {
+      const agency = new AgencyDtoBuilder()
+        .withValidatorEmails([])
+        .withStatus(status)
+        .build();
+
+      const result = agencySchema.safeParse(agency);
+      expect(result.success).toBe(false);
+    });
+
     it.each(
       closedOrRejectedAgencyStatuses,
     )("can have no validator email if the agency is %s", (status) => {

--- a/shared/src/agency/agency.schema.ts
+++ b/shared/src/agency/agency.schema.ts
@@ -27,6 +27,7 @@ import {
   type AgencyIdResponse,
   type AgencyKind,
   type AgencyOption,
+  type AgencyStatus,
   activeAgencyStatuses,
   agencyKindFilters,
   allAgencyStatuses,
@@ -129,6 +130,11 @@ const delegationAgencyInfoSchema: ZodSchemaWithInputMatchingOutput<DelegationAge
 
 const withEmails = {
   counsellorEmails: z.array(emailSchema),
+  validatorEmails: z.array(emailSchema),
+};
+
+const withRequiredValidatorEmails = {
+  counsellorEmails: z.array(emailSchema),
   validatorEmails: z.array(emailSchema).refine((emails) => emails.length > 0, {
     message: localization.atLeastOneEmail,
   }),
@@ -152,11 +158,20 @@ const commonAgencyShape = {
   phoneNumber: phoneNumberSchema,
 };
 
+const mustHaveValidatorEmailsIfActiveOrNeedsReview = ({
+  status,
+  validatorEmails,
+}: {
+  status: AgencyStatus;
+  validatorEmails: Email[];
+}): boolean =>
+  closedOrRejectedAgencyStatuses.includes(status) || validatorEmails.length > 0;
+
 export const createAgencySchema: z.ZodType<
   CreateAgencyDto,
   CreateAgencyInitialValues
 > = z
-  .object({ ...commonAgencyShape, ...withEmails })
+  .object({ ...commonAgencyShape, ...withRequiredValidatorEmails })
   .and(
     z.object({
       refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
@@ -178,7 +193,18 @@ export const createAgencySchema: z.ZodType<
           "Une structure d'accompagnement doit avoir au moins un email de conseiller pour examen préabable",
       });
     }
-  });
+  })
+  .refine(
+    ({ validatorEmails }) =>
+      mustHaveValidatorEmailsIfActiveOrNeedsReview({
+        status: "needsReview",
+        validatorEmails,
+      }),
+    {
+      message: localization.atLeastOneEmail,
+      path: ["validatorEmails"],
+    },
+  );
 
 const mustHaveStatutJustificationIfClosedOrRejected = (
   agency: AgencyDto,
@@ -217,6 +243,10 @@ export const editAgencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
   .refine(mustHaveStatutJustificationIfClosedOrRejected, {
     message: "Une agence inactive doit avoir une justification",
     path: ["statusJustification"],
+  })
+  .refine(mustHaveValidatorEmailsIfActiveOrNeedsReview, {
+    message: localization.atLeastOneEmail,
+    path: ["validatorEmails"],
   });
 
 const withAdminEmailsSchema: ZodSchemaWithInputMatchingOutput<{
@@ -261,6 +291,10 @@ export const agencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
   .refine(mustHaveStatutJustificationIfClosedOrRejected, {
     message: "Une agence inactive doit avoir une justification",
     path: ["statusJustification"],
+  })
+  .refine(mustHaveValidatorEmailsIfActiveOrNeedsReview, {
+    message: localization.atLeastOneEmail,
+    path: ["validatorEmails"],
   });
 
 export const privateListAgenciesRequestSchema: ZodSchemaWithInputMatchingOutput<PrivateListAgenciesRequestDto> =

--- a/shared/src/agency/agency.schema.ts
+++ b/shared/src/agency/agency.schema.ts
@@ -128,17 +128,17 @@ const delegationAgencyInfoSchema: ZodSchemaWithInputMatchingOutput<DelegationAge
     delegationAgencyKind: delegationAgencyKindSchema.nullable(),
   });
 
-const withEmails = {
+const withCounsellorsAndValidatorsEmailsSchema = z.object({
   counsellorEmails: z.array(emailSchema),
   validatorEmails: z.array(emailSchema),
-};
+});
 
-const withRequiredValidatorEmails = {
+const withCounsellorsAndRequiredValidatorEmailsSchema = z.object({
   counsellorEmails: z.array(emailSchema),
   validatorEmails: z.array(emailSchema).refine((emails) => emails.length > 0, {
     message: localization.atLeastOneEmail,
   }),
-};
+});
 
 export const agencyNameSchema: ZodSchemaWithInputMatchingOutput<string> =
   stringWithMaxLength255;
@@ -171,7 +171,8 @@ export const createAgencySchema: z.ZodType<
   CreateAgencyDto,
   CreateAgencyInitialValues
 > = z
-  .object({ ...commonAgencyShape, ...withRequiredValidatorEmails })
+  .object(commonAgencyShape)
+  .and(withCounsellorsAndRequiredValidatorEmailsSchema)
   .and(
     z.object({
       refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
@@ -227,7 +228,8 @@ const mustHaveStatutJustificationIfClosedOrRejected = (
 };
 
 export const editAgencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
-  .object({ ...commonAgencyShape, ...withEmails })
+  .object(commonAgencyShape)
+  .and(withCounsellorsAndValidatorsEmailsSchema)
   .and(
     z.object({
       status: agencyStatusSchema,
@@ -274,19 +276,18 @@ export const agencyDtoForAgencyUsersAndAdminsSchema: ZodSchemaWithInputMatchingO
     .and(withAdminEmailsSchema);
 
 export const agencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
-  .object({ ...commonAgencyShape, ...withEmails })
-  .merge(
-    z.object({
-      agencySiret: siretSchema,
-      status: agencyStatusSchema,
-      codeSafir: zStringMinLength1Max1024.or(z.null()),
-      refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
-      refersToAgencyName: zStringMinLength1Max1024.or(z.null()),
-      refersToAgencyContactEmail: emailSchema.or(z.null()),
-      statusJustification: zStringMinLength1Max1024.or(z.null()),
-      delegationAgencyInfo: delegationAgencyInfoSchema.or(z.null()),
-    }),
-  )
+  .object(commonAgencyShape)
+  .extend({
+    agencySiret: siretSchema,
+    status: agencyStatusSchema,
+    codeSafir: zStringMinLength1Max1024.or(z.null()),
+    refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
+    refersToAgencyName: zStringMinLength1Max1024.or(z.null()),
+    refersToAgencyContactEmail: emailSchema.or(z.null()),
+    statusJustification: zStringMinLength1Max1024.or(z.null()),
+    delegationAgencyInfo: delegationAgencyInfoSchema.or(z.null()),
+  })
+  .and(withCounsellorsAndValidatorsEmailsSchema)
   .and(withAcquisitionSchema)
   .refine(mustHaveStatutJustificationIfClosedOrRejected, {
     message: "Une agence inactive doit avoir une justification",


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

