### PR TITLE
#5332 - Sauvegarder un brouillon de convention sans les données FT Connect du bénéficiaire en cas de partage

### DIFF
--- a/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
@@ -205,6 +205,7 @@ describe("convention e2e", () => {
 
         const response = await unauthenticatedRequest.saveConventionDraft({
           body: {
+            mode: "share",
             senderEmail: "any@email.fr",
             conventionDraft: {
               id: conventionDraftId,
@@ -242,6 +243,7 @@ describe("convention e2e", () => {
         expectToEqual(inMemoryUow.conventionRepository.conventions, []);
         const response = await unauthenticatedRequest.saveConventionDraft({
           body: {
+            mode: "share",
             details: "any@email.fr",
             senderEmail: "invalid-email",
             conventionDraft: {

--- a/back/src/domains/convention/use-cases/SaveConventionDraft.ts
+++ b/back/src/domains/convention/use-cases/SaveConventionDraft.ts
@@ -24,7 +24,14 @@ export const makeSaveConventionDraft = useCaseBuilder("SaveConventionDraft")
       conventionDraftUpdated: inputParams.conventionDraft,
     });
 
-    await uow.conventionDraftRepository.save(inputParams.conventionDraft, now);
+    await uow.conventionDraftRepository.save(
+      inputParams.mode === "duplicate"
+        ? removeBeneficiaryFtConnectFederatedIdentityFromConvention(
+            inputParams.conventionDraft,
+          )
+        : inputParams.conventionDraft,
+      now,
+    );
 
     await uow.outboxRepository.save(
       deps.createNewEvent({
@@ -68,3 +75,24 @@ const throwConflictErrorWhenConventionDraftHasBeenUpdatedSinceLastSave =
       });
     }
   };
+
+const removeBeneficiaryFtConnectFederatedIdentityFromConvention = (
+  conventionDraft: ConventionDraftDto,
+): ConventionDraftDto => {
+  if (
+    conventionDraft.signatories?.beneficiary?.federatedIdentity?.provider !==
+    "ftConnect"
+  )
+    return conventionDraft;
+
+  const { federatedIdentity: _, ...beneficiaryWithoutFederatedIdentity } =
+    conventionDraft.signatories.beneficiary;
+
+  return {
+    ...conventionDraft,
+    signatories: {
+      ...conventionDraft.signatories,
+      beneficiary: beneficiaryWithoutFederatedIdentity,
+    },
+  };
+};

--- a/back/src/domains/convention/use-cases/SaveConventionDraft.unit.test.ts
+++ b/back/src/domains/convention/use-cases/SaveConventionDraft.unit.test.ts
@@ -1,5 +1,6 @@
 import { subDays } from "date-fns";
 import {
+  type Beneficiary,
   type ConventionDraftDto,
   errors,
   expectObjectInArrayToMatch,
@@ -58,6 +59,7 @@ describe("SaveConventionDraft", () => {
 
     await usecase.execute({
       conventionDraft,
+      mode: "share",
       senderEmail: email,
     });
 
@@ -90,6 +92,7 @@ describe("SaveConventionDraft", () => {
 
     await usecase.execute({
       conventionDraft,
+      mode: "share",
       senderEmail: email,
       recipientEmail,
       details: messageContent,
@@ -130,6 +133,7 @@ describe("SaveConventionDraft", () => {
 
     await usecase.execute({
       conventionDraft,
+      mode: "share",
       senderEmail: email,
       details: messageContent,
     });
@@ -154,6 +158,104 @@ describe("SaveConventionDraft", () => {
     ]);
   });
 
+  it("save draft without FT Connect infos on duplicate", async () => {
+    const beneficiaryBasicInfos: Beneficiary<"immersion"> = {
+      role: "beneficiary",
+      firstName: "Billy",
+      lastName: "Idol",
+      birthdate: new Date().toISOString(),
+      email: "mail@mail.com",
+      phone: "+33600000000",
+    };
+
+    const conventionDraftWithFtConnectInfos: ConventionDraftDto = {
+      id: uuid(),
+      internshipKind,
+      signatories: {
+        beneficiary: {
+          ...beneficiaryBasicInfos,
+          federatedIdentity: {
+            payload: {
+              advisor: {
+                email: "conseiller@mail.com",
+                firstName: "Jean",
+                lastName: "Conseiller",
+                type: "PLACEMENT",
+              },
+            },
+            provider: "ftConnect",
+            token: "token",
+          },
+        },
+      },
+    };
+
+    await usecase.execute({
+      mode: "duplicate",
+      conventionDraft: conventionDraftWithFtConnectInfos,
+      senderEmail: email,
+      details: messageContent,
+    });
+
+    expectToEqual(uow.conventionDraftRepository.conventionDrafts, [
+      {
+        ...conventionDraftWithFtConnectInfos,
+        signatories: {
+          ...conventionDraftWithFtConnectInfos.signatories,
+          beneficiary: beneficiaryBasicInfos,
+        },
+        updatedAt: timeGateway.now().toISOString(),
+      },
+    ]);
+  });
+
+  it("save draft with FT Connect infos on share", async () => {
+    const beneficiaryBasicInfos: Beneficiary<"immersion"> = {
+      role: "beneficiary",
+      firstName: "Billy",
+      lastName: "Idol",
+      birthdate: new Date().toISOString(),
+      email: "mail@mail.com",
+      phone: "+33600000000",
+    };
+
+    const conventionDraftWithFtConnectInfos: ConventionDraftDto = {
+      id: uuid(),
+      internshipKind,
+      signatories: {
+        beneficiary: {
+          ...beneficiaryBasicInfos,
+          federatedIdentity: {
+            payload: {
+              advisor: {
+                email: "conseiller@mail.com",
+                firstName: "Jean",
+                lastName: "Conseiller",
+                type: "PLACEMENT",
+              },
+            },
+            provider: "ftConnect",
+            token: "token",
+          },
+        },
+      },
+    };
+
+    await usecase.execute({
+      mode: "share",
+      conventionDraft: conventionDraftWithFtConnectInfos,
+      senderEmail: email,
+      details: messageContent,
+    });
+
+    expectToEqual(uow.conventionDraftRepository.conventionDrafts, [
+      {
+        ...conventionDraftWithFtConnectInfos,
+        updatedAt: timeGateway.now().toISOString(),
+      },
+    ]);
+  });
+
   it("throw a conflict error if the convention draft has been updated since the last save", async () => {
     const conventionDraft: ConventionDraftDto = {
       id: uuid(),
@@ -169,6 +271,7 @@ describe("SaveConventionDraft", () => {
 
     await expectPromiseToFailWithError(
       usecase.execute({
+        mode: "share",
         conventionDraft: {
           ...conventionDraft,
           updatedAt: "2024-10-08T00:00:00.000Z",

--- a/front/src/app/components/agency/agency-dashboard/ConventionTemplatesList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionTemplatesList.tsx
@@ -99,7 +99,7 @@ export const ConventionTemplatesList = ({
 
   const shareForm = useForm<SaveConventionDraftFromConventionTemplateDto>({
     mode: "onTouched",
-    defaultValues: { recipientEmail: "" },
+    defaultValues: { recipientEmail: "", mode: "share" },
     resolver: zodResolver(saveConventionDraftFromConventionTemplateSchema),
   });
   const { register, handleSubmit, formState, reset } = shareForm;
@@ -114,6 +114,7 @@ export const ConventionTemplatesList = ({
     reset({
       recipientEmail: "",
       details: "",
+      mode: "share",
       conventionDraft:
         makeConventionDraftDtoFromConventionTemplate(conventionTemplate),
     });

--- a/front/src/app/components/establishment/establishment-dashboard/DiscussionManageContent.tsx
+++ b/front/src/app/components/establishment/establishment-dashboard/DiscussionManageContent.tsx
@@ -339,6 +339,7 @@ const DiscussionDetails = (props: DiscussionDetailsProps): JSX.Element => {
       conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
         conventionDraft,
         redirectUrl,
+        mode: "share",
         feedbackTopic: "convention-draft",
       }),
     );

--- a/front/src/app/components/forms/convention/ShareForm.tsx
+++ b/front/src/app/components/forms/convention/ShareForm.tsx
@@ -33,6 +33,7 @@ const makeInitialValues = ({
   conventionFormData: CreateConventionPresentationInitialValues;
 }): SaveConventionDraftFromConventionDto => ({
   senderEmail: "",
+  mode: "share",
   conventionDraft: toConventionDraftDto({ convention: conventionFormData }),
   details:
     "Je vous invite à prendre connaissance de cette demande de convention d’immersion déjà partiellement remplie afin que vous la complétiez.  Merci !",

--- a/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
+++ b/front/src/app/components/forms/convention/manage-actions/getButtonConfigBySubStatus.ts
@@ -455,6 +455,7 @@ const createButtonPropsByVerificationAction = (
             conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested(
               {
                 ...conventionDraftWithRedirectUrl,
+                mode: "duplicate",
                 feedbackTopic: "convention-draft",
               },
             ),

--- a/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
+++ b/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
@@ -125,6 +125,7 @@ describe("ConventionDraft slice", () => {
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
           senderEmail: "sender@example.com",
           recipientEmail: "recipient@example.com",
+          mode: "share",
           conventionDraft,
           feedbackTopic: "convention-draft",
         }),
@@ -158,6 +159,7 @@ describe("ConventionDraft slice", () => {
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
           senderEmail: "sender@example.com",
           recipientEmail: "recipient@example.com",
+          mode: "share",
           conventionDraft,
           feedbackTopic: "convention-draft",
         }),
@@ -193,6 +195,7 @@ describe("ConventionDraft slice", () => {
           senderEmail: "sender@example.com",
           recipientEmail: "recipient@example.com",
           conventionDraft,
+          mode: "share",
           redirectUrl,
           feedbackTopic: "convention-draft",
         }),
@@ -212,6 +215,7 @@ describe("ConventionDraft slice", () => {
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
           senderEmail: "sender@example.com",
           recipientEmail: "recipient@example.com",
+          mode: "share",
           conventionDraft,
           feedbackTopic: "convention-draft",
         }),
@@ -233,6 +237,7 @@ describe("ConventionDraft slice", () => {
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
           senderEmail: "sender@example.com",
           recipientEmail: "recipient@example.com",
+          mode: "share",
           conventionDraft,
           redirectUrl,
           feedbackTopic: "convention-draft",

--- a/shared/src/convention/saveConventionDraft.dto.ts
+++ b/shared/src/convention/saveConventionDraft.dto.ts
@@ -43,20 +43,25 @@ type WithConventionDraft = {
 
 export type SaveConventionDraftFromConventionDto = WithConventionDraft & {
   senderEmail: Email;
+  mode: SaveConventionDraftMode;
   recipientEmail?: Email;
   details?: string;
 };
 
 export type SaveConventionDraftFromConventionTemplateDto =
   WithConventionDraft & {
+    mode: SaveConventionDraftMode;
     recipientEmail: Email;
     details?: string;
   };
 
+export type SaveConventionDraftMode = (typeof saveConventionDraftModes)[number];
+export const saveConventionDraftModes = ["duplicate", "share"] as const;
+
 export type SaveConventionDraftDto =
   | SaveConventionDraftFromConventionDto
   | SaveConventionDraftFromConventionTemplateDto
-  | WithConventionDraft;
+  | (WithConventionDraft & { mode: SaveConventionDraftMode });
 
 export const toConventionDraftDto = ({
   convention,

--- a/shared/src/convention/saveConventionDraft.schema.ts
+++ b/shared/src/convention/saveConventionDraft.schema.ts
@@ -11,12 +11,13 @@ import {
   immersionConventionSchema,
   miniStageConventionSchema,
 } from "./convention.schema";
-import type {
-  ConventionDraftDto,
-  ConventionDraftId,
-  SaveConventionDraftDto,
-  SaveConventionDraftFromConventionDto,
-  SaveConventionDraftFromConventionTemplateDto,
+import {
+  type ConventionDraftDto,
+  type ConventionDraftId,
+  type SaveConventionDraftDto,
+  type SaveConventionDraftFromConventionDto,
+  type SaveConventionDraftFromConventionTemplateDto,
+  saveConventionDraftModes,
 } from "./saveConventionDraft.dto";
 
 export const makeConventionDeepPartialSchema = (
@@ -136,6 +137,7 @@ export const saveConventionDraftFromConventionSchema: ZodSchemaWithInputMatching
     recipientEmail: emailSchema.optional(),
     details: conventionDraftDetailSchema.optional(),
     conventionDraft: conventionDraftSchema,
+    mode: z.enum(saveConventionDraftModes),
   });
 
 export const saveConventionDraftFromConventionTemplateSchema: ZodSchemaWithInputMatchingOutput<SaveConventionDraftFromConventionTemplateDto> =
@@ -143,6 +145,7 @@ export const saveConventionDraftFromConventionTemplateSchema: ZodSchemaWithInput
     recipientEmail: emailSchema,
     details: conventionDraftDetailSchema.optional(),
     conventionDraft: conventionDraftSchema,
+    mode: z.enum(saveConventionDraftModes),
   });
 
 export const saveConventionDraftSchema: ZodSchemaWithInputMatchingOutput<SaveConventionDraftDto> =
@@ -152,6 +155,7 @@ export const saveConventionDraftSchema: ZodSchemaWithInputMatchingOutput<SaveCon
       z
         .object({
           conventionDraft: conventionDraftSchema,
+          mode: z.enum(saveConventionDraftModes),
         })
         .strict(),
     );

--- a/shared/src/convention/saveConventionDraft.schema.unit.test.ts
+++ b/shared/src/convention/saveConventionDraft.schema.unit.test.ts
@@ -15,21 +15,22 @@ import {
 
 describe("saveConventionDraftSchema schema validation", () => {
   it("can have no senderEmail nor recipientEmail", () => {
-    expectToEqual(
-      saveConventionDraftSchema.safeParse({
-        conventionDraft: {
-          id: "aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa",
-          internshipKind: "immersion",
-        },
-      }).success,
-      true,
-    );
+    const safeParse = saveConventionDraftSchema.safeParse({
+      mode: "duplicate",
+      conventionDraft: {
+        id: "aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa",
+        internshipKind: "immersion",
+      },
+    });
+    expectToEqual(safeParse.error, undefined);
+    expectToEqual(safeParse.success, true);
   });
 });
 
 describe("saveConventionDraftFromConventionSchema schema validation", () => {
   it.each<SaveConventionDraftFromConventionDto>([
     {
+      mode: "duplicate",
       senderEmail: "test@test.com",
       conventionDraft: {
         id: "aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa",
@@ -37,6 +38,7 @@ describe("saveConventionDraftFromConventionSchema schema validation", () => {
       },
     },
     {
+      mode: "duplicate",
       senderEmail: "sender@example.com",
       recipientEmail: "recipient@example.com",
       details: "Some details",
@@ -75,6 +77,7 @@ describe("saveConventionDraftFromConventionSchema schema validation", () => {
 describe("saveConventionDraftFromConventionTemplateSchema schema validation", () => {
   it.each<SaveConventionDraftFromConventionTemplateDto>([
     {
+      mode: "duplicate",
       recipientEmail: "test@test.com",
       conventionDraft: {
         id: "aaaaac99-9c0b-1aaa-aa6d-6bb9bd38aaaa",
@@ -82,6 +85,7 @@ describe("saveConventionDraftFromConventionTemplateSchema schema validation", ()
       },
     },
     {
+      mode: "duplicate",
       recipientEmail: "test@example.com",
       details: "Some details",
       conventionDraft: {


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
