### PR TITLE
#5048 - Corriger le wording du mail envoyé prescripteur lors du bannissement d'une entreprise

### DIFF
--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1893,7 +1893,7 @@ Tél : ${beneficiaryPhone}`,
         content: `
         Nous vous contactons car une convention d'immersion a été validée pour ${beneficiaryFirstName} ${beneficiaryLastName} au sein de l'entreprise ${businessName}.
 
-        Nous vous informons que cette entreprise a été bannie de notre plateforme suite à des signalements, car elle ne respectait pas la législation ou le cadre bienveillant exigé en matière d'immersion.
+        Nous vous informons que <strong>cette entreprise a été bannie de notre plateforme</strong> suite à des signalements, car elle ne respectait pas la législation ou le cadre bienveillant exigé en matière d'immersion.
 
         <strong>Que pouvez-vous faire ?</strong>
 
@@ -1915,7 +1915,8 @@ Tél : ${beneficiaryPhone}`,
         Le bénéficiaire a également reçu un email l'informant que l'entreprise a été bannie de notre site et lui demandant de se rapprocher de vous pour annuler sa démarche.
         Nous restons à votre entière disposition si vous avez des questions concernant cette situation exceptionnelle.
 
-        ${defaultSignature("immersion")}
+        Bien cordialement,
+        L'équipe Immersion Facilitée
         `,
       }),
     },

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1889,7 +1889,7 @@ Tél : ${beneficiaryPhone}`,
         immersionBaseUrl,
       }) => ({
         subject: `Urgent : Entreprise bannie - Convention à revoir pour ${beneficiaryFirstName} ${beneficiaryLastName}`,
-        greetings: `${greetingsWithConventionId(conventionId)} Bonjour${beneficiaryFirstName ? ` ${beneficiaryFirstName}` : ""}${beneficiaryLastName ? ` ${beneficiaryLastName}` : ""},`,
+        greetings: greetingsWithConventionId(conventionId),
         content: `
         Nous vous contactons car une convention d'immersion a été validée pour ${beneficiaryFirstName} ${beneficiaryLastName} au sein de l'entreprise ${businessName}.
 
@@ -1899,12 +1899,6 @@ Tél : ${beneficiaryPhone}`,
 
           • <strong>Si l'immersion n'a pas encore commencé :</strong> Nous vous recommandons fortement de procéder à l'annulation de cette convention afin de protéger le bénéficiaire.
           • <strong>Si l'immersion est actuellement en cours :</strong> Nous vous conseillons de contacter le bénéficiaire dans les plus brefs délais pour faire un point sur sa situation au sein de l'établissement. S'il s'avère que les conditions d'accueil ne sont pas respectées, vous pouvez procéder à une rupture anticipée de l’immersion.
-
-        
-        Ne vous découragez pas ! De nombreuses autres entreprises sont prêtes à vous accueillir. Si vous souhaitez toujours réaliser une immersion, vous pouvez :
-
-          • Rechercher d'autres immersions sur notre site.
-          • Contacter votre conseiller pour vous aider dans vos recherches.
         `,
         buttons: [
           {

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -1915,8 +1915,7 @@ Tél : ${beneficiaryPhone}`,
         Le bénéficiaire a également reçu un email l'informant que l'entreprise a été bannie de notre site et lui demandant de se rapprocher de vous pour annuler sa démarche.
         Nous restons à votre entière disposition si vous avez des questions concernant cette situation exceptionnelle.
 
-        Bien cordialement,
-        L'équipe Immersion Facilitée
+        ${defaultSignature("immersion")}
         `,
       }),
     },


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Correctif suite à la recette KO de l'issue #5048 : le template `ESTABLISHMENT_BANNED_NOTIFICATION_TO_VALIDATOR_AND_PREVALIDATOR` reprenait par erreur le wording destiné au bénéficiaire.

**Changements :**
- Salutation : suppression du prénom/nom du bénéficiaire dans le « Bonjour » (alignement sur les autres mails prescripteurs)
- Contenu : suppression du paragraphe « Ne vous découragez pas ! / rebondir » qui appartient au mail bénéficiaire

Closes #5048


Made with [Cursor](https://cursor.com)