### PR TITLE
#4186 - Afficher un message de prévention si le prescripteur veut valider une convention qui est en erreur de synchro

### DIFF
--- a/front/src/app/components/forms/convention/manage-actions/ManageActionModalWrapper.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/ManageActionModalWrapper.tsx
@@ -1,3 +1,4 @@
+import type { ModalProps } from "@codegouvfr/react-dsfr/Modal";
 import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import { type Dispatch, Fragment, type SetStateAction, useState } from "react";
 import { createPortal } from "react-dom";
@@ -8,12 +9,14 @@ import {
   conventionStatusesWithValidator,
   type DeleteAssessmentRequestDto,
   doesStatusNeedsValidators,
+  domElementIds,
   type EditConventionCounsellorNameRequestDto,
   type EditConventionWithFinalStatusRequestDto,
   isUnvalidatedConventionStatus,
   type MarkPartnersErroredConventionAsHandledRequest,
   type RenewConventionParams,
   type Role,
+  type SubscriberErrorFeedback,
   type TransferConventionToAgencyRequestDto,
   type UpdateConventionStatusRequestDto,
   unvalidatedConventionStatuses,
@@ -58,6 +61,7 @@ export type ModalWrapperProps = {
   onCloseValidatorModalWithoutValidatorInfo?: Dispatch<
     SetStateAction<string | null>
   >;
+  broadcastErrorFeedback?: SubscriberErrorFeedback | null;
   currentUser?: ConnectedUser;
   isSubmitDisabled?: boolean;
 };
@@ -69,11 +73,18 @@ export const ModalWrapper = (props: ModalWrapperProps) => {
     initialStatus,
     onSubmit,
     onCloseValidatorModalWithoutValidatorInfo,
+    broadcastErrorFeedback,
     currentUser,
   } = props;
   const modalObject = modalByAction(verificationAction);
   const { createModalParams } = modalObject;
-  const isModalOpen = useIsModalOpen(createModalParams);
+  const [
+    hasSeenSyncErrorWarningBeforeValidation,
+    setHasSeenSyncErrorWarningBeforeValidation,
+  ] = useState(false);
+  const isModalOpen = useIsModalOpen(createModalParams, {
+    onConceal: () => setHasSeenSyncErrorWarningBeforeValidation(false),
+  });
   const [modalProps] = useState<ModalWrapperProps>(props);
   const renewFeedback = useFeedbackTopic("convention-action-renew");
   const showTransferModal = verificationAction === "TRANSFER";
@@ -117,6 +128,11 @@ export const ModalWrapper = (props: ModalWrapperProps) => {
       initialStatus,
       newStatusByVerificationAction[verificationAction],
     );
+  const showValidatorSyncErrorWarningBeforeValidation =
+    showValidatorModal &&
+    verificationAction === "ACCEPT_VALIDATOR" &&
+    !!broadcastErrorFeedback &&
+    !hasSeenSyncErrorWarningBeforeValidation;
 
   if (
     !showTransferModal &&
@@ -247,6 +263,10 @@ export const ModalWrapper = (props: ModalWrapperProps) => {
               closeModal={closeModal}
               newStatus={newStatus}
               convention={convention}
+              showSyncErrorWarningStep={
+                showValidatorSyncErrorWarningBeforeValidation
+              }
+              syncErrorMessage={broadcastErrorFeedback?.message}
               onCloseValidatorModalWithoutValidatorInfo={
                 onCloseValidatorModalWithoutValidatorInfo
               }
@@ -365,9 +385,61 @@ export const ModalWrapper = (props: ModalWrapperProps) => {
   );
 
   const Modal = modalObject.modal;
+  const modalTitle = showValidatorSyncErrorWarningBeforeValidation
+    ? "Attention : Erreur de synchronisation"
+    : modalProps.title;
+  const getValidatorModalButtons = (): ModalProps["buttons"] => {
+    if (!showValidatorModal || verificationAction !== "ACCEPT_VALIDATOR")
+      return undefined;
+
+    if (showValidatorSyncErrorWarningBeforeValidation)
+      return [
+        {
+          children: "Valider quand même",
+          type: "button",
+          priority: "secondary",
+          iconId: "fr-icon-arrow-right-line",
+          iconPosition: "right",
+          id: domElementIds.manageConvention
+            .validatorModalSyncErrorWarningConfirmButton,
+          doClosesModal: false,
+          onClick: () => setHasSeenSyncErrorWarningBeforeValidation(true),
+        },
+        {
+          children: "Fermer et corriger l'erreur",
+          type: "button",
+          priority: "primary",
+          id: domElementIds.manageConvention
+            .validatorModalSyncErrorWarningCloseButton,
+          onClick: closeModal,
+        },
+      ];
+
+    return [
+      {
+        children: "Annuler",
+        type: "button",
+        priority: "secondary",
+        id: domElementIds.manageConvention.validatorModalCancelButton,
+        onClick: closeModal,
+      },
+      {
+        children: "Valider la demande",
+        type: "submit",
+        priority: "primary",
+        id: domElementIds.manageConvention.validatorModalSubmitButton,
+      },
+    ];
+  };
+  const validatorModalButtons = getValidatorModalButtons();
 
   return createPortal(
-    <Modal {...modalProps} isSubmitDisabled={props.isSubmitDisabled}>
+    <Modal
+      {...modalProps}
+      isSubmitDisabled={props.isSubmitDisabled}
+      title={modalTitle}
+      buttons={validatorModalButtons}
+    >
       {modalContent}
     </Modal>,
     document.body,

--- a/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
@@ -606,6 +606,7 @@ const createButtonPropsByVerificationAction = (
         currentSignatoryRoles: requesterRoles,
         onSubmit: createOnSubmitWithFeedbackKind,
         onCloseValidatorModalWithoutValidatorInfo: setValidatorWarningMessage,
+        broadcastErrorFeedback,
         buttonId:
           domElementIds.manageConvention.conventionValidationValidateButton,
         iconId: "fr-icon-checkbox-circle-line",

--- a/front/src/app/components/forms/convention/manage-actions/getVerificationActionButtonProps.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getVerificationActionButtonProps.ts
@@ -15,6 +15,7 @@ import type {
   MarkPartnersErroredConventionAsHandledRequest,
   RenewConventionParams,
   Role,
+  SubscriberErrorFeedback,
   TransferConventionToAgencyRequestDto,
   UpdateConventionStatusRequestDto,
   WithConventionId,
@@ -53,6 +54,7 @@ type VerificationActionModalParams = {
   onCloseValidatorModalWithoutValidatorInfo?: Dispatch<
     SetStateAction<string | null>
   >;
+  broadcastErrorFeedback?: SubscriberErrorFeedback | null;
   modalTitle: string;
 };
 
@@ -291,6 +293,7 @@ export const getVerificationActionProps = (
       currentSignatoryRoles,
       initialStatus,
       onCloseValidatorModalWithoutValidatorInfo,
+      broadcastErrorFeedback,
       modalTitle,
       buttonId,
       iconId,
@@ -324,6 +327,7 @@ export const getVerificationActionProps = (
         currentSignatoryRoles: currentSignatoryRoles,
         onCloseValidatorModalWithoutValidatorInfo:
           onCloseValidatorModalWithoutValidatorInfo,
+        broadcastErrorFeedback,
         isSubmitDisabled: disabled,
       },
     };

--- a/front/src/app/components/forms/convention/manage-actions/manageActionModals.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/manageActionModals.tsx
@@ -121,10 +121,6 @@ const createValidatorModalParams = {
   id: domElementIds.manageConvention.validatorModal,
   isOpenedByDefault: false,
   formId: domElementIds.manageConvention.validatorModalForm,
-  submitButton: {
-    id: domElementIds.manageConvention.validatorModalSubmitButton,
-    children: "Valider la demande",
-  },
 };
 const {
   Component: ValidatorModal,

--- a/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
@@ -3,7 +3,7 @@ import Alert from "@codegouvfr/react-dsfr/Alert";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { pick } from "ramda";
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import {
   type ConventionReadDto,
@@ -39,7 +39,6 @@ export const ValidatorModalContent = ({
 }) => {
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
   const { modalOnCancelCallback, formId } = useFormModal();
-  const [isValidatorFormSubmit, setIsValidatorFormSubmit] = useState(false);
   const currentUserName =
     currentUser?.firstName && currentUser?.lastName
       ? pick(["firstname", "lastname"], {
@@ -58,7 +57,6 @@ export const ValidatorModalContent = ({
     firstname,
     lastname,
   }) => {
-    setIsValidatorFormSubmit(true);
     onSubmit({
       status: newStatus,
       conventionId: convention.id,
@@ -70,8 +68,8 @@ export const ValidatorModalContent = ({
   const getFieldError = makeFieldError(formState);
 
   useEffect(() => {
+    if (showSyncErrorWarningStep) return;
     return modalOnCancelCallback(() => {
-      if (isValidatorFormSubmit) return;
       if (onCloseValidatorModalWithoutValidatorInfo) {
         onCloseValidatorModalWithoutValidatorInfo(
           warningMessagesByConventionStatus[newStatus],
@@ -82,7 +80,7 @@ export const ValidatorModalContent = ({
     modalOnCancelCallback,
     onCloseValidatorModalWithoutValidatorInfo,
     newStatus,
-    isValidatorFormSubmit,
+    showSyncErrorWarningStep,
   ]);
 
   if (showSyncErrorWarningStep)

--- a/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
+++ b/front/src/app/components/forms/convention/manage-actions/modals/ValidatorModalContent.tsx
@@ -3,7 +3,7 @@ import Alert from "@codegouvfr/react-dsfr/Alert";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { pick } from "ramda";
-import { type Dispatch, type SetStateAction, useEffect } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import {
   type ConventionReadDto,
@@ -23,18 +23,23 @@ export const ValidatorModalContent = ({
   closeModal,
   newStatus,
   convention,
+  showSyncErrorWarningStep = false,
+  syncErrorMessage,
   onCloseValidatorModalWithoutValidatorInfo,
 }: {
   onSubmit: (params: UpdateConventionStatusRequestDto) => void;
   closeModal: () => void;
   newStatus: ConventionStatusWithValidator;
   convention: ConventionReadDto;
+  showSyncErrorWarningStep?: boolean;
+  syncErrorMessage?: string;
   onCloseValidatorModalWithoutValidatorInfo?: Dispatch<
     SetStateAction<string | null>
   >;
 }) => {
   const currentUser = useAppSelector(connectedUserSelectors.currentUser);
   const { modalOnCancelCallback, formId } = useFormModal();
+  const [isValidatorFormSubmit, setIsValidatorFormSubmit] = useState(false);
   const currentUserName =
     currentUser?.firstName && currentUser?.lastName
       ? pick(["firstname", "lastname"], {
@@ -53,6 +58,7 @@ export const ValidatorModalContent = ({
     firstname,
     lastname,
   }) => {
+    setIsValidatorFormSubmit(true);
     onSubmit({
       status: newStatus,
       conventionId: convention.id,
@@ -65,6 +71,7 @@ export const ValidatorModalContent = ({
 
   useEffect(() => {
     return modalOnCancelCallback(() => {
+      if (isValidatorFormSubmit) return;
       if (onCloseValidatorModalWithoutValidatorInfo) {
         onCloseValidatorModalWithoutValidatorInfo(
           warningMessagesByConventionStatus[newStatus],
@@ -75,7 +82,37 @@ export const ValidatorModalContent = ({
     modalOnCancelCallback,
     onCloseValidatorModalWithoutValidatorInfo,
     newStatus,
+    isValidatorFormSubmit,
   ]);
+
+  if (showSyncErrorWarningStep)
+    return (
+      <>
+        <p>
+          Vous êtes sur le point de valider une convention qui présente une
+          erreur de synchronisation avec{" "}
+          {convention.agencyKind === "mission-locale" ||
+          convention.agencyRefersTo?.kind === "mission-locale"
+            ? "i-Milo"
+            : "France Travail"}
+          .
+        </p>
+        <p>
+          <strong>Motif de l’erreur :</strong>{" "}
+          {syncErrorMessage ?? "Non renseigné"}
+        </p>
+        <p>
+          <strong>Conséquence :</strong> Une fois validée, la convention ne
+          pourra plus être modifiée et les données ne remonteront pas dans votre
+          applicatif.
+        </p>
+        <p>
+          <strong>Corriger l’erreur :</strong> Fermez cette fenêtre et consultez
+          l'encart “Détails des solutions possibles” affiché sur votre page.
+        </p>
+      </>
+    );
+
   return (
     <form onSubmit={handleSubmit(onFormSubmit)} id={formId}>
       {convention.isEstablishmentBanned && (

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -468,6 +468,10 @@ export const domElementIds = {
     deprecatedModalSubmitButton: "im-deprecated-modal__submit-button",
     validatorModalCancelButton: "im-validator-modal__cancel-button",
     validatorModalSubmitButton: "im-validator-modal__submit-button",
+    validatorModalSyncErrorWarningConfirmButton:
+      "im-validator-modal__sync-error-warning-confirm-button",
+    validatorModalSyncErrorWarningCloseButton:
+      "im-validator-modal__sync-error-warning-close-button",
     validatorModalForm: "im-validator-modal__form",
     counsellorModal: "im-counsellor-modal",
     counsellorModalForm: "im-counsellor-modal__form",


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
