### PR TITLE
#4892 - Formulaire de demande d'accès à une convention archivée

### DIFF
--- a/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
@@ -3,7 +3,7 @@ import {
   type AbsoluteUrl,
   type AddConventionInput,
   AgencyDtoBuilder,
-  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestDto,
   AssessmentDtoBuilder,
   authExpiredMessage,
   CONVENTION_MANUAL_REMINDER_COOLDOWN_IN_HOURS,
@@ -530,7 +530,7 @@ describe("convention e2e", () => {
 
       inMemoryUow.userRepository.users = [basicUser];
 
-      const archivedConventionRequestDto: ArchivedConventionRequestFormDto = {
+      const archivedConventionRequestDto: ArchivedConventionRequestDto = {
         id: "11111111-1111-4111-8111-111111111111",
         conventionSearchMethod: "withConventionId",
         conventionId: convention.id,

--- a/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
@@ -3,7 +3,9 @@ import {
   type AbsoluteUrl,
   type AddConventionInput,
   AgencyDtoBuilder,
+  type ArchivedConventionRequestFormDto,
   AssessmentDtoBuilder,
+  authExpiredMessage,
   CONVENTION_MANUAL_REMINDER_COOLDOWN_IN_HOURS,
   ConnectedUserBuilder,
   type ConnectedUserJwtPayload,
@@ -37,6 +39,7 @@ import type { HttpClient } from "shared-routes";
 import { createSupertestSharedClient } from "shared-routes/supertest";
 import { match } from "ts-pattern";
 import { v4 as uuid } from "uuid";
+import { invalidTokenMessage } from "../../../../config/bootstrap/connectedUserAuthMiddleware";
 import { createAssessmentEntity } from "../../../../domains/convention/entities/AssessmentEntity";
 import type { BasicEventCrawler } from "../../../../domains/core/events/adapters/EventCrawlerImplementations";
 import type {
@@ -506,6 +509,103 @@ describe("convention e2e", () => {
           status: 404,
           message: errors.convention.notFound({ conventionId: unknownId })
             .message,
+        },
+      });
+    });
+  });
+
+  describe(`${displayRouteName(
+    conventionMagicLinkRoutes.createArchivedConventionRequest,
+  )} submits an archived convention access request`, () => {
+    it("201 - succeeds with a valid request", async () => {
+      const basicUser = new ConnectedUserBuilder()
+        .withId("basic-user")
+        .buildUser();
+      const basicUserJwtPayload: ConnectedUserJwtPayload = {
+        version: currentJwtVersions.connectedUser,
+        iat: Date.now(),
+        exp: addDays(new Date(), 30).getTime(),
+        userId: basicUser.id,
+      };
+
+      inMemoryUow.userRepository.users = [basicUser];
+
+      const archivedConventionRequestDto: ArchivedConventionRequestFormDto = {
+        id: "11111111-1111-4111-8111-111111111111",
+        conventionSearchMethod: "withConventionId",
+        conventionId: convention.id,
+        reason: "legalDispute",
+      };
+
+      const response = await magicLinkRequest.createArchivedConventionRequest({
+        headers: {
+          authorization: generateConnectedUserJwt(basicUserJwtPayload),
+        },
+        body: archivedConventionRequestDto,
+      });
+
+      expectHttpResponseToEqual(response, {
+        status: 201,
+        body: "",
+      });
+
+      expectToEqual(
+        inMemoryUow.archivedConventionRequestRepository
+          .archivedConventionRequests,
+        {
+          [archivedConventionRequestDto.id]: {
+            ...archivedConventionRequestDto,
+            userId: basicUser.id,
+            createdAt: gateways.timeGateway.now().toISOString(),
+          },
+        },
+      );
+    });
+
+    it("401 - Invalid JWT", async () => {
+      const response = await magicLinkRequest.createArchivedConventionRequest({
+        headers: { authorization: "invalid-token" },
+        body: {
+          id: "11111111-1111-4111-8111-111111111111",
+          conventionSearchMethod: "withConventionId",
+          conventionId: convention.id,
+          reason: "legalDispute",
+        },
+      });
+
+      expectHttpResponseToEqual(response, {
+        status: 401,
+        body: {
+          status: 401,
+          message: invalidTokenMessage,
+        },
+      });
+    });
+
+    it("401 - Expired JWT", async () => {
+      const token = generateConnectedUserJwt(
+        {
+          userId: "basic-user",
+          version: currentJwtVersions.connectedUser,
+        },
+        0,
+      );
+
+      const response = await magicLinkRequest.createArchivedConventionRequest({
+        headers: { authorization: token },
+        body: {
+          id: "11111111-1111-4111-8111-111111111111",
+          conventionSearchMethod: "withConventionId",
+          conventionId: convention.id,
+          reason: "legalDispute",
+        },
+      });
+
+      expectHttpResponseToEqual(response, {
+        status: 401,
+        body: {
+          status: 401,
+          message: authExpiredMessage(),
         },
       });
     });

--- a/back/src/adapters/primary/routers/magicLink/createMagicLinkRouter.ts
+++ b/back/src/adapters/primary/routers/magicLink/createMagicLinkRouter.ts
@@ -61,6 +61,17 @@ export const createMagicLinkRouter = (deps: AppDependencies) => {
       ),
   );
 
+  sharedRouter.createArchivedConventionRequest(
+    deps.connectedUserAuthMiddleware,
+    (req, res) =>
+      sendHttpResponse(req, res.status(201), () =>
+        deps.useCases.addArchivedConventionRequest.execute(
+          req.body,
+          getGenericAuthOrThrow(req.payloads?.currentUser),
+        ),
+      ),
+  );
+
   sharedRouter.updateConvention(
     deps.conventionMagicLinkAuthMiddleware,
     (req, res) =>

--- a/back/src/adapters/primary/routers/magicLink/createMagicLinkRouter.ts
+++ b/back/src/adapters/primary/routers/magicLink/createMagicLinkRouter.ts
@@ -65,7 +65,7 @@ export const createMagicLinkRouter = (deps: AppDependencies) => {
     deps.connectedUserAuthMiddleware,
     (req, res) =>
       sendHttpResponse(req, res.status(201), () =>
-        deps.useCases.addArchivedConventionRequest.execute(
+        deps.useCases.createArchivedConventionRequest.execute(
           req.body,
           getGenericAuthOrThrow(req.payloads?.currentUser),
         ),

--- a/back/src/adapters/primary/routers/technical/technicalRouter.e2e.test.ts
+++ b/back/src/adapters/primary/routers/technical/technicalRouter.e2e.test.ts
@@ -415,6 +415,7 @@ describe("technical router", () => {
       }),
       enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
       enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+      enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
     };
     it(`${displayRouteName(
       technicalRoutes.featureFlags,

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -27,6 +27,7 @@ import { makeGetUsers } from "../../domains/connected-users/use-cases/GetUsers";
 import { makeLinkFranceTravailUsersToTheirAgencies } from "../../domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies";
 import { makeRejectUserForAgency } from "../../domains/connected-users/use-cases/RejectUserForAgency";
 import { makeUpdateUserForAgency } from "../../domains/connected-users/use-cases/UpdateUserForAgency";
+import { makeAddArchivedConventionRequest } from "../../domains/convention/use-cases/AddArchivedConventionRequest";
 import { makeAddConvention } from "../../domains/convention/use-cases/AddConvention";
 import { makeAddValidatedConventionNps } from "../../domains/convention/use-cases/AddValidatedConventionNps";
 import { makeBroadcastConventionAgain } from "../../domains/convention/use-cases/broadcast/BroadcastConventionAgain";
@@ -310,6 +311,13 @@ export const createUseCases = ({
     }),
 
     saveConventionDraft: makeSaveConventionDraft({
+      uowPerformer,
+      deps: {
+        createNewEvent,
+        timeGateway: gateways.timeGateway,
+      },
+    }),
+    addArchivedConventionRequest: makeAddArchivedConventionRequest({
       uowPerformer,
       deps: {
         createNewEvent,

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -27,13 +27,13 @@ import { makeGetUsers } from "../../domains/connected-users/use-cases/GetUsers";
 import { makeLinkFranceTravailUsersToTheirAgencies } from "../../domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies";
 import { makeRejectUserForAgency } from "../../domains/connected-users/use-cases/RejectUserForAgency";
 import { makeUpdateUserForAgency } from "../../domains/connected-users/use-cases/UpdateUserForAgency";
-import { makeAddArchivedConventionRequest } from "../../domains/convention/use-cases/AddArchivedConventionRequest";
 import { makeAddConvention } from "../../domains/convention/use-cases/AddConvention";
 import { makeAddValidatedConventionNps } from "../../domains/convention/use-cases/AddValidatedConventionNps";
 import { makeBroadcastConventionAgain } from "../../domains/convention/use-cases/broadcast/BroadcastConventionAgain";
 import { makeBroadcastToFranceTravailOnConventionUpdates } from "../../domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates";
 import { makeBroadcastToFranceTravailOrchestrator } from "../../domains/convention/use-cases/broadcast/BroadcastToFranceTravailOrchestrator";
 import { makeGetConventionsWithErroredBroadcastFeedback } from "../../domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback";
+import { makeCreateArchivedConventionRequest } from "../../domains/convention/use-cases/CreateArchivedConventionRequest";
 import { makeCreateAssessment } from "../../domains/convention/use-cases/CreateAssessment";
 import { makeCreateOrUpdateConventionTemplate } from "../../domains/convention/use-cases/CreateOrUpdateConventionTemplate";
 import { makeDeleteAssessment } from "../../domains/convention/use-cases/DeleteAssessment";
@@ -318,7 +318,7 @@ export const createUseCases = ({
         timeGateway: gateways.timeGateway,
       },
     }),
-    addArchivedConventionRequest: makeAddArchivedConventionRequest({
+    createArchivedConventionRequest: makeCreateArchivedConventionRequest({
       uowPerformer,
       deps: {
         createNewEvent,

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -74,6 +74,7 @@ import { makeNotifyToAgencyConventionSubmitted } from "../../domains/convention/
 import { makeNotifyUserAgencyRightChanged } from "../../domains/convention/use-cases/notifications/NotifyUserAgencyRightChanged";
 import { makeNotifyUserAgencyRightRejected } from "../../domains/convention/use-cases/notifications/NotifyUserAgencyRightRejected";
 import { makeNotifyUserThatAgencyRegistrationRequestWasReceived } from "../../domains/convention/use-cases/notifications/NotifyUserThatAgencyRegistrationRequestWasReceived";
+import { makeNotifyUserThatArchivedConventionRequestWasReceived } from "../../domains/convention/use-cases/notifications/NotifyUserThatArchivedConventionRequestWasReceived";
 import { makeMarkPartnersErroredConventionAsHandled } from "../../domains/convention/use-cases/partners-errored-convention/MarkPartnersErroredConventionAsHandled";
 import { makeRemoveConventionFTAdvisorIfAgencyIsNotFranceTravail } from "../../domains/convention/use-cases/RemoveConventionFTAdvisorIfAgencyIsNotFranceTravail";
 import { makeRenewConvention } from "../../domains/convention/use-cases/RenewConvention";
@@ -1272,6 +1273,13 @@ export const createUseCases = ({
           },
         },
       ),
+    notifyUserThatArchivedConventionRequestWasReceived:
+      makeNotifyUserThatArchivedConventionRequestWasReceived({
+        uowPerformer,
+        deps: {
+          saveNotificationAndRelatedEvent,
+        },
+      }),
     notifyToAgencyConventionSubmitted: makeNotifyToAgencyConventionSubmitted({
       uowPerformer,
       deps: {

--- a/back/src/config/pg/kysely/model/database.ts
+++ b/back/src/config/pg/kysely/model/database.ts
@@ -25,6 +25,7 @@ export interface Database {
   agency_groups: AgencyGroups;
   api_consumers_subscriptions: ApiConsumersSubscriptions;
   api_consumers: ApiConsumers;
+  archived_convention_requests: ArchivedConventionRequests;
   banned_establishments: BannedEstablishments;
   broadcast_feedbacks: BroadcastFeedbacks;
   convention_external_ids: ConventionExternalIds;
@@ -221,6 +222,20 @@ interface Agencies extends WithAcquisition {
   phone_id: number;
   contact_email: string;
   delegation_info: Json | null;
+}
+
+interface ArchivedConventionRequests {
+  id: string;
+  user_id: string;
+  created_at: Timestamp;
+  convention_id: string | null;
+  beneficiary_first_name: string | null;
+  beneficiary_last_name: string | null;
+  siret: string | null;
+  immersion_date: string | null;
+  immersion_appellation_code: number | null;
+  reason: string;
+  other_reason: string | null;
 }
 
 interface BannedEstablishments {

--- a/back/src/config/pg/migrations/1785492647604_add-archived-convention-requests-table.ts
+++ b/back/src/config/pg/migrations/1785492647604_add-archived-convention-requests-table.ts
@@ -41,8 +41,18 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       },
     },
   );
+
+  await pgm.db.query(`
+    INSERT INTO feature_flags(flag_name, is_active, kind)
+    VALUES ('enableRequestArchivedConvention', false, 'boolean')
+  `);
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    DELETE FROM feature_flags
+    WHERE flag_name = 'enableRequestArchivedConvention';
+  `);
+
   pgm.dropTable("archived_convention_requests");
 }

--- a/back/src/config/pg/migrations/1785492647604_add-archived-convention-requests-table.ts
+++ b/back/src/config/pg/migrations/1785492647604_add-archived-convention-requests-table.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable("archived_convention_requests", {
+    id: { type: "uuid", primaryKey: true },
+    user_id: { type: "uuid", notNull: true },
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("now()"),
+    },
+    convention_id: { type: "uuid" },
+    beneficiary_first_name: { type: "varchar(255)" },
+    beneficiary_last_name: { type: "varchar(255)" },
+    siret: { type: "char(14)" },
+    immersion_date: { type: "varchar(255)" },
+    immersion_appellation_code: { type: "integer" },
+    reason: { type: "varchar(100)", notNull: true },
+    other_reason: { type: "varchar(100)" },
+  });
+
+  pgm.addConstraint(
+    "archived_convention_requests",
+    "archived_convention_requests_user_id_fk",
+    {
+      foreignKeys: {
+        columns: "user_id",
+        references: "users(id)",
+      },
+    },
+  );
+
+  pgm.addConstraint(
+    "archived_convention_requests",
+    "archived_convention_requests_immersion_appellation_code_fk",
+    {
+      foreignKeys: {
+        columns: "immersion_appellation_code",
+        references: "public_appellations_data(ogr_appellation)",
+      },
+    },
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable("archived_convention_requests");
+}

--- a/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
@@ -1,0 +1,28 @@
+import type { ArchivedConventionRequestId } from "shared";
+import type {
+  ArchivedConventionRequestEntity,
+  ArchivedConventionRequestRepository,
+} from "../ports/ArchivedConventionRequestRepository";
+
+export class InMemoryArchivedConventionRequestRepository
+  implements ArchivedConventionRequestRepository
+{
+  public archivedConventionRequests: Record<
+    ArchivedConventionRequestId,
+    ArchivedConventionRequestEntity
+  > = {};
+
+  public async getAll(): Promise<ArchivedConventionRequestEntity[]> {
+    return Object.values(this.archivedConventionRequests).sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }
+
+  public async save(
+    archivedConventionRequest: ArchivedConventionRequestEntity,
+  ): Promise<void> {
+    this.archivedConventionRequests[archivedConventionRequest.id] =
+      archivedConventionRequest;
+  }
+}

--- a/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
@@ -19,6 +19,12 @@ export class InMemoryArchivedConventionRequestRepository
     );
   }
 
+  public async getById(
+    id: ArchivedConventionRequestId,
+  ): Promise<ArchivedConventionRequestEntity | undefined> {
+    return this.archivedConventionRequests[id];
+  }
+
   public async save(
     archivedConventionRequest: ArchivedConventionRequestEntity,
   ): Promise<void> {

--- a/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
@@ -1,8 +1,9 @@
 import type { ArchivedConventionRequestId } from "shared";
-import type {
-  ArchivedConventionRequestEntity,
-  ArchivedConventionRequestRepository,
-} from "../ports/ArchivedConventionRequestRepository";
+import {
+  type ArchivedConventionRequestEntity,
+  toArchivedConventionRequestEntity,
+} from "../entities/ArchivedConventionRequestEntity";
+import type { ArchivedConventionRequestRepository } from "../ports/ArchivedConventionRequestRepository";
 
 export class InMemoryArchivedConventionRequestRepository
   implements ArchivedConventionRequestRepository
@@ -15,7 +16,35 @@ export class InMemoryArchivedConventionRequestRepository
   public async getById(
     id: ArchivedConventionRequestId,
   ): Promise<ArchivedConventionRequestEntity | undefined> {
-    return this.archivedConventionRequests[id];
+    const request = this.archivedConventionRequests[id];
+    if (!request) return undefined;
+
+    return toArchivedConventionRequestEntity({
+      id: request.id,
+      user_id: request.userId,
+      created_at: new Date(request.createdAt),
+      ...(request.conventionSearchMethod === "withConventionDetails"
+        ? {
+            convention_id: null,
+            beneficiary_first_name: request.beneficiaryFirstName ?? null,
+            beneficiary_last_name: request.beneficiaryLastName ?? null,
+            siret: request.siret ?? null,
+            immersion_date: request.immersionDate ?? null,
+            immersion_appellation_code: request.immersionAppellationCode
+              ? Number.parseInt(request.immersionAppellationCode, 10)
+              : null,
+          }
+        : {
+            convention_id: request.conventionId,
+            beneficiary_first_name: null,
+            beneficiary_last_name: null,
+            siret: null,
+            immersion_date: null,
+            immersion_appellation_code: null,
+          }),
+      reason: request.reason,
+      other_reason: request.otherReason ?? null,
+    });
   }
 
   public async save(

--- a/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/InMemoryArchivedConventionRequestRepository.ts
@@ -12,13 +12,6 @@ export class InMemoryArchivedConventionRequestRepository
     ArchivedConventionRequestEntity
   > = {};
 
-  public async getAll(): Promise<ArchivedConventionRequestEntity[]> {
-    return Object.values(this.archivedConventionRequests).sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
-  }
-
   public async getById(
     id: ArchivedConventionRequestId,
   ): Promise<ArchivedConventionRequestEntity | undefined> {

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
@@ -1,19 +1,29 @@
 import type { Pool } from "pg";
-import { ConnectedUserBuilder, expectToEqual } from "shared";
+import {
+  type ArchivedConventionRequestReason,
+  ConnectedUserBuilder,
+  errors,
+  expectPromiseToFailWithError,
+  expectToEqual,
+} from "shared";
 import {
   type KyselyDb,
   makeKyselyDb,
 } from "../../../config/pg/kysely/kyselyUtils";
 import { makeTestPgPool } from "../../../config/pg/pgPool";
 import { PgUserRepository } from "../../core/authentication/connected-user/adapters/PgUserRepository";
-import type { ArchivedConventionRequestEntity } from "../ports/ArchivedConventionRequestRepository";
+import type { ArchivedConventionRequestEntity } from "../entities/ArchivedConventionRequestEntity";
+import { InMemoryArchivedConventionRequestRepository } from "./InMemoryArchivedConventionRequestRepository";
 import { PgArchivedConventionRequestRepository } from "./PgArchivedConventionRequestRepository";
 
-describe("PgArchivedConventionRequestRepository", () => {
+const adapters: ("InMemory" | "Pg")[] = ["Pg", "InMemory"];
+
+describe.each(adapters)("%s ArchivedConventionRequestRepository", (adapter) => {
   let pool: Pool;
   let db: KyselyDb;
-  let repository: PgArchivedConventionRequestRepository;
-  let userRepository: PgUserRepository;
+  let repository:
+    | PgArchivedConventionRequestRepository
+    | InMemoryArchivedConventionRequestRepository;
 
   const user = new ConnectedUserBuilder()
     .withId("11111111-1111-4111-8111-111111111111")
@@ -26,7 +36,7 @@ describe("PgArchivedConventionRequestRepository", () => {
     romeLabel: "Boulangerie - viennoiserie",
   };
 
-  beforeAll(async () => {
+  beforeAll(() => {
     pool = makeTestPgPool();
     db = makeKyselyDb(pool);
   });
@@ -36,47 +46,108 @@ describe("PgArchivedConventionRequestRepository", () => {
   });
 
   beforeEach(async () => {
-    await db.deleteFrom("archived_convention_requests").execute();
-    await db.deleteFrom("users").where("id", "=", user.id).execute();
+    repository = new InMemoryArchivedConventionRequestRepository();
+    adapter === "Pg"
+      ? new PgArchivedConventionRequestRepository(db)
+      : new InMemoryArchivedConventionRequestRepository();
 
-    userRepository = new PgUserRepository(db);
-    repository = new PgArchivedConventionRequestRepository(db);
-
-    await userRepository.save(user);
+    if (adapter === "Pg") {
+      await db.deleteFrom("archived_convention_requests").execute();
+      await db.deleteFrom("users").where("id", "=", user.id).execute();
+      await new PgUserRepository(db).save(user);
+    }
   });
 
-  it("saves a request with conventionSearchMethod = withConventionId", async () => {
-    const request: ArchivedConventionRequestEntity = {
-      id: "11111111-1111-4111-8111-111111111111",
-      userId: user.id,
-      createdAt,
-      conventionSearchMethod: "withConventionId",
-      conventionId: "22222222-2222-4222-8222-222222222222",
-      reason: "legalDispute",
-    };
+  describe("save", () => {
+    it("saves a request with conventionSearchMethod = withConventionId", async () => {
+      const request: ArchivedConventionRequestEntity = {
+        id: "11111111-1111-4111-8111-111111111111",
+        userId: user.id,
+        createdAt,
+        conventionSearchMethod: "withConventionId",
+        conventionId: "22222222-2222-4222-8222-222222222222",
+        reason: "legalDispute",
+      };
 
-    await repository.save(request);
+      await repository.save(request);
 
-    expectToEqual(await repository.getById(request.id), request);
+      expectToEqual(await repository.getById(request.id), request);
+    });
+
+    it("saves a request with conventionSearchMethod = withConventionDetails", async () => {
+      const request: ArchivedConventionRequestEntity = {
+        userId: user.id,
+        createdAt,
+        id: "33333333-3333-4333-8333-333333333333",
+        conventionSearchMethod: "withConventionDetails",
+        beneficiaryFirstName: "Jean",
+        beneficiaryLastName: "Dupont",
+        siret: "12345678901234",
+        immersionDate: "2024-01-15",
+        immersionAppellationCode: immersionAppellation.appellationCode,
+        reason: "other",
+        otherReason: "Motif personnalisé pour la demande",
+      };
+
+      await repository.save(request);
+
+      expectToEqual(await repository.getById(request.id), request);
+    });
   });
 
-  it("saves a request with conventionSearchMethod = withConventionDetails", async () => {
-    const request: ArchivedConventionRequestEntity = {
-      userId: user.id,
-      createdAt,
-      id: "33333333-3333-4333-8333-333333333333",
-      conventionSearchMethod: "withConventionDetails",
-      beneficiaryFirstName: "Jean",
-      beneficiaryLastName: "Dupont",
-      siret: "12345678901234",
-      immersionDate: "2024-01-15",
-      immersionAppellationCode: immersionAppellation.appellationCode,
-      reason: "other",
-      otherReason: "Motif personnalisé pour la demande",
-    };
+  describe("getById", () => {
+    it("returns undefined when request does not exist", async () => {
+      expectToEqual(
+        await repository.getById("99999999-9999-4999-8999-999999999999"),
+        undefined,
+      );
+    });
 
-    await repository.save(request);
+    it("throws when request details are incomplete", async () => {
+      const id = "44444444-4444-4444-8444-444444444444";
 
-    expectToEqual(await repository.getById(request.id), request);
+      const request: ArchivedConventionRequestEntity = {
+        userId: user.id,
+        createdAt,
+        id,
+        conventionSearchMethod: "withConventionDetails",
+        immersionAppellationCode: immersionAppellation.appellationCode,
+        reason: "other",
+      } as ArchivedConventionRequestEntity; //intentionally force as ArchivedConventionRequestEntity to test incomplete request
+
+      await repository.save(request);
+
+      await expectPromiseToFailWithError(
+        repository.getById(id),
+        errors.archivedConventionRequest.incomplete({ id }),
+      );
+    });
+
+    it("throws when reason is unknown", async () => {
+      const id = "55555555-5555-4555-8555-555555555555";
+      const unknownReason = "not-a-valid-reason";
+
+      const request: ArchivedConventionRequestEntity = {
+        userId: user.id,
+        createdAt,
+        id,
+        conventionSearchMethod: "withConventionDetails",
+        beneficiaryFirstName: "Jean",
+        beneficiaryLastName: "Dupont",
+        siret: "12345678901234",
+        immersionDate: "2024-01-15",
+        immersionAppellationCode: immersionAppellation.appellationCode,
+        reason: unknownReason as ArchivedConventionRequestReason, //intentionally force as ArchivedConventionRequestEntity to test invalid reason
+      };
+
+      await repository.save(request);
+
+      await expectPromiseToFailWithError(
+        repository.getById(id),
+        errors.archivedConventionRequest.unknownReason({
+          reason: unknownReason,
+        }),
+      );
+    });
   });
 });

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
@@ -1,0 +1,111 @@
+import type { Pool } from "pg";
+import { ConnectedUserBuilder, expectToEqual } from "shared";
+import {
+  type KyselyDb,
+  makeKyselyDb,
+} from "../../../config/pg/kysely/kyselyUtils";
+import { makeTestPgPool } from "../../../config/pg/pgPool";
+import { PgUserRepository } from "../../core/authentication/connected-user/adapters/PgUserRepository";
+import type { ArchivedConventionRequestEntity } from "../ports/ArchivedConventionRequestRepository";
+import { PgArchivedConventionRequestRepository } from "./PgArchivedConventionRequestRepository";
+
+describe("PgArchivedConventionRequestRepository", () => {
+  let pool: Pool;
+  let db: KyselyDb;
+  let repository: PgArchivedConventionRequestRepository;
+  let userRepository: PgUserRepository;
+
+  const user = new ConnectedUserBuilder()
+    .withId("11111111-1111-4111-8111-111111111111")
+    .buildUser();
+  const createdAt = "2024-06-01T12:00:00.000Z";
+  const immersionAppellation = {
+    appellationCode: "11573",
+    appellationLabel: "Boulanger / Boulangère",
+    romeCode: "D1102",
+    romeLabel: "Boulangerie - viennoiserie",
+  };
+
+  beforeAll(async () => {
+    pool = makeTestPgPool();
+    db = makeKyselyDb(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom("archived_convention_requests").execute();
+    await db.deleteFrom("users").where("id", "=", user.id).execute();
+
+    userRepository = new PgUserRepository(db);
+    repository = new PgArchivedConventionRequestRepository(db);
+
+    await userRepository.save(user);
+  });
+
+  it("saves a request with conventionSearchMethod = withConventionId", async () => {
+    const request: ArchivedConventionRequestEntity = {
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: user.id,
+      createdAt,
+      conventionSearchMethod: "withConventionId",
+      conventionId: "22222222-2222-4222-8222-222222222222",
+      reason: "legalDispute",
+    };
+
+    await repository.save(request);
+
+    expectToEqual(await repository.getAll(), [request]);
+  });
+
+  it("saves a request with conventionSearchMethod = withConventionDetails", async () => {
+    const request: ArchivedConventionRequestEntity = {
+      userId: user.id,
+      createdAt,
+      id: "33333333-3333-4333-8333-333333333333",
+      conventionSearchMethod: "withConventionDetails",
+      beneficiaryFirstName: "Jean",
+      beneficiaryLastName: "Dupont",
+      siret: "12345678901234",
+      immersionDate: "2024-01-15",
+      immersionAppellationCode: immersionAppellation.appellationCode,
+      reason: "other",
+      otherReason: "Motif personnalisé pour la demande",
+    };
+
+    await repository.save(request);
+
+    expectToEqual(await repository.getAll(), [request]);
+  });
+
+  it("returns all requests sorted by createdAt descending", async () => {
+    const olderRequest: ArchivedConventionRequestEntity = {
+      id: "11111111-1111-4111-8111-111111111111",
+      userId: user.id,
+      createdAt: "2024-06-01T12:00:00.000Z",
+      conventionSearchMethod: "withConventionId",
+      conventionId: "22222222-2222-4222-8222-222222222222",
+      reason: "legalDispute",
+    };
+    const newerRequest: ArchivedConventionRequestEntity = {
+      id: "33333333-3333-4333-8333-333333333333",
+      userId: user.id,
+      createdAt: "2024-06-02T12:00:00.000Z",
+      conventionSearchMethod: "withConventionDetails",
+      beneficiaryFirstName: "Jean",
+      beneficiaryLastName: "Dupont",
+      siret: "12345678901234",
+      immersionDate: "2024-01-15",
+      immersionAppellationCode: immersionAppellation.appellationCode,
+      reason: "other",
+      otherReason: "Motif personnalisé pour la demande",
+    };
+
+    await repository.save(olderRequest);
+    await repository.save(newerRequest);
+
+    expectToEqual(await repository.getAll(), [newerRequest, olderRequest]);
+  });
+});

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.integration.test.ts
@@ -57,7 +57,7 @@ describe("PgArchivedConventionRequestRepository", () => {
 
     await repository.save(request);
 
-    expectToEqual(await repository.getAll(), [request]);
+    expectToEqual(await repository.getById(request.id), request);
   });
 
   it("saves a request with conventionSearchMethod = withConventionDetails", async () => {
@@ -77,35 +77,6 @@ describe("PgArchivedConventionRequestRepository", () => {
 
     await repository.save(request);
 
-    expectToEqual(await repository.getAll(), [request]);
-  });
-
-  it("returns all requests sorted by createdAt descending", async () => {
-    const olderRequest: ArchivedConventionRequestEntity = {
-      id: "11111111-1111-4111-8111-111111111111",
-      userId: user.id,
-      createdAt: "2024-06-01T12:00:00.000Z",
-      conventionSearchMethod: "withConventionId",
-      conventionId: "22222222-2222-4222-8222-222222222222",
-      reason: "legalDispute",
-    };
-    const newerRequest: ArchivedConventionRequestEntity = {
-      id: "33333333-3333-4333-8333-333333333333",
-      userId: user.id,
-      createdAt: "2024-06-02T12:00:00.000Z",
-      conventionSearchMethod: "withConventionDetails",
-      beneficiaryFirstName: "Jean",
-      beneficiaryLastName: "Dupont",
-      siret: "12345678901234",
-      immersionDate: "2024-01-15",
-      immersionAppellationCode: immersionAppellation.appellationCode,
-      reason: "other",
-      otherReason: "Motif personnalisé pour la demande",
-    };
-
-    await repository.save(olderRequest);
-    await repository.save(newerRequest);
-
-    expectToEqual(await repository.getAll(), [newerRequest, olderRequest]);
+    expectToEqual(await repository.getById(request.id), request);
   });
 });

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
@@ -1,28 +1,10 @@
-import type {
-  ArchivedConventionRequestId,
-  ArchivedConventionRequestReason,
-  ArchivedConventionRequestReasonFields,
-} from "shared";
-import { archivedConventionRequestReasons, errors } from "shared";
+import type { ArchivedConventionRequestId } from "shared";
 import type { KyselyDb } from "../../../config/pg/kysely/kyselyUtils";
-import type {
-  ArchivedConventionRequestEntity,
-  ArchivedConventionRequestRepository,
-} from "../ports/ArchivedConventionRequestRepository";
-
-type ArchivedConventionRequestRow = {
-  id: string;
-  user_id: string;
-  created_at: Date;
-  convention_id: string | null;
-  beneficiary_first_name: string | null;
-  beneficiary_last_name: string | null;
-  siret: string | null;
-  immersion_date: string | null;
-  immersion_appellation_code: number | null;
-  reason: string;
-  other_reason: string | null;
-};
+import {
+  type ArchivedConventionRequestEntity,
+  toArchivedConventionRequestEntity,
+} from "../entities/ArchivedConventionRequestEntity";
+import type { ArchivedConventionRequestRepository } from "../ports/ArchivedConventionRequestRepository";
 
 export class PgArchivedConventionRequestRepository
   implements ArchivedConventionRequestRepository
@@ -81,60 +63,3 @@ export class PgArchivedConventionRequestRepository
       .execute();
   }
 }
-
-const isArchivedConventionRequestReason = (
-  reason: string,
-): reason is ArchivedConventionRequestReason =>
-  archivedConventionRequestReasons.some((value) => value === reason);
-
-const toArchivedConventionRequestEntity = (
-  row: ArchivedConventionRequestRow,
-): ArchivedConventionRequestEntity => {
-  if (!isArchivedConventionRequestReason(row.reason))
-    throw errors.archivedConventionRequest.unknownReason({
-      reason: row.reason,
-    });
-
-  const reasonFields: ArchivedConventionRequestReasonFields =
-    row.reason === "other"
-      ? {
-          reason: "other",
-          otherReason: row.other_reason ?? "",
-        }
-      : { reason: row.reason };
-
-  const common = {
-    id: row.id,
-    userId: row.user_id,
-    createdAt: row.created_at.toISOString(),
-    ...reasonFields,
-  };
-
-  if (row.convention_id)
-    return {
-      ...common,
-      conventionSearchMethod: "withConventionId",
-      conventionId: row.convention_id,
-    };
-
-  if (
-    !row.beneficiary_first_name ||
-    !row.beneficiary_last_name ||
-    !row.siret ||
-    !row.immersion_date ||
-    !row.immersion_appellation_code
-  )
-    throw errors.archivedConventionRequest.incomplete({
-      id: row.id,
-    });
-
-  return {
-    ...common,
-    conventionSearchMethod: "withConventionDetails",
-    beneficiaryFirstName: row.beneficiary_first_name,
-    beneficiaryLastName: row.beneficiary_last_name,
-    siret: row.siret,
-    immersionDate: row.immersion_date,
-    immersionAppellationCode: row.immersion_appellation_code.toString(),
-  };
-};

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
@@ -29,16 +29,6 @@ export class PgArchivedConventionRequestRepository
 {
   constructor(private readonly transaction: KyselyDb) {}
 
-  public async getAll(): Promise<ArchivedConventionRequestEntity[]> {
-    const rows = await this.transaction
-      .selectFrom("archived_convention_requests")
-      .selectAll()
-      .orderBy("archived_convention_requests.created_at", "desc")
-      .execute();
-
-    return rows.map(toArchivedConventionRequestEntity);
-  }
-
   public async getById(
     id: ArchivedConventionRequestId,
   ): Promise<ArchivedConventionRequestEntity | undefined> {

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
@@ -1,0 +1,137 @@
+import type {
+  ArchivedConventionRequestReason,
+  ArchivedConventionRequestReasonFields,
+} from "shared";
+import { archivedConventionRequestReasons, errors } from "shared";
+import type { KyselyDb } from "../../../config/pg/kysely/kyselyUtils";
+import type {
+  ArchivedConventionRequestEntity,
+  ArchivedConventionRequestRepository,
+} from "../ports/ArchivedConventionRequestRepository";
+
+type ArchivedConventionRequestRow = {
+  id: string;
+  user_id: string;
+  created_at: Date;
+  convention_id: string | null;
+  beneficiary_first_name: string | null;
+  beneficiary_last_name: string | null;
+  siret: string | null;
+  immersion_date: string | null;
+  immersion_appellation_code: number | null;
+  reason: string;
+  other_reason: string | null;
+};
+
+export class PgArchivedConventionRequestRepository
+  implements ArchivedConventionRequestRepository
+{
+  constructor(private readonly transaction: KyselyDb) {}
+
+  public async getAll(): Promise<ArchivedConventionRequestEntity[]> {
+    const rows = await this.transaction
+      .selectFrom("archived_convention_requests")
+      .selectAll()
+      .orderBy("archived_convention_requests.created_at", "desc")
+      .execute();
+
+    return rows.map(toArchivedConventionRequestEntity);
+  }
+
+  public async save(
+    archivedConventionRequest: ArchivedConventionRequestEntity,
+  ): Promise<void> {
+    const commonValues = {
+      id: archivedConventionRequest.id,
+      user_id: archivedConventionRequest.userId,
+      created_at: new Date(archivedConventionRequest.createdAt),
+      reason: archivedConventionRequest.reason,
+      other_reason: archivedConventionRequest.otherReason,
+    };
+
+    if (
+      archivedConventionRequest.conventionSearchMethod === "withConventionId"
+    ) {
+      await this.transaction
+        .insertInto("archived_convention_requests")
+        .values({
+          ...commonValues,
+          convention_id: archivedConventionRequest.conventionId,
+        })
+        .execute();
+      return;
+    }
+
+    await this.transaction
+      .insertInto("archived_convention_requests")
+      .values({
+        ...commonValues,
+        beneficiary_first_name: archivedConventionRequest.beneficiaryFirstName,
+        beneficiary_last_name: archivedConventionRequest.beneficiaryLastName,
+        siret: archivedConventionRequest.siret,
+        immersion_date: archivedConventionRequest.immersionDate,
+        immersion_appellation_code: Number.parseInt(
+          archivedConventionRequest.immersionAppellationCode,
+          10,
+        ),
+      })
+      .execute();
+  }
+}
+
+const isArchivedConventionRequestReason = (
+  reason: string,
+): reason is ArchivedConventionRequestReason =>
+  archivedConventionRequestReasons.some((value) => value === reason);
+
+const toArchivedConventionRequestEntity = (
+  row: ArchivedConventionRequestRow,
+): ArchivedConventionRequestEntity => {
+  if (!isArchivedConventionRequestReason(row.reason))
+    throw errors.archivedConventionRequest.unknownReason({
+      reason: row.reason,
+    });
+
+  const reasonFields: ArchivedConventionRequestReasonFields =
+    row.reason === "other"
+      ? {
+          reason: "other",
+          otherReason: row.other_reason ?? "",
+        }
+      : { reason: row.reason };
+
+  const common = {
+    id: row.id,
+    userId: row.user_id,
+    createdAt: row.created_at.toISOString(),
+    ...reasonFields,
+  };
+
+  if (row.convention_id)
+    return {
+      ...common,
+      conventionSearchMethod: "withConventionId",
+      conventionId: row.convention_id,
+    };
+
+  if (
+    !row.beneficiary_first_name ||
+    !row.beneficiary_last_name ||
+    !row.siret ||
+    !row.immersion_date ||
+    !row.immersion_appellation_code
+  )
+    throw errors.archivedConventionRequest.incomplete({
+      id: row.id,
+    });
+
+  return {
+    ...common,
+    conventionSearchMethod: "withConventionDetails",
+    beneficiaryFirstName: row.beneficiary_first_name,
+    beneficiaryLastName: row.beneficiary_last_name,
+    siret: row.siret,
+    immersionDate: row.immersion_date,
+    immersionAppellationCode: row.immersion_appellation_code.toString(),
+  };
+};

--- a/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/adapters/PgArchivedConventionRequestRepository.ts
@@ -1,4 +1,5 @@
 import type {
+  ArchivedConventionRequestId,
   ArchivedConventionRequestReason,
   ArchivedConventionRequestReasonFields,
 } from "shared";
@@ -36,6 +37,18 @@ export class PgArchivedConventionRequestRepository
       .execute();
 
     return rows.map(toArchivedConventionRequestEntity);
+  }
+
+  public async getById(
+    id: ArchivedConventionRequestId,
+  ): Promise<ArchivedConventionRequestEntity | undefined> {
+    const row = await this.transaction
+      .selectFrom("archived_convention_requests")
+      .selectAll()
+      .where("archived_convention_requests.id", "=", id)
+      .executeTakeFirst();
+
+    return row ? toArchivedConventionRequestEntity(row) : undefined;
   }
 
   public async save(

--- a/back/src/domains/convention/entities/ArchivedConventionRequestEntity.ts
+++ b/back/src/domains/convention/entities/ArchivedConventionRequestEntity.ts
@@ -1,0 +1,117 @@
+import type {
+  AppellationCode,
+  ArchivedConventionRequestReason,
+  ArchivedConventionRequestReasonFields,
+  ArchivedConventionRequestWithConventionDetailsDto,
+  ArchivedConventionRequestWithConventionIdDto,
+  DateString,
+  UserId,
+  ZodSchemaWithInputMatchingOutput,
+} from "shared";
+import {
+  appellationCodeSchema,
+  archivedConventionRequestReasons,
+  errors,
+  firstnameMandatorySchema,
+  lastnameMandatorySchema,
+  siretSchema,
+  zStringMinLength1Max255,
+} from "shared";
+import { z } from "zod";
+
+export type ArchivedConventionRequestEntity = (
+  | ArchivedConventionRequestWithConventionIdDto
+  | (Omit<
+      ArchivedConventionRequestWithConventionDetailsDto,
+      "immersionAppellation"
+    > & {
+      immersionAppellationCode: AppellationCode;
+    })
+) & {
+  userId: UserId;
+  createdAt: DateString;
+};
+
+type ArchivedConventionRequestRow = {
+  id: string;
+  user_id: string;
+  created_at: Date;
+  convention_id: string | null;
+  beneficiary_first_name: string | null;
+  beneficiary_last_name: string | null;
+  siret: string | null;
+  immersion_date: string | null;
+  immersion_appellation_code: number | null;
+  reason: string;
+  other_reason: string | null;
+};
+
+const archivedConventionRequestDetailsFieldsSchema: ZodSchemaWithInputMatchingOutput<
+  Omit<
+    ArchivedConventionRequestWithConventionDetailsDto,
+    "immersionAppellation" | "reason" | "id" | "conventionSearchMethod"
+  > & {
+    immersionAppellationCode: AppellationCode;
+  }
+> = z.object({
+  beneficiaryFirstName: firstnameMandatorySchema,
+  beneficiaryLastName: lastnameMandatorySchema,
+  siret: siretSchema,
+  immersionDate: zStringMinLength1Max255,
+  immersionAppellationCode: appellationCodeSchema,
+});
+
+const isArchivedConventionRequestReason = (
+  reason: string,
+): reason is ArchivedConventionRequestReason =>
+  archivedConventionRequestReasons.some((value) => value === reason);
+
+export const toArchivedConventionRequestEntity = (
+  row: ArchivedConventionRequestRow,
+): ArchivedConventionRequestEntity => {
+  if (!isArchivedConventionRequestReason(row.reason))
+    throw errors.archivedConventionRequest.unknownReason({
+      reason: row.reason,
+    });
+
+  const reasonFields: ArchivedConventionRequestReasonFields =
+    row.reason === "other"
+      ? {
+          reason: "other",
+          otherReason: row.other_reason ?? "",
+        }
+      : { reason: row.reason };
+
+  const common = {
+    id: row.id,
+    userId: row.user_id,
+    createdAt: row.created_at.toISOString(),
+    ...reasonFields,
+  };
+
+  if (row.convention_id)
+    return {
+      ...common,
+      conventionSearchMethod: "withConventionId",
+      conventionId: row.convention_id,
+    };
+
+  const parseResult = archivedConventionRequestDetailsFieldsSchema.safeParse({
+    beneficiaryFirstName: row.beneficiary_first_name,
+    beneficiaryLastName: row.beneficiary_last_name,
+    siret: row.siret,
+    immersionDate: row.immersion_date,
+    immersionAppellationCode: row.immersion_appellation_code?.toString(),
+  });
+
+  if (!parseResult.success)
+    throw errors.archivedConventionRequest.incomplete({
+      id: row.id,
+    });
+
+  return {
+    ...common,
+    conventionSearchMethod: "withConventionDetails",
+    ...parseResult.data,
+  };
+};

--- a/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
@@ -1,5 +1,6 @@
 import type {
   AppellationCode,
+  ArchivedConventionRequestId,
   ArchivedConventionRequestWithConventionDetailsFormDto,
   ArchivedConventionRequestWithConventionIdFormDto,
   DateString,
@@ -23,5 +24,8 @@ export interface ArchivedConventionRequestRepository {
   save: (
     archivedConventionRequest: ArchivedConventionRequestEntity,
   ) => Promise<void>;
+  getById: (
+    id: ArchivedConventionRequestId,
+  ) => Promise<ArchivedConventionRequestEntity | undefined>;
   getAll: () => Promise<ArchivedConventionRequestEntity[]>;
 }

--- a/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
@@ -1,0 +1,27 @@
+import type {
+  AppellationCode,
+  ArchivedConventionRequestWithConventionDetailsFormDto,
+  ArchivedConventionRequestWithConventionIdFormDto,
+  DateString,
+  UserId,
+} from "shared";
+
+export type ArchivedConventionRequestEntity = (
+  | ArchivedConventionRequestWithConventionIdFormDto
+  | (Omit<
+      ArchivedConventionRequestWithConventionDetailsFormDto,
+      "immersionAppellation"
+    > & {
+      immersionAppellationCode: AppellationCode;
+    })
+) & {
+  userId: UserId;
+  createdAt: DateString;
+};
+
+export interface ArchivedConventionRequestRepository {
+  save: (
+    archivedConventionRequest: ArchivedConventionRequestEntity,
+  ) => Promise<void>;
+  getAll: () => Promise<ArchivedConventionRequestEntity[]>;
+}

--- a/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
@@ -1,24 +1,5 @@
-import type {
-  AppellationCode,
-  ArchivedConventionRequestId,
-  ArchivedConventionRequestWithConventionDetailsFormDto,
-  ArchivedConventionRequestWithConventionIdFormDto,
-  DateString,
-  UserId,
-} from "shared";
-
-export type ArchivedConventionRequestEntity = (
-  | ArchivedConventionRequestWithConventionIdFormDto
-  | (Omit<
-      ArchivedConventionRequestWithConventionDetailsFormDto,
-      "immersionAppellation"
-    > & {
-      immersionAppellationCode: AppellationCode;
-    })
-) & {
-  userId: UserId;
-  createdAt: DateString;
-};
+import type { ArchivedConventionRequestId } from "shared";
+import type { ArchivedConventionRequestEntity } from "../entities/ArchivedConventionRequestEntity";
 
 export interface ArchivedConventionRequestRepository {
   save: (

--- a/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
+++ b/back/src/domains/convention/ports/ArchivedConventionRequestRepository.ts
@@ -27,5 +27,4 @@ export interface ArchivedConventionRequestRepository {
   getById: (
     id: ArchivedConventionRequestId,
   ) => Promise<ArchivedConventionRequestEntity | undefined>;
-  getAll: () => Promise<ArchivedConventionRequestEntity[]>;
 }

--- a/back/src/domains/convention/use-cases/AddArchivedConventionRequest.ts
+++ b/back/src/domains/convention/use-cases/AddArchivedConventionRequest.ts
@@ -1,0 +1,52 @@
+import { archivedConventionRequestSchema, type ConnectedUser } from "shared";
+import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
+import { useCaseBuilder } from "../../core/useCaseBuilder";
+import type { ArchivedConventionRequestEntity } from "../ports/ArchivedConventionRequestRepository";
+
+export type AddArchivedConventionRequest = ReturnType<
+  typeof makeAddArchivedConventionRequest
+>;
+
+export const makeAddArchivedConventionRequest = useCaseBuilder(
+  "AddArchivedConventionRequest",
+)
+  .withInput(archivedConventionRequestSchema)
+  .withCurrentUser<ConnectedUser>()
+  .withDeps<{
+    createNewEvent: CreateNewEvent;
+    timeGateway: TimeGateway;
+  }>()
+  .build(async ({ uow, inputParams, currentUser, deps }) => {
+    const archivedConventionRequestEntity: ArchivedConventionRequestEntity =
+      inputParams.conventionSearchMethod === "withConventionId"
+        ? {
+            ...inputParams,
+            userId: currentUser.id,
+            createdAt: deps.timeGateway.now().toISOString(),
+          }
+        : {
+            ...inputParams,
+            immersionAppellationCode:
+              inputParams.immersionAppellation.appellationCode,
+            userId: currentUser.id,
+            createdAt: deps.timeGateway.now().toISOString(),
+          };
+
+    await uow.archivedConventionRequestRepository.save(
+      archivedConventionRequestEntity,
+    );
+
+    await uow.outboxRepository.save(
+      deps.createNewEvent({
+        topic: "ArchivedConventionRequestCreated",
+        payload: {
+          archivedConventionRequestId: inputParams.id,
+          triggeredBy: {
+            kind: "connected-user",
+            userId: currentUser.id,
+          },
+        },
+      }),
+    );
+  });

--- a/back/src/domains/convention/use-cases/AddArchivedConventionRequest.unit.test.ts
+++ b/back/src/domains/convention/use-cases/AddArchivedConventionRequest.unit.test.ts
@@ -1,0 +1,113 @@
+import {
+  type ArchivedConventionRequestFormDto,
+  type ConnectedUser,
+  ConnectedUserBuilder,
+  expectArraysToMatch,
+  expectToEqual,
+} from "shared";
+import {
+  type CreateNewEvent,
+  makeCreateNewEvent,
+} from "../../core/events/ports/EventBus";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
+import {
+  createInMemoryUow,
+  type InMemoryUnitOfWork,
+} from "../../core/unit-of-work/adapters/createInMemoryUow";
+import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
+import {
+  type AddArchivedConventionRequest,
+  makeAddArchivedConventionRequest,
+} from "./AddArchivedConventionRequest";
+
+describe("AddArchivedConventionRequest", () => {
+  let uow: InMemoryUnitOfWork;
+  let saveArchivedConventionRequest: AddArchivedConventionRequest;
+  let createNewEvent: CreateNewEvent;
+  let timeGateway: CustomTimeGateway;
+
+  const connectedUser: ConnectedUser = new ConnectedUserBuilder().build();
+  const now = new Date("2024-06-01T12:00:00.000Z");
+  const requestId = "11111111-1111-4111-8111-111111111111";
+
+  beforeEach(() => {
+    timeGateway = new CustomTimeGateway(now);
+    const uuidGenerator = new TestUuidGenerator();
+
+    uow = createInMemoryUow();
+    createNewEvent = makeCreateNewEvent({ timeGateway, uuidGenerator });
+    saveArchivedConventionRequest = makeAddArchivedConventionRequest({
+      uowPerformer: new InMemoryUowPerformer(uow),
+      deps: { createNewEvent, timeGateway },
+    });
+  });
+
+  it("saves an archived convention request with conventionSearchMethod = withConventionId", async () => {
+    const input: ArchivedConventionRequestFormDto = {
+      id: requestId,
+      conventionSearchMethod: "withConventionId",
+      conventionId: "22222222-2222-4222-8222-222222222222",
+      reason: "legalDispute",
+    };
+
+    await saveArchivedConventionRequest.execute(input, connectedUser);
+
+    expectToEqual(
+      uow.archivedConventionRequestRepository.archivedConventionRequests,
+      {
+        [requestId]: {
+          ...input,
+          userId: connectedUser.id,
+          createdAt: now.toISOString(),
+        },
+      },
+    );
+
+    expectArraysToMatch(uow.outboxRepository.events, [
+      {
+        topic: "ArchivedConventionRequestCreated",
+        payload: {
+          archivedConventionRequestId: requestId,
+          triggeredBy: {
+            kind: "connected-user",
+            userId: connectedUser.id,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("saves an archived convention request with conventionSearchMethod = withConventionDetails", async () => {
+    const input: ArchivedConventionRequestFormDto = {
+      id: requestId,
+      conventionSearchMethod: "withConventionDetails",
+      beneficiaryFirstName: "Jean",
+      beneficiaryLastName: "Dupont",
+      siret: "12345678901234",
+      immersionDate: "2024-01-15",
+      immersionAppellation: {
+        appellationCode: "11573",
+        appellationLabel: "Boulanger / Boulangère",
+        romeCode: "D1102",
+        romeLabel: "Boulangerie - viennoiserie",
+      },
+      reason: "other",
+      otherReason: "Motif personnalisé",
+    };
+
+    await saveArchivedConventionRequest.execute(input, connectedUser);
+
+    expectToEqual(
+      uow.archivedConventionRequestRepository.archivedConventionRequests[
+        requestId
+      ],
+      {
+        ...input,
+        immersionAppellationCode: input.immersionAppellation.appellationCode,
+        userId: connectedUser.id,
+        createdAt: now.toISOString(),
+      },
+    );
+  });
+});

--- a/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.ts
+++ b/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.ts
@@ -4,12 +4,12 @@ import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 import type { ArchivedConventionRequestEntity } from "../ports/ArchivedConventionRequestRepository";
 
-export type AddArchivedConventionRequest = ReturnType<
-  typeof makeAddArchivedConventionRequest
+export type CreateArchivedConventionRequest = ReturnType<
+  typeof makeCreateArchivedConventionRequest
 >;
 
-export const makeAddArchivedConventionRequest = useCaseBuilder(
-  "AddArchivedConventionRequest",
+export const makeCreateArchivedConventionRequest = useCaseBuilder(
+  "CreateArchivedConventionRequest",
 )
   .withInput(archivedConventionRequestSchema)
   .withCurrentUser<ConnectedUser>()

--- a/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.ts
+++ b/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.ts
@@ -2,7 +2,7 @@ import { archivedConventionRequestSchema, type ConnectedUser } from "shared";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
 import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
-import type { ArchivedConventionRequestEntity } from "../ports/ArchivedConventionRequestRepository";
+import type { ArchivedConventionRequestEntity } from "../entities/ArchivedConventionRequestEntity";
 
 export type CreateArchivedConventionRequest = ReturnType<
   typeof makeCreateArchivedConventionRequest

--- a/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.unit.test.ts
+++ b/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.unit.test.ts
@@ -17,13 +17,13 @@ import {
 import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
 import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
 import {
-  type AddArchivedConventionRequest,
-  makeAddArchivedConventionRequest,
-} from "./AddArchivedConventionRequest";
+  type CreateArchivedConventionRequest,
+  makeCreateArchivedConventionRequest,
+} from "./CreateArchivedConventionRequest";
 
-describe("AddArchivedConventionRequest", () => {
+describe("CreateArchivedConventionRequest", () => {
   let uow: InMemoryUnitOfWork;
-  let saveArchivedConventionRequest: AddArchivedConventionRequest;
+  let createArchivedConventionRequest: CreateArchivedConventionRequest;
   let createNewEvent: CreateNewEvent;
   let timeGateway: CustomTimeGateway;
 
@@ -37,7 +37,7 @@ describe("AddArchivedConventionRequest", () => {
 
     uow = createInMemoryUow();
     createNewEvent = makeCreateNewEvent({ timeGateway, uuidGenerator });
-    saveArchivedConventionRequest = makeAddArchivedConventionRequest({
+    createArchivedConventionRequest = makeCreateArchivedConventionRequest({
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: { createNewEvent, timeGateway },
     });
@@ -51,7 +51,7 @@ describe("AddArchivedConventionRequest", () => {
       reason: "legalDispute",
     };
 
-    await saveArchivedConventionRequest.execute(input, connectedUser);
+    await createArchivedConventionRequest.execute(input, connectedUser);
 
     expectToEqual(
       uow.archivedConventionRequestRepository.archivedConventionRequests,
@@ -96,7 +96,7 @@ describe("AddArchivedConventionRequest", () => {
       otherReason: "Motif personnalisé",
     };
 
-    await saveArchivedConventionRequest.execute(input, connectedUser);
+    await createArchivedConventionRequest.execute(input, connectedUser);
 
     expectToEqual(
       uow.archivedConventionRequestRepository.archivedConventionRequests[

--- a/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.unit.test.ts
+++ b/back/src/domains/convention/use-cases/CreateArchivedConventionRequest.unit.test.ts
@@ -1,5 +1,5 @@
 import {
-  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestDto,
   type ConnectedUser,
   ConnectedUserBuilder,
   expectArraysToMatch,
@@ -44,7 +44,7 @@ describe("CreateArchivedConventionRequest", () => {
   });
 
   it("saves an archived convention request with conventionSearchMethod = withConventionId", async () => {
-    const input: ArchivedConventionRequestFormDto = {
+    const input: ArchivedConventionRequestDto = {
       id: requestId,
       conventionSearchMethod: "withConventionId",
       conventionId: "22222222-2222-4222-8222-222222222222",
@@ -79,7 +79,7 @@ describe("CreateArchivedConventionRequest", () => {
   });
 
   it("saves an archived convention request with conventionSearchMethod = withConventionDetails", async () => {
-    const input: ArchivedConventionRequestFormDto = {
+    const input: ArchivedConventionRequestDto = {
       id: requestId,
       conventionSearchMethod: "withConventionDetails",
       beneficiaryFirstName: "Jean",

--- a/back/src/domains/convention/use-cases/notifications/NotifyUserThatArchivedConventionRequestWasReceived.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyUserThatArchivedConventionRequestWasReceived.ts
@@ -1,0 +1,67 @@
+import {
+  type ArchivedConventionRequestId,
+  errors,
+  type ZodSchemaWithInputMatchingOutput,
+} from "shared";
+import { z } from "zod";
+import {
+  triggeredBySchema,
+  type WithTriggeredBy,
+} from "../../../core/events/events";
+import type { SaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
+import { useCaseBuilder } from "../../../core/useCaseBuilder";
+
+type NotifyUserThatArchivedConventionRequestWasReceivedParams = {
+  archivedConventionRequestId: ArchivedConventionRequestId;
+} & WithTriggeredBy;
+
+const notifyUserThatArchivedConventionRequestWasReceivedSchema: ZodSchemaWithInputMatchingOutput<NotifyUserThatArchivedConventionRequestWasReceivedParams> =
+  z.object({
+    archivedConventionRequestId: z.uuid(),
+    triggeredBy: triggeredBySchema,
+  });
+
+export type NotifyUserThatArchivedConventionRequestWasReceived = ReturnType<
+  typeof makeNotifyUserThatArchivedConventionRequestWasReceived
+>;
+
+export const makeNotifyUserThatArchivedConventionRequestWasReceived =
+  useCaseBuilder("NotifyUserThatArchivedConventionRequestWasReceived")
+    .withInput(notifyUserThatArchivedConventionRequestWasReceivedSchema)
+    .withDeps<{
+      saveNotificationAndRelatedEvent: SaveNotificationAndRelatedEvent;
+    }>()
+    .build(
+      async ({ inputParams: { archivedConventionRequestId }, uow, deps }) => {
+        const archivedConventionRequest =
+          await uow.archivedConventionRequestRepository.getById(
+            archivedConventionRequestId,
+          );
+        if (!archivedConventionRequest)
+          throw errors.archivedConventionRequest.notFound({
+            id: archivedConventionRequestId,
+          });
+
+        const requester = await uow.userRepository.getById(
+          archivedConventionRequest.userId,
+        );
+        if (!requester)
+          throw errors.user.notFound({
+            userId: archivedConventionRequest.userId,
+          });
+
+        await deps.saveNotificationAndRelatedEvent(uow, {
+          kind: "email",
+          templatedContent: {
+            kind: "ARCHIVED_CONVENTION_REQUEST_RECEIVED",
+            recipients: [requester.email],
+            params: {
+              archivedConventionRequestId,
+            },
+          },
+          followedIds: {
+            userId: requester.id,
+          },
+        });
+      },
+    );

--- a/back/src/domains/convention/use-cases/notifications/NotifyUserThatArchivedConventionRequestWasReceived.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyUserThatArchivedConventionRequestWasReceived.unit.test.ts
@@ -1,0 +1,147 @@
+import {
+  type ConnectedUser,
+  ConnectedUserBuilder,
+  errors,
+  expectArraysToMatch,
+  expectPromiseToFailWithError,
+  expectToEqual,
+} from "shared";
+import { makeSaveNotificationAndRelatedEvent } from "../../../core/notifications/helpers/Notification";
+import { CustomTimeGateway } from "../../../core/time-gateway/adapters/CustomTimeGateway";
+import {
+  createInMemoryUow,
+  type InMemoryUnitOfWork,
+} from "../../../core/unit-of-work/adapters/createInMemoryUow";
+import { InMemoryUowPerformer } from "../../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import { TestUuidGenerator } from "../../../core/uuid-generator/adapters/UuidGeneratorImplementations";
+import {
+  makeNotifyUserThatArchivedConventionRequestWasReceived,
+  type NotifyUserThatArchivedConventionRequestWasReceived,
+} from "./NotifyUserThatArchivedConventionRequestWasReceived";
+
+describe("NotifyUserThatArchivedConventionRequestWasReceived", () => {
+  let uow: InMemoryUnitOfWork;
+  let notifyUserThatArchivedConventionRequestWasReceived: NotifyUserThatArchivedConventionRequestWasReceived;
+
+  const requester: ConnectedUser = new ConnectedUserBuilder()
+    .withId("requester-id")
+    .withEmail("requester@example.com")
+    .build();
+
+  const archivedConventionRequestId = "11111111-1111-4111-8111-111111111111";
+
+  beforeEach(() => {
+    uow = createInMemoryUow();
+    const uuidGenerator = new TestUuidGenerator([
+      "notification-id",
+      "notification-event-id",
+    ]);
+    const timeGateway = new CustomTimeGateway(
+      new Date("2024-06-01T12:00:00.000Z"),
+    );
+
+    notifyUserThatArchivedConventionRequestWasReceived =
+      makeNotifyUserThatArchivedConventionRequestWasReceived({
+        uowPerformer: new InMemoryUowPerformer(uow),
+        deps: {
+          saveNotificationAndRelatedEvent: makeSaveNotificationAndRelatedEvent(
+            uuidGenerator,
+            timeGateway,
+          ),
+        },
+      });
+  });
+
+  it("saves an email notification for the requester", async () => {
+    uow.userRepository.users = [requester];
+    await uow.archivedConventionRequestRepository.save({
+      id: archivedConventionRequestId,
+      userId: requester.id,
+      createdAt: "2024-06-01T12:00:00.000Z",
+      conventionSearchMethod: "withConventionId",
+      conventionId: "22222222-2222-4222-8222-222222222222",
+      reason: "legalDispute",
+    });
+
+    await notifyUserThatArchivedConventionRequestWasReceived.execute({
+      archivedConventionRequestId,
+      triggeredBy: {
+        kind: "connected-user",
+        userId: requester.id,
+      },
+    });
+
+    expectToEqual(uow.notificationRepository.notifications, [
+      {
+        id: "notification-id",
+        kind: "email",
+        createdAt: "2024-06-01T12:00:00.000Z",
+        templatedContent: {
+          kind: "ARCHIVED_CONVENTION_REQUEST_RECEIVED",
+          recipients: [requester.email],
+          params: {
+            archivedConventionRequestId,
+          },
+        },
+        followedIds: {
+          userId: requester.id,
+        },
+      },
+    ]);
+
+    expectArraysToMatch(uow.outboxRepository.events, [
+      {
+        topic: "NotificationAdded",
+        payload: {
+          id: "notification-id",
+          kind: "email",
+        },
+      },
+    ]);
+  });
+
+  it("throws when archived convention request is not found", async () => {
+    await expectPromiseToFailWithError(
+      notifyUserThatArchivedConventionRequestWasReceived.execute({
+        archivedConventionRequestId,
+        triggeredBy: {
+          kind: "connected-user",
+          userId: requester.id,
+        },
+      }),
+      errors.archivedConventionRequest.notFound({
+        id: archivedConventionRequestId,
+      }),
+    );
+
+    expectToEqual(uow.notificationRepository.notifications, []);
+    expectToEqual(uow.outboxRepository.events, []);
+  });
+
+  it("throws when requester is not found", async () => {
+    await uow.archivedConventionRequestRepository.save({
+      id: archivedConventionRequestId,
+      userId: requester.id,
+      createdAt: "2024-06-01T12:00:00.000Z",
+      conventionSearchMethod: "withConventionId",
+      conventionId: "22222222-2222-4222-8222-222222222222",
+      reason: "legalDispute",
+    });
+
+    await expectPromiseToFailWithError(
+      notifyUserThatArchivedConventionRequestWasReceived.execute({
+        archivedConventionRequestId,
+        triggeredBy: {
+          kind: "connected-user",
+          userId: requester.id,
+        },
+      }),
+      errors.user.notFound({
+        userId: requester.id,
+      }),
+    );
+
+    expectToEqual(uow.notificationRepository.notifications, []);
+    expectToEqual(uow.outboxRepository.events, []);
+  });
+});

--- a/back/src/domains/core/events/events.ts
+++ b/back/src/domains/core/events/events.ts
@@ -1,5 +1,6 @@
 import {
   type AgencyId,
+  type ArchivedConventionRequestId,
   type ContactEstablishmentEventPayload,
   type ConventionDraftId,
   type ConventionId,
@@ -147,6 +148,7 @@ export type DomainEvent =
   | GenericEvent<"ConventionDeprecated", WithConventionDto & WithTriggeredBy>
   | GenericEvent<"ConventionDraftToDelete", WithConventionDraftId & WithTriggeredBy>
   | GenericEvent<"ConventionDraftSaved",NotifyConventionDraftSavedInputParams>
+  | GenericEvent<"ArchivedConventionRequestCreated", { archivedConventionRequestId: ArchivedConventionRequestId } & WithTriggeredBy>
 
   // ESTABLISHMENT RELATED
   | GenericEvent<"NewEstablishmentAggregateInsertedFromForm", WithEstablishmentAggregate & WithTriggeredBy>

--- a/back/src/domains/core/events/events.ts
+++ b/back/src/domains/core/events/events.ts
@@ -1,6 +1,5 @@
 import {
   type AgencyId,
-  type ArchivedConventionRequestId,
   type ContactEstablishmentEventPayload,
   type ConventionDraftId,
   type ConventionId,
@@ -20,6 +19,7 @@ import {
   userIdSchema,
   type WithAgencyId,
   type WithAgencyIdAndUserId,
+  type WithArchivedConventionRequestId,
   type WithAssessmentDto,
   type WithConventionDraftId,
   type WithConventionDto,
@@ -148,7 +148,7 @@ export type DomainEvent =
   | GenericEvent<"ConventionDeprecated", WithConventionDto & WithTriggeredBy>
   | GenericEvent<"ConventionDraftToDelete", WithConventionDraftId & WithTriggeredBy>
   | GenericEvent<"ConventionDraftSaved",NotifyConventionDraftSavedInputParams>
-  | GenericEvent<"ArchivedConventionRequestCreated", { archivedConventionRequestId: ArchivedConventionRequestId } & WithTriggeredBy>
+  | GenericEvent<"ArchivedConventionRequestCreated", WithArchivedConventionRequestId & WithTriggeredBy>
 
   // ESTABLISHMENT RELATED
   | GenericEvent<"NewEstablishmentAggregateInsertedFromForm", WithEstablishmentAggregate & WithTriggeredBy>

--- a/back/src/domains/core/events/subscribeToEvents.ts
+++ b/back/src/domains/core/events/subscribeToEvents.ts
@@ -31,6 +31,7 @@ type UseCaseSubscriptionsByTopics = {
 const getUseCasesByTopics = (
   useCases: UseCases,
 ): UseCaseSubscriptionsByTopics => ({
+  ArchivedConventionRequestCreated: [],
   ConventionDraftSaved: [useCases.notifyConventionDraftSaved],
   UserDeleted: [],
   AllEstablishmentUsersDeleted: [useCases.deleteEstablishment],

--- a/back/src/domains/core/events/subscribeToEvents.ts
+++ b/back/src/domains/core/events/subscribeToEvents.ts
@@ -31,7 +31,9 @@ type UseCaseSubscriptionsByTopics = {
 const getUseCasesByTopics = (
   useCases: UseCases,
 ): UseCaseSubscriptionsByTopics => ({
-  ArchivedConventionRequestCreated: [],
+  ArchivedConventionRequestCreated: [
+    useCases.notifyUserThatArchivedConventionRequestWasReceived,
+  ],
   ConventionDraftSaved: [useCases.notifyConventionDraftSaved],
   UserDeleted: [],
   AllEstablishmentUsersDeleted: [useCases.deleteEstablishment],

--- a/back/src/domains/core/feature-flags/adapters/InMemoryFeatureFlagRepository.ts
+++ b/back/src/domains/core/feature-flags/adapters/InMemoryFeatureFlagRepository.ts
@@ -39,6 +39,7 @@ const defaultFlags: FeatureFlags = {
   }),
   enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
   enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+  enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
 };
 
 export class InMemoryFeatureFlagRepository implements FeatureFlagRepository {

--- a/back/src/domains/core/feature-flags/adapters/PgFeatureFlagRepositoryAndQueries.integration.test.ts
+++ b/back/src/domains/core/feature-flags/adapters/PgFeatureFlagRepositoryAndQueries.integration.test.ts
@@ -70,6 +70,7 @@ describe("PG getFeatureFlags", () => {
       }),
       enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
       enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+      enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
     };
 
     await featureFlagRepository.insertAll(expectedFeatureFlags);
@@ -105,6 +106,7 @@ describe("PG getFeatureFlags", () => {
       }),
       enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
       enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+      enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
     });
   });
 
@@ -140,6 +142,7 @@ describe("PG getFeatureFlags", () => {
       }),
       enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
       enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+      enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
     };
 
     await featureFlagRepository.insertAll(initialFeatureFlags);
@@ -204,6 +207,7 @@ describe("PG getFeatureFlags", () => {
       }),
       enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
       enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+      enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
     });
   });
 });

--- a/back/src/domains/core/unit-of-work/adapters/createInMemoryUow.ts
+++ b/back/src/domains/core/unit-of-work/adapters/createInMemoryUow.ts
@@ -1,6 +1,7 @@
 import { InMemoryAgencyGroupRepository } from "../../../agency/adapters/InMemoryAgencyGroupRepository";
 import { InMemoryAgencyRepository } from "../../../agency/adapters/InMemoryAgencyRepository";
 import { InMemoryDelegationContactRepository } from "../../../agency/adapters/InMemoryDelegationContactRepository";
+import { InMemoryArchivedConventionRequestRepository } from "../../../convention/adapters/InMemoryArchivedConventionRequestRepository";
 import { InMemoryAssessmentRepository } from "../../../convention/adapters/InMemoryAssessmentRepository";
 import { InMemoryConventionDraftRepository } from "../../../convention/adapters/InMemoryConventionDraftRepository";
 import { InMemoryConventionExternalIdRepository } from "../../../convention/adapters/InMemoryConventionExternalIdRepository";
@@ -64,6 +65,8 @@ export const createInMemoryUow = () => {
     agencyRepository,
     agencyGroupRepository: new InMemoryAgencyGroupRepository(),
     apiConsumerRepository: new InMemoryApiConsumerRepository(),
+    archivedConventionRequestRepository:
+      new InMemoryArchivedConventionRequestRepository(),
     userRepository,
     bannedEstablishmentRepository,
     broadcastFeedbacksRepository,

--- a/back/src/domains/core/unit-of-work/adapters/createPgUow.ts
+++ b/back/src/domains/core/unit-of-work/adapters/createPgUow.ts
@@ -2,6 +2,7 @@ import type { KyselyDb } from "../../../../config/pg/kysely/kyselyUtils";
 import { PgAgencyGroupRepository } from "../../../agency/adapters/PgAgencyGroupRepository";
 import { PgAgencyRepository } from "../../../agency/adapters/PgAgencyRepository";
 import { PgDelegationContactRepository } from "../../../agency/adapters/PgDelegationContactRepository";
+import { PgArchivedConventionRequestRepository } from "../../../convention/adapters/PgArchivedConventionRequestRepository";
 import { PgAssessmentRepository } from "../../../convention/adapters/PgAssessmentRepository";
 import { PgConventionDraftRepository } from "../../../convention/adapters/PgConventionDraftRepository";
 import { PgConventionExternalIdRepository } from "../../../convention/adapters/PgConventionExternalIdRepository";
@@ -42,6 +43,8 @@ export const createPgUow = (transaction: KyselyDb): UnitOfWork => {
     agencyRepository: new PgAgencyRepository(transaction),
     agencyGroupRepository: new PgAgencyGroupRepository(transaction),
     apiConsumerRepository: new PgApiConsumerRepository(transaction),
+    archivedConventionRequestRepository:
+      new PgArchivedConventionRequestRepository(transaction),
     bannedEstablishmentRepository: new PgBannedEstablishmentRepository(
       transaction,
     ),

--- a/back/src/domains/core/unit-of-work/ports/UnitOfWork.ts
+++ b/back/src/domains/core/unit-of-work/ports/UnitOfWork.ts
@@ -1,6 +1,7 @@
 import type { AgencyGroupRepository } from "../../../agency/ports/AgencyGroupRepository";
 import type { AgencyRepository } from "../../../agency/ports/AgencyRepository";
 import type { DelegationContactRepository } from "../../../agency/ports/DelegationContactRepository";
+import type { ArchivedConventionRequestRepository } from "../../../convention/ports/ArchivedConventionRequestRepository";
 import type { AssessmentRepository } from "../../../convention/ports/AssessmentRepository";
 import type { ConventionDraftRepository } from "../../../convention/ports/ConventionDraftRepository";
 import type { ConventionExternalIdRepository } from "../../../convention/ports/ConventionExternalIdRepository";
@@ -39,6 +40,7 @@ export type UnitOfWork = {
   agencyGroupRepository: AgencyGroupRepository;
   agencyRepository: AgencyRepository;
   apiConsumerRepository: ApiConsumerRepository;
+  archivedConventionRequestRepository: ArchivedConventionRequestRepository;
   assessmentRepository: AssessmentRepository;
   bannedEstablishmentRepository: BannedEstablishmentRepository;
   conventionDraftRepository: ConventionDraftRepository;

--- a/back/src/scripts/seed/featureFlagSeed.ts
+++ b/back/src/scripts/seed/featureFlagSeed.ts
@@ -42,6 +42,7 @@ export const featureFlagsSeed = async (uow: UnitOfWork) => {
     }),
     enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
     enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+    enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
   };
 
   await uow.featureFlagRepository.insertAll(featureFlags);

--- a/front/src/app/components/layout/LayoutFooter.tsx
+++ b/front/src/app/components/layout/LayoutFooter.tsx
@@ -261,6 +261,16 @@ const navTopGroupLinks: NavTopGroupLinks[] = [
       },
     ],
   },
+  {
+    title: "Outils et démarches",
+    links: [
+      {
+        label: "Accéder à une convention archivée",
+        ...frontRoutes.archivedConventionRequest().link,
+        id: navTopGroupLinksIds.archivedConventionRequest,
+      },
+    ],
+  },
 ];
 
 export const LayoutFooter = () => (

--- a/front/src/app/components/layout/LayoutFooter.tsx
+++ b/front/src/app/components/layout/LayoutFooter.tsx
@@ -17,6 +17,7 @@ import {
 import { type AbsoluteUrl, domElementIds, frontRoutes } from "shared";
 import { getConsentModal } from "src/app/components/ConsentManager";
 import { ressourcesAndWebinarsUrl } from "src/app/contents/home/content";
+import { useFeatureFlags } from "src/app/hooks/useFeatureFlags";
 import { useStyles } from "tss-react/dsfr";
 import lesEntrepriseSengagentLight from "../../../assets/img/les-entreprises-s-engagent.svg";
 import lesEntrepriseSengagentDark from "../../../assets/img/les-entreprises-s-engagent-dark.svg";
@@ -200,7 +201,9 @@ const bottomsLinks: (NavLink | typeof headerFooterDisplayItem)[] = [
   headerFooterDisplayItem,
 ];
 
-const navTopGroupLinks: NavTopGroupLinks[] = [
+const makeNavTopGroupLinks = (
+  isArchivedConventionRequestEnabled: boolean,
+): NavTopGroupLinks[] => [
   {
     title: "Candidats",
     links: [
@@ -261,29 +264,39 @@ const navTopGroupLinks: NavTopGroupLinks[] = [
       },
     ],
   },
-  {
-    title: "Outils et démarches",
-    links: [
-      {
-        label: "Accéder à une convention archivée",
-        ...frontRoutes.archivedConventionRequest().link,
-        id: navTopGroupLinksIds.archivedConventionRequest,
-      },
-    ],
-  },
+  ...(isArchivedConventionRequestEnabled
+    ? [
+        {
+          title: "Outils et démarches",
+          links: [
+            {
+              label: "Accéder à une convention archivée",
+              ...frontRoutes.archivedConventionRequest().link,
+              id: navTopGroupLinksIds.archivedConventionRequest,
+            },
+          ],
+        },
+      ]
+    : []),
 ];
 
-export const LayoutFooter = () => (
-  <>
-    <OverFooter cols={overFooterCols} />
-    <Footer
-      navTopGroupLinks={navTopGroupLinks}
-      links={links}
-      partnersLogos={<PartnersLogos />}
-      bottomLinks={bottomsLinks}
-    />
-    <Display />
-  </>
-);
+export const LayoutFooter = () => {
+  const { enableRequestArchivedConvention } = useFeatureFlags();
+
+  return (
+    <>
+      <OverFooter cols={overFooterCols} />
+      <Footer
+        navTopGroupLinks={makeNavTopGroupLinks(
+          enableRequestArchivedConvention.isActive,
+        )}
+        links={links}
+        partnersLogos={<PartnersLogos />}
+        bottomLinks={bottomsLinks}
+      />
+      <Display />
+    </>
+  );
+};
 
 LayoutFooter.displayName = "LayoutFooter";

--- a/front/src/app/pages/admin/EmailPreviewTab.tsx
+++ b/front/src/app/pages/admin/EmailPreviewTab.tsx
@@ -263,6 +263,9 @@ export const defaultEmailValueByEmailKind: {
       },
     ],
   },
+  ARCHIVED_CONVENTION_REQUEST_RECEIVED: {
+    archivedConventionRequestId: "ARCHIVED_CONVENTION_REQUEST_ID",
+  },
   AGENCY_WITH_REFERS_TO_ACTIVATED: {
     nameOfAgencyRefering: "ACCOMPANYING_AGENCY_NAME",
     refersToAgencyName: "REFERS_TO_AGENCY_NAME",

--- a/front/src/app/pages/admin/technical-options-sections/FeatureFlagsSection.tsx
+++ b/front/src/app/pages/admin/technical-options-sections/FeatureFlagsSection.tsx
@@ -158,6 +158,10 @@ const labelsByFeatureFlag: Record<
     enableLabel:
       "Traiter automatiquement les events de suppression (sinon mis en quarantaine)",
   },
+  enableRequestArchivedConvention: {
+    title: "Archivage des conventions",
+    enableLabel: "Activer la demande d'accès à une convention archivée",
+  },
 };
 
 const FeatureFlagTextWithSeverityForm = ({

--- a/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
+++ b/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
@@ -130,6 +130,7 @@ type ConnectPrivateRoute =
   | Route<typeof frontRoutes.myAccountEstablishments>
   | Route<typeof frontRoutes.myAccountEstablishmentRegistration>
   | Route<typeof frontRoutes.addAgency>
+  | Route<typeof frontRoutes.archivedConventionRequest>
   | Route<typeof frontRoutes.manageConventionConnectedUser>
   | Route<typeof frontRoutes.beneficiaryDashboardDiscussions>;
 
@@ -382,6 +383,8 @@ const getAllowedStartAuthPage = (
     return "establishmentDashboardDiscussions";
   if (routeName === "manageConventionConnectedUser")
     return "manageConventionConnectedUser";
+  if (routeName === "archivedConventionRequest")
+    return "archivedConventionRequest";
   if (
     agencyDashboardRoutes.includes(routeName as AgencyDashboardRouteName) &&
     "isAgencyRegistration" in routeParams &&
@@ -633,6 +636,7 @@ const pageContentByRoute: Record<AllowedLoginSource | "default", PageContent> =
       withProConnectLogin: true,
     },
     conventionTemplate: defaultPageContent,
+    archivedConventionRequest: defaultPageContent,
     myAccount: defaultPageContent,
     beneficiaryDashboard: beneficiaryDashboardContent,
     beneficiaryDashboardDiscussions: beneficiaryDashboardContent,

--- a/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
+++ b/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
@@ -17,15 +17,19 @@ import {
 import { AppellationAutocomplete } from "src/app/components/forms/autocomplete/AppellationAutocomplete";
 import { ConnectedPrivateRoutePage } from "src/app/pages/auth/ConnectedPrivateRoutePage";
 import type { Route } from "type-route";
+import { v4 as uuidV4 } from "uuid";
 
 type ArchivedConventionRequestPageProps = {
   route: Route<typeof frontRoutes.archivedConventionRequest>;
 };
 
-const initialValues: DefaultValues<ArchivedConventionRequestFormDto> = {
+const initialValues = (
+  id: string,
+): DefaultValues<ArchivedConventionRequestFormDto> => ({
+  id,
   conventionSearchMethod: "withConventionId",
   conventionId: "",
-};
+});
 
 export const ArchivedConventionRequestPage = ({
   route,
@@ -35,7 +39,7 @@ export const ArchivedConventionRequestPage = ({
   const methods = useForm<ArchivedConventionRequestFormDto>({
     resolver: zodResolver(archivedConventionRequestSchema),
     mode: "onTouched",
-    defaultValues: initialValues,
+    defaultValues: initialValues(uuidV4()),
   });
   const {
     formState: { errors },
@@ -70,6 +74,7 @@ export const ArchivedConventionRequestPage = ({
           id={domElementIds.archivedConventionRequest.form}
           onSubmit={handleSubmit(onSubmit)}
         >
+          <input type="hidden" {...register("id")} />
           <h2 className={fr.cx("fr-h6", "fr-mt-4w")}>
             Données de la convention
           </h2>

--- a/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
+++ b/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
@@ -8,7 +8,7 @@ import { Loader, PageHeader } from "react-design-system";
 import { type DefaultValues, FormProvider, useForm } from "react-hook-form";
 import { useDispatch } from "react-redux";
 import {
-  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestDto,
   archivedConventionRequestSchema,
   domElementIds,
   frontRoutes,
@@ -33,7 +33,7 @@ type ArchivedConventionRequestPageProps = {
 
 const initialValues = (
   id: string,
-): DefaultValues<ArchivedConventionRequestFormDto> => ({
+): DefaultValues<ArchivedConventionRequestDto> => ({
   id,
   conventionSearchMethod: "withConventionId",
   conventionId: "",
@@ -47,7 +47,7 @@ export const ArchivedConventionRequestPage = ({
   const isLoading = useAppSelector(
     archivedConventionRequestSelectors.isLoading,
   );
-  const methods = useForm<ArchivedConventionRequestFormDto>({
+  const methods = useForm<ArchivedConventionRequestDto>({
     resolver: zodResolver(archivedConventionRequestSchema),
     mode: "onTouched",
     defaultValues: initialValues(uuidV4()),
@@ -63,7 +63,7 @@ export const ArchivedConventionRequestPage = ({
   const conventionSearchMethod = watch("conventionSearchMethod");
   const reason = watch("reason");
 
-  const onSubmit = (values: ArchivedConventionRequestFormDto) => {
+  const onSubmit = (values: ArchivedConventionRequestDto) => {
     if (!connectedUserJwt) return;
 
     dispatch(
@@ -307,7 +307,7 @@ export const ArchivedConventionRequestPage = ({
 
 const reasonOptions: {
   label: string;
-  value: ArchivedConventionRequestFormDto["reason"];
+  value: ArchivedConventionRequestDto["reason"];
 }[] = [
   {
     label: "Contentieux juridique",

--- a/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
+++ b/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
@@ -1,0 +1,259 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
+import Select from "@codegouvfr/react-dsfr/SelectNext";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { PageHeader } from "react-design-system";
+import { type DefaultValues, FormProvider, useForm } from "react-hook-form";
+import {
+  type ArchivedConventionRequestFormDto,
+  archivedConventionRequestSchema,
+  domElementIds,
+  type frontRoutes,
+} from "shared";
+import { AppellationAutocomplete } from "src/app/components/forms/autocomplete/AppellationAutocomplete";
+import { ConnectedPrivateRoutePage } from "src/app/pages/auth/ConnectedPrivateRoutePage";
+import type { Route } from "type-route";
+
+type ArchivedConventionRequestPageProps = {
+  route: Route<typeof frontRoutes.archivedConventionRequest>;
+};
+
+const initialValues: DefaultValues<ArchivedConventionRequestFormDto> = {
+  conventionSearchMethod: "withConventionId",
+  conventionId: "",
+};
+
+export const ArchivedConventionRequestPage = ({
+  route,
+}: ArchivedConventionRequestPageProps) => {
+  const [validatedRequest, setValidatedRequest] =
+    useState<ArchivedConventionRequestFormDto | null>(null);
+  const methods = useForm<ArchivedConventionRequestFormDto>({
+    resolver: zodResolver(archivedConventionRequestSchema),
+    mode: "onTouched",
+    defaultValues: initialValues,
+  });
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    setValue,
+    watch,
+  } = methods;
+  const conventionSearchMethod = watch("conventionSearchMethod");
+  const reason = watch("reason");
+
+  const onSubmit = (values: ArchivedConventionRequestFormDto) => {
+    console.log("values", values);
+    setValidatedRequest(values);
+  };
+
+  return (
+    <ConnectedPrivateRoutePage
+      route={route}
+      oAuthConnectionPageHeader={
+        <PageHeader title="Vous devez vous connecter pour accéder à une convention archivée" />
+      }
+    >
+      <h1>Demande d'accès à une convention archivée</h1>
+      <p className={fr.cx("fr-text--lead")}>
+        Les conventions de plus de 2 ans sont automatiquement archivées. Pour
+        des raisons légales ou de suivi, vous pouvez demander la récupération
+        d'une convention et de son bilan.
+      </p>
+      <FormProvider {...methods}>
+        <form
+          id={domElementIds.archivedConventionRequest.form}
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <h2 className={fr.cx("fr-h6", "fr-mt-4w")}>
+            Données de la convention
+          </h2>
+          <p>
+            Renseignez l'identifiant exact de la convention ou les informations
+            détaillées permettant à notre équipe de la retrouver.
+          </p>
+          <RadioButtons
+            id={domElementIds.archivedConventionRequest.conventionSearchMethod}
+            legend="Informations disponibles"
+            options={[
+              {
+                label: "Je connais l'identifiant de la convention",
+                nativeInputProps: {
+                  value: "withConventionId",
+                  ...register("conventionSearchMethod"),
+                },
+              },
+              {
+                label: "Je ne connais pas l'identifiant de la convention",
+                nativeInputProps: {
+                  value: "withConventionDetails",
+                  ...register("conventionSearchMethod"),
+                },
+              },
+            ]}
+            state={errors.conventionSearchMethod ? "error" : "default"}
+            stateRelatedMessage={errors.conventionSearchMethod?.message}
+          />
+          {conventionSearchMethod === "withConventionId" ? (
+            <Input
+              label="ID de la convention *"
+              nativeInputProps={{
+                id: domElementIds.archivedConventionRequest.conventionIdInput,
+                ...register("conventionId"),
+              }}
+              state={errors.conventionId ? "error" : "default"}
+              stateRelatedMessage={errors.conventionId?.message}
+            />
+          ) : (
+            <>
+              <Input
+                label="Nom du bénéficiaire *"
+                nativeInputProps={{
+                  id: domElementIds.archivedConventionRequest
+                    .beneficiaryLastNameInput,
+                  ...register("beneficiaryLastName"),
+                }}
+                state={errors.beneficiaryLastName ? "error" : "default"}
+                stateRelatedMessage={errors.beneficiaryLastName?.message}
+              />
+              <Input
+                label="Prénom du bénéficiaire *"
+                nativeInputProps={{
+                  id: domElementIds.archivedConventionRequest
+                    .beneficiaryFirstNameInput,
+                  ...register("beneficiaryFirstName"),
+                }}
+                state={errors.beneficiaryFirstName ? "error" : "default"}
+                stateRelatedMessage={errors.beneficiaryFirstName?.message}
+              />
+              <Input
+                label="SIRET de l'entreprise *"
+                hintText={
+                  <>
+                    Vous pouvez le retrouver sur{" "}
+                    <a
+                      href="https://annuaire-entreprises.data.gouv.fr/"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      l'annuaire des entreprises
+                    </a>
+                    .
+                  </>
+                }
+                nativeInputProps={{
+                  id: domElementIds.archivedConventionRequest.siretInput,
+                  ...register("siret"),
+                }}
+                state={errors.siret ? "error" : "default"}
+                stateRelatedMessage={errors.siret?.message}
+              />
+              <Input
+                label="Date estimée de l'immersion *"
+                nativeInputProps={{
+                  id: domElementIds.archivedConventionRequest
+                    .immersionDateInput,
+                  ...register("immersionDate"),
+                }}
+                state={errors.immersionDate ? "error" : "default"}
+                stateRelatedMessage={errors.immersionDate?.message}
+              />
+              <div className={fr.cx("fr-input-group")}>
+                <AppellationAutocomplete
+                  locator="archived-convention-request"
+                  label="Métier *"
+                  onAppellationSelected={(appellationMatch) => {
+                    setValue(
+                      "immersionAppellation",
+                      appellationMatch.appellation,
+                      { shouldValidate: true },
+                    );
+                  }}
+                  onAppellationClear={() => {
+                    setValue("immersionAppellation", undefined, {
+                      shouldValidate: true,
+                    });
+                  }}
+                  selectProps={{
+                    inputId:
+                      domElementIds.archivedConventionRequest
+                        .appellationAutocomplete,
+                  }}
+                  state={errors.immersionAppellation ? "error" : undefined}
+                  stateRelatedMessage={errors.immersionAppellation?.message}
+                />
+              </div>
+            </>
+          )}
+          <Select
+            label="Raison de la demande *"
+            placeholder="Sélectionner un motif"
+            options={reasonOptions}
+            nativeSelectProps={{
+              id: domElementIds.archivedConventionRequest.reasonSelect,
+              ...register("reason"),
+            }}
+            state={errors.reason ? "error" : "default"}
+            stateRelatedMessage={errors.reason?.message}
+          />
+          {reason === "other" && (
+            <Input
+              label="Précisez le motif *"
+              textArea
+              nativeTextAreaProps={{
+                id: domElementIds.archivedConventionRequest.otherReasonInput,
+                ...register("otherReason"),
+              }}
+              state={errors.otherReason ? "error" : "default"}
+              stateRelatedMessage={errors.otherReason?.message}
+            />
+          )}
+          <Button
+            type="submit"
+            nativeButtonProps={{
+              id: domElementIds.archivedConventionRequest.submitButton,
+            }}
+          >
+            Envoyer la demande
+          </Button>
+        </form>
+      </FormProvider>
+      {validatedRequest && (
+        <Alert
+          className={fr.cx("fr-mt-4w")}
+          severity="success"
+          title="La demande est valide"
+          description="Le raccordement à l'envoi de la demande pourra être ajouté à l'étape suivante."
+        />
+      )}
+    </ConnectedPrivateRoutePage>
+  );
+};
+
+const reasonOptions: {
+  label: string;
+  value: ArchivedConventionRequestFormDto["reason"];
+}[] = [
+  {
+    label: "Contentieux juridique",
+    value: "legalDispute",
+  },
+  {
+    label: "Contrôle URSSAF ou inspection du travail",
+    value: "urssafOrInspectionControl",
+  },
+  {
+    label:
+      "Demande d'accès d'un conseiller du Réseau pour l'emploi (RPE) sur l'historique d'une personne",
+    value: "rpeAdvisorAccessToBeneficiaryHistory",
+  },
+  {
+    label: "Autre",
+    value: "other",
+  },
+];

--- a/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
+++ b/front/src/app/pages/convention/ArchivedConventionRequestPage.tsx
@@ -1,21 +1,29 @@
 import { fr } from "@codegouvfr/react-dsfr";
-import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import Select from "@codegouvfr/react-dsfr/SelectNext";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
-import { PageHeader } from "react-design-system";
+import { Loader, PageHeader } from "react-design-system";
 import { type DefaultValues, FormProvider, useForm } from "react-hook-form";
+import { useDispatch } from "react-redux";
 import {
   type ArchivedConventionRequestFormDto,
   archivedConventionRequestSchema,
   domElementIds,
-  type frontRoutes,
+  frontRoutes,
 } from "shared";
+import { Feedback } from "src/app/components/feedback/Feedback";
+import { FullPageFeedback } from "src/app/components/feedback/FullpageFeedback";
+import { WithFeedbackReplacer } from "src/app/components/feedback/WithFeedbackReplacer";
 import { AppellationAutocomplete } from "src/app/components/forms/autocomplete/AppellationAutocomplete";
+import { useAppSelector } from "src/app/hooks/reduxHooks";
 import { ConnectedPrivateRoutePage } from "src/app/pages/auth/ConnectedPrivateRoutePage";
+import { commonIllustrations } from "src/assets/img/illustrations";
+import { authSelectors } from "src/core-logic/domain/auth/auth.selectors";
+import { archivedConventionRequestSelectors } from "src/core-logic/domain/convention/archivedConventionRequest.selectors";
+import { archivedConventionRequestSlice } from "src/core-logic/domain/convention/archivedConventionRequest.slice";
+import { feedbackSlice } from "src/core-logic/domain/feedback/feedback.slice";
 import type { Route } from "type-route";
 import { v4 as uuidV4 } from "uuid";
 
@@ -34,8 +42,11 @@ const initialValues = (
 export const ArchivedConventionRequestPage = ({
   route,
 }: ArchivedConventionRequestPageProps) => {
-  const [validatedRequest, setValidatedRequest] =
-    useState<ArchivedConventionRequestFormDto | null>(null);
+  const dispatch = useDispatch();
+  const connectedUserJwt = useAppSelector(authSelectors.connectedUserJwt);
+  const isLoading = useAppSelector(
+    archivedConventionRequestSelectors.isLoading,
+  );
   const methods = useForm<ArchivedConventionRequestFormDto>({
     resolver: zodResolver(archivedConventionRequestSchema),
     mode: "onTouched",
@@ -45,6 +56,7 @@ export const ArchivedConventionRequestPage = ({
     formState: { errors },
     handleSubmit,
     register,
+    reset,
     setValue,
     watch,
   } = methods;
@@ -52,8 +64,17 @@ export const ArchivedConventionRequestPage = ({
   const reason = watch("reason");
 
   const onSubmit = (values: ArchivedConventionRequestFormDto) => {
-    console.log("values", values);
-    setValidatedRequest(values);
+    if (!connectedUserJwt) return;
+
+    dispatch(
+      archivedConventionRequestSlice.actions.saveArchivedConventionRequestRequested(
+        {
+          archivedConventionRequest: values,
+          jwt: connectedUserJwt,
+          feedbackTopic: "archived-convention-request",
+        },
+      ),
+    );
   };
 
   return (
@@ -63,179 +84,223 @@ export const ArchivedConventionRequestPage = ({
         <PageHeader title="Vous devez vous connecter pour accéder à une convention archivée" />
       }
     >
-      <h1>Demande d'accès à une convention archivée</h1>
-      <p className={fr.cx("fr-text--lead")}>
-        Les conventions de plus de 2 ans sont automatiquement archivées. Pour
-        des raisons légales ou de suivi, vous pouvez demander la récupération
-        d'une convention et de son bilan.
-      </p>
-      <FormProvider {...methods}>
-        <form
-          id={domElementIds.archivedConventionRequest.form}
-          onSubmit={handleSubmit(onSubmit)}
-        >
-          <input type="hidden" {...register("id")} />
-          <h2 className={fr.cx("fr-h6", "fr-mt-4w")}>
-            Données de la convention
-          </h2>
-          <p>
-            Renseignez l'identifiant exact de la convention ou les informations
-            détaillées permettant à notre équipe de la retrouver.
-          </p>
-          <RadioButtons
-            id={domElementIds.archivedConventionRequest.conventionSearchMethod}
-            legend="Informations disponibles"
-            options={[
-              {
-                label: "Je connais l'identifiant de la convention",
-                nativeInputProps: {
-                  value: "withConventionId",
-                  ...register("conventionSearchMethod"),
+      <WithFeedbackReplacer
+        topic="archived-convention-request"
+        renderFeedback={({ level }) =>
+          level === "success" ? (
+            <FullPageFeedback
+              includeWrapper={false}
+              title="Demande envoyée avec succès"
+              illustration={commonIllustrations.success}
+              content={
+                <>
+                  <p>Votre demande d'accès a bien été enregistrée.</p>
+                  <p>
+                    Notre équipe va examiner votre demande pour s'assurer que
+                    nous pouvons vous transmettre ces documents de manière
+                    légitime.
+                  </p>
+                  <p>
+                    Si votre demande est validée, la convention ainsi que le
+                    bilan d'immersion vous seront envoyés directement par email
+                    d'ici quelques jours.
+                  </p>
+                </>
+              }
+              buttons={[
+                {
+                  id: domElementIds.archivedConventionRequest.success
+                    .goToMyAccountButton,
+                  children: "Retourner à mon espace",
+                  priority: "primary",
+                  linkProps: frontRoutes.myAccount().link,
                 },
-              },
-              {
-                label: "Je ne connais pas l'identifiant de la convention",
-                nativeInputProps: {
-                  value: "withConventionDetails",
-                  ...register("conventionSearchMethod"),
+                {
+                  id: domElementIds.archivedConventionRequest.success
+                    .newRequestButton,
+                  children: "Faire une autre demande",
+                  priority: "secondary",
+                  onClick: () => {
+                    reset(initialValues(uuidV4()));
+                    dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
+                  },
                 },
-              },
-            ]}
-            state={errors.conventionSearchMethod ? "error" : "default"}
-            stateRelatedMessage={errors.conventionSearchMethod?.message}
-          />
-          {conventionSearchMethod === "withConventionId" ? (
-            <Input
-              label="ID de la convention *"
-              nativeInputProps={{
-                id: domElementIds.archivedConventionRequest.conventionIdInput,
-                ...register("conventionId"),
-              }}
-              state={errors.conventionId ? "error" : "default"}
-              stateRelatedMessage={errors.conventionId?.message}
+              ]}
             />
           ) : (
-            <>
-              <Input
-                label="Nom du bénéficiaire *"
-                nativeInputProps={{
-                  id: domElementIds.archivedConventionRequest
-                    .beneficiaryLastNameInput,
-                  ...register("beneficiaryLastName"),
-                }}
-                state={errors.beneficiaryLastName ? "error" : "default"}
-                stateRelatedMessage={errors.beneficiaryLastName?.message}
-              />
-              <Input
-                label="Prénom du bénéficiaire *"
-                nativeInputProps={{
-                  id: domElementIds.archivedConventionRequest
-                    .beneficiaryFirstNameInput,
-                  ...register("beneficiaryFirstName"),
-                }}
-                state={errors.beneficiaryFirstName ? "error" : "default"}
-                stateRelatedMessage={errors.beneficiaryFirstName?.message}
-              />
-              <Input
-                label="SIRET de l'entreprise *"
-                hintText={
-                  <>
-                    Vous pouvez le retrouver sur{" "}
-                    <a
-                      href="https://annuaire-entreprises.data.gouv.fr/"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      l'annuaire des entreprises
-                    </a>
-                    .
-                  </>
-                }
-                nativeInputProps={{
-                  id: domElementIds.archivedConventionRequest.siretInput,
-                  ...register("siret"),
-                }}
-                state={errors.siret ? "error" : "default"}
-                stateRelatedMessage={errors.siret?.message}
-              />
-              <Input
-                label="Date estimée de l'immersion *"
-                nativeInputProps={{
-                  id: domElementIds.archivedConventionRequest
-                    .immersionDateInput,
-                  ...register("immersionDate"),
-                }}
-                state={errors.immersionDate ? "error" : "default"}
-                stateRelatedMessage={errors.immersionDate?.message}
-              />
-              <div className={fr.cx("fr-input-group")}>
-                <AppellationAutocomplete
-                  locator="archived-convention-request"
-                  label="Métier *"
-                  onAppellationSelected={(appellationMatch) => {
-                    setValue(
-                      "immersionAppellation",
-                      appellationMatch.appellation,
-                      { shouldValidate: true },
-                    );
-                  }}
-                  onAppellationClear={() => {
-                    setValue("immersionAppellation", undefined, {
-                      shouldValidate: true,
-                    });
-                  }}
-                  selectProps={{
-                    inputId:
-                      domElementIds.archivedConventionRequest
-                        .appellationAutocomplete,
-                  }}
-                  state={errors.immersionAppellation ? "error" : undefined}
-                  stateRelatedMessage={errors.immersionAppellation?.message}
-                />
-              </div>
-            </>
-          )}
-          <Select
-            label="Raison de la demande *"
-            placeholder="Sélectionner un motif"
-            options={reasonOptions}
-            nativeSelectProps={{
-              id: domElementIds.archivedConventionRequest.reasonSelect,
-              ...register("reason"),
-            }}
-            state={errors.reason ? "error" : "default"}
-            stateRelatedMessage={errors.reason?.message}
-          />
-          {reason === "other" && (
-            <Input
-              label="Précisez le motif *"
-              textArea
-              nativeTextAreaProps={{
-                id: domElementIds.archivedConventionRequest.otherReasonInput,
-                ...register("otherReason"),
-              }}
-              state={errors.otherReason ? "error" : "default"}
-              stateRelatedMessage={errors.otherReason?.message}
-            />
-          )}
-          <Button
-            type="submit"
-            nativeButtonProps={{
-              id: domElementIds.archivedConventionRequest.submitButton,
-            }}
+            <Feedback topics={["archived-convention-request"]} />
+          )
+        }
+      >
+        {isLoading && <Loader />}
+        <h1>Demande d'accès à une convention archivée</h1>
+        <p className={fr.cx("fr-text--lead")}>
+          Les conventions de plus de 2 ans sont automatiquement archivées. Pour
+          des raisons légales ou de suivi, vous pouvez demander la récupération
+          d'une convention et de son bilan.
+        </p>
+        <FormProvider {...methods}>
+          <form
+            id={domElementIds.archivedConventionRequest.form}
+            onSubmit={handleSubmit(onSubmit)}
           >
-            Envoyer la demande
-          </Button>
-        </form>
-      </FormProvider>
-      {validatedRequest && (
-        <Alert
-          className={fr.cx("fr-mt-4w")}
-          severity="success"
-          title="La demande est valide"
-          description="Le raccordement à l'envoi de la demande pourra être ajouté à l'étape suivante."
-        />
-      )}
+            <input type="hidden" {...register("id")} />
+            <h2 className={fr.cx("fr-h6", "fr-mt-4w")}>
+              Données de la convention
+            </h2>
+            <p>
+              Renseignez l'identifiant exact de la convention ou les
+              informations détaillées permettant à notre équipe de la retrouver.
+            </p>
+            <RadioButtons
+              id={
+                domElementIds.archivedConventionRequest.conventionSearchMethod
+              }
+              legend="Informations disponibles"
+              options={[
+                {
+                  label: "Je connais l'identifiant de la convention",
+                  nativeInputProps: {
+                    value: "withConventionId",
+                    ...register("conventionSearchMethod"),
+                  },
+                },
+                {
+                  label: "Je ne connais pas l'identifiant de la convention",
+                  nativeInputProps: {
+                    value: "withConventionDetails",
+                    ...register("conventionSearchMethod"),
+                  },
+                },
+              ]}
+              state={errors.conventionSearchMethod ? "error" : "default"}
+              stateRelatedMessage={errors.conventionSearchMethod?.message}
+            />
+            {conventionSearchMethod === "withConventionId" ? (
+              <Input
+                label="ID de la convention *"
+                nativeInputProps={{
+                  id: domElementIds.archivedConventionRequest.conventionIdInput,
+                  ...register("conventionId"),
+                }}
+                state={errors.conventionId ? "error" : "default"}
+                stateRelatedMessage={errors.conventionId?.message}
+              />
+            ) : (
+              <>
+                <Input
+                  label="Nom du bénéficiaire *"
+                  nativeInputProps={{
+                    id: domElementIds.archivedConventionRequest
+                      .beneficiaryLastNameInput,
+                    ...register("beneficiaryLastName"),
+                  }}
+                  state={errors.beneficiaryLastName ? "error" : "default"}
+                  stateRelatedMessage={errors.beneficiaryLastName?.message}
+                />
+                <Input
+                  label="Prénom du bénéficiaire *"
+                  nativeInputProps={{
+                    id: domElementIds.archivedConventionRequest
+                      .beneficiaryFirstNameInput,
+                    ...register("beneficiaryFirstName"),
+                  }}
+                  state={errors.beneficiaryFirstName ? "error" : "default"}
+                  stateRelatedMessage={errors.beneficiaryFirstName?.message}
+                />
+                <Input
+                  label="SIRET de l'entreprise *"
+                  hintText={
+                    <>
+                      Vous pouvez le retrouver sur{" "}
+                      <a
+                        href="https://annuaire-entreprises.data.gouv.fr/"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        l'annuaire des entreprises
+                      </a>
+                      .
+                    </>
+                  }
+                  nativeInputProps={{
+                    id: domElementIds.archivedConventionRequest.siretInput,
+                    ...register("siret"),
+                  }}
+                  state={errors.siret ? "error" : "default"}
+                  stateRelatedMessage={errors.siret?.message}
+                />
+                <Input
+                  label="Date estimée de l'immersion *"
+                  nativeInputProps={{
+                    id: domElementIds.archivedConventionRequest
+                      .immersionDateInput,
+                    ...register("immersionDate"),
+                  }}
+                  state={errors.immersionDate ? "error" : "default"}
+                  stateRelatedMessage={errors.immersionDate?.message}
+                />
+                <div className={fr.cx("fr-input-group")}>
+                  <AppellationAutocomplete
+                    locator="archived-convention-request"
+                    label="Métier *"
+                    onAppellationSelected={(appellationMatch) => {
+                      setValue(
+                        "immersionAppellation",
+                        appellationMatch.appellation,
+                        { shouldValidate: true },
+                      );
+                    }}
+                    onAppellationClear={() => {
+                      setValue("immersionAppellation", undefined, {
+                        shouldValidate: true,
+                      });
+                    }}
+                    selectProps={{
+                      inputId:
+                        domElementIds.archivedConventionRequest
+                          .appellationAutocomplete,
+                    }}
+                    state={errors.immersionAppellation ? "error" : undefined}
+                    stateRelatedMessage={errors.immersionAppellation?.message}
+                  />
+                </div>
+              </>
+            )}
+            <Select
+              label="Raison de la demande *"
+              placeholder="Sélectionner un motif"
+              options={reasonOptions}
+              nativeSelectProps={{
+                id: domElementIds.archivedConventionRequest.reasonSelect,
+                ...register("reason"),
+              }}
+              state={errors.reason ? "error" : "default"}
+              stateRelatedMessage={errors.reason?.message}
+            />
+            {reason === "other" && (
+              <Input
+                label="Précisez le motif *"
+                textArea
+                nativeTextAreaProps={{
+                  id: domElementIds.archivedConventionRequest.otherReasonInput,
+                  ...register("otherReason"),
+                }}
+                state={errors.otherReason ? "error" : "default"}
+                stateRelatedMessage={errors.otherReason?.message}
+              />
+            )}
+            <Button
+              type="submit"
+              nativeButtonProps={{
+                id: domElementIds.archivedConventionRequest.submitButton,
+              }}
+            >
+              Envoyer la demande
+            </Button>
+          </form>
+        </FormProvider>
+      </WithFeedbackReplacer>
     </ConnectedPrivateRoutePage>
   );
 };

--- a/front/src/app/routes/Router.tsx
+++ b/front/src/app/routes/Router.tsx
@@ -28,6 +28,7 @@ import { ConnectedPrivateRoutePage } from "src/app/pages/auth/ConnectedPrivateRo
 import { DashboardPrivateRoutePage } from "src/app/pages/auth/DashboardPrivateRoutePage";
 import { MagicLinkInterstitialPage } from "src/app/pages/auth/MagicLinkInterstitialPage";
 import { BeneficiaryDashboardPage } from "src/app/pages/beneficiary-dashboard/BeneficiaryDashboardPage";
+import { ArchivedConventionRequestPage } from "src/app/pages/convention/ArchivedConventionRequestPage";
 import { AssessmentDocumentPage } from "src/app/pages/convention/AssessmentDocumentPage";
 import { ConventionConfirmationPage } from "src/app/pages/convention/ConventionConfirmationPage";
 import { ConventionImmersionPage } from "src/app/pages/convention/ConventionImmersionPage";
@@ -232,6 +233,9 @@ const getPageByRouteName: {
     </DashboardPrivateRoutePage>
   ),
   assessmentDocument: (route) => <AssessmentDocumentPage route={route} />,
+  archivedConventionRequest: (route) => (
+    <ArchivedConventionRequestPage route={route} />
+  ),
   beneficiaryDashboard: (route) => (
     <RedirectTo
       route={frontRoutes.beneficiaryDashboardDiscussions(route.params)}

--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -2,6 +2,7 @@ import { from, type Observable } from "rxjs";
 import type {
   AddConventionInput,
   ApiConsumerName,
+  ArchivedConventionRequestFormDto,
   AuthenticatedConventionRoutes,
   BeneficiaryConventionListDto,
   ConnectedUserJwt,
@@ -137,6 +138,26 @@ export class HttpConventionGateway implements ConventionGateway {
             .with({ status: 400 }, throwBadRequestWithExplicitMessage)
             .with({ status: 409 }, logBodyAndThrow)
             .with({ status: 503 }, throwServiceUnavailableWithExplicitMessage)
+            .otherwise(otherwiseThrow),
+        ),
+    );
+  }
+
+  public saveArchivedConventionRequest$(
+    archivedConventionRequest: ArchivedConventionRequestFormDto,
+    jwt: ConnectedUserJwt,
+  ): Observable<void> {
+    return from(
+      this.magicLinkHttpClient
+        .createArchivedConventionRequest({
+          body: archivedConventionRequest,
+          headers: { authorization: jwt },
+        })
+        .then((response) =>
+          match(response)
+            .with({ status: 201 }, () => undefined)
+            .with({ status: 400 }, throwBadRequestWithExplicitMessage)
+            .with({ status: 401 }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
     );

--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -2,7 +2,7 @@ import { from, type Observable } from "rxjs";
 import type {
   AddConventionInput,
   ApiConsumerName,
-  ArchivedConventionRequestFormDto,
+  ArchivedConventionRequestDto,
   AuthenticatedConventionRoutes,
   BeneficiaryConventionListDto,
   ConnectedUserJwt,
@@ -144,7 +144,7 @@ export class HttpConventionGateway implements ConventionGateway {
   }
 
   public saveArchivedConventionRequest$(
-    archivedConventionRequest: ArchivedConventionRequestFormDto,
+    archivedConventionRequest: ArchivedConventionRequestDto,
     jwt: ConnectedUserJwt,
   ): Observable<void> {
     return from(

--- a/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
@@ -3,7 +3,7 @@ import {
   type AddConventionInput,
   type AgencyOption,
   type ApiConsumerName,
-  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestDto,
   type BeneficiaryConventionListDto,
   type ConnectedUserJwt,
   type ConventionDraftDto,
@@ -135,7 +135,7 @@ export class InMemoryConventionGateway implements ConventionGateway {
   }
 
   public saveArchivedConventionRequest$(
-    _archivedConventionRequest: ArchivedConventionRequestFormDto,
+    _archivedConventionRequest: ArchivedConventionRequestDto,
     _jwt: ConnectedUserJwt,
   ): Observable<void> {
     return this.saveArchivedConventionRequestResult$;
@@ -263,7 +263,6 @@ export class InMemoryConventionGateway implements ConventionGateway {
     return this.conventionModificationResult$;
   }
 
-  // Same as GET above, but using a magic link
   async #getMagicLink({
     conventionId,
   }: FetchConventionRequestedPayload): Promise<ConventionReadDto> {

--- a/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
@@ -3,6 +3,7 @@ import {
   type AddConventionInput,
   type AgencyOption,
   type ApiConsumerName,
+  type ArchivedConventionRequestFormDto,
   type BeneficiaryConventionListDto,
   type ConnectedUserJwt,
   type ConventionDraftDto,
@@ -46,6 +47,8 @@ export class InMemoryConventionGateway implements ConventionGateway {
   public addConventionCallCount = 0;
 
   public addConventionResult$ = new Subject<void>();
+
+  public saveArchivedConventionRequestResult$ = new Subject<void>();
 
   // For testing purpose
   public convention$ = new Subject<ConventionReadDto | undefined>();
@@ -129,6 +132,13 @@ export class InMemoryConventionGateway implements ConventionGateway {
   public createConvention$(_params: AddConventionInput): Observable<void> {
     this.addConventionCallCount++;
     return this.addConventionResult$;
+  }
+
+  public saveArchivedConventionRequest$(
+    _archivedConventionRequest: ArchivedConventionRequestFormDto,
+    _jwt: ConnectedUserJwt,
+  ): Observable<void> {
+    return this.saveArchivedConventionRequestResult$;
   }
 
   public editConventionCounsellorName$(

--- a/front/src/core-logic/domain/appellation/appellation.slice.ts
+++ b/front/src/core-logic/domain/appellation/appellation.slice.ts
@@ -14,6 +14,7 @@ export type MultipleAppellationAutocompleteLocator =
 export type AppellationAutocompleteLocator =
   | "search-form-appellation"
   | "convention-profession"
+  | "archived-convention-request"
   | "form-establishment-offer-modal"
   | MultipleAppellationAutocompleteLocator;
 

--- a/front/src/core-logic/domain/convention/archivedConventionRequest.epics.ts
+++ b/front/src/core-logic/domain/convention/archivedConventionRequest.epics.ts
@@ -1,0 +1,52 @@
+import { filter, map, switchMap } from "rxjs";
+import { catchEpicError } from "src/core-logic/storeConfig/catchEpicError";
+import type {
+  ActionOfSlice,
+  AppEpic,
+} from "src/core-logic/storeConfig/redux.helpers";
+import { archivedConventionRequestSlice } from "./archivedConventionRequest.slice";
+
+type ArchivedConventionRequestAction = ActionOfSlice<
+  typeof archivedConventionRequestSlice
+>;
+type ArchivedConventionRequestEpic = AppEpic<ArchivedConventionRequestAction>;
+
+const saveArchivedConventionRequestEpic: ArchivedConventionRequestEpic = (
+  action$,
+  _state$,
+  { conventionGateway },
+) =>
+  action$.pipe(
+    filter(
+      archivedConventionRequestSlice.actions
+        .saveArchivedConventionRequestRequested.match,
+    ),
+    switchMap((action) =>
+      conventionGateway
+        .saveArchivedConventionRequest$(
+          action.payload.archivedConventionRequest,
+          action.payload.jwt,
+        )
+        .pipe(
+          map(() =>
+            archivedConventionRequestSlice.actions.saveArchivedConventionRequestSucceeded(
+              {
+                feedbackTopic: action.payload.feedbackTopic,
+              },
+            ),
+          ),
+          catchEpicError((error: Error) =>
+            archivedConventionRequestSlice.actions.saveArchivedConventionRequestFailed(
+              {
+                errorMessage: error.message,
+                feedbackTopic: action.payload.feedbackTopic,
+              },
+            ),
+          ),
+        ),
+    ),
+  );
+
+export const archivedConventionRequestEpics = [
+  saveArchivedConventionRequestEpic,
+];

--- a/front/src/core-logic/domain/convention/archivedConventionRequest.selectors.ts
+++ b/front/src/core-logic/domain/convention/archivedConventionRequest.selectors.ts
@@ -1,0 +1,15 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { createRootSelector } from "src/core-logic/storeConfig/store";
+
+const archivedConventionRequestState = createRootSelector(
+  (state) => state.archivedConventionRequest,
+);
+
+const isLoading = createSelector(
+  archivedConventionRequestState,
+  ({ isLoading }) => isLoading,
+);
+
+export const archivedConventionRequestSelectors = {
+  isLoading,
+};

--- a/front/src/core-logic/domain/convention/archivedConventionRequest.slice.ts
+++ b/front/src/core-logic/domain/convention/archivedConventionRequest.slice.ts
@@ -1,0 +1,46 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type {
+  ArchivedConventionRequestFormDto,
+  ConnectedUserJwt,
+} from "shared";
+import type {
+  PayloadActionWithFeedbackTopic,
+  PayloadActionWithFeedbackTopicError,
+} from "src/core-logic/domain/feedback/feedback.slice";
+
+export interface ArchivedConventionRequestState {
+  isLoading: boolean;
+}
+
+export const initialArchivedConventionRequestState: ArchivedConventionRequestState =
+  {
+    isLoading: false,
+  };
+
+export const archivedConventionRequestSlice = createSlice({
+  name: "archivedConventionRequest",
+  initialState: initialArchivedConventionRequestState,
+  reducers: {
+    saveArchivedConventionRequestRequested: (
+      state,
+      _action: PayloadActionWithFeedbackTopic<{
+        archivedConventionRequest: ArchivedConventionRequestFormDto;
+        jwt: ConnectedUserJwt;
+      }>,
+    ) => {
+      state.isLoading = true;
+    },
+    saveArchivedConventionRequestSucceeded: (
+      state,
+      _action: PayloadActionWithFeedbackTopic,
+    ) => {
+      state.isLoading = false;
+    },
+    saveArchivedConventionRequestFailed: (
+      state,
+      _action: PayloadActionWithFeedbackTopicError,
+    ) => {
+      state.isLoading = false;
+    },
+  },
+});

--- a/front/src/core-logic/domain/convention/archivedConventionRequest.slice.ts
+++ b/front/src/core-logic/domain/convention/archivedConventionRequest.slice.ts
@@ -1,8 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import type {
-  ArchivedConventionRequestFormDto,
-  ConnectedUserJwt,
-} from "shared";
+import type { ArchivedConventionRequestDto, ConnectedUserJwt } from "shared";
 import type {
   PayloadActionWithFeedbackTopic,
   PayloadActionWithFeedbackTopicError,
@@ -24,7 +21,7 @@ export const archivedConventionRequestSlice = createSlice({
     saveArchivedConventionRequestRequested: (
       state,
       _action: PayloadActionWithFeedbackTopic<{
-        archivedConventionRequest: ArchivedConventionRequestFormDto;
+        archivedConventionRequest: ArchivedConventionRequestDto;
         jwt: ConnectedUserJwt;
       }>,
     ) => {

--- a/front/src/core-logic/domain/featureFlags/featureFlags.slice.ts
+++ b/front/src/core-logic/domain/featureFlags/featureFlags.slice.ts
@@ -43,6 +43,7 @@ const initialState: FeatureFlagsState = {
   }),
   enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
   enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+  enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
   isLoading: true,
 };
 

--- a/front/src/core-logic/domain/featureFlags/featureFlags.test.ts
+++ b/front/src/core-logic/domain/featureFlags/featureFlags.test.ts
@@ -60,6 +60,7 @@ const defaultFeatureFlags: FeatureFlags = {
   ),
   enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
   enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+  enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
 };
 
 const flagsFromApi: FeatureFlags = {
@@ -89,6 +90,7 @@ const flagsFromApi: FeatureFlags = {
   ),
   enableInactiveUsersCleanup: makeBooleanFeatureFlag(true),
   enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+  enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
 };
 
 describe("feature flag slice", () => {

--- a/front/src/core-logic/domain/feedback/feedback.content.ts
+++ b/front/src/core-logic/domain/feedback/feedback.content.ts
@@ -14,6 +14,7 @@ import { connectedUserSlice } from "src/core-logic/domain/connected-user/connect
 import { conventionListSlice } from "src/core-logic/domain/connected-user/conventionList/connectedUserConventionList.slice";
 import { connectedUserConventionsToManageSlice } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.slice";
 import { conventionsWithBroadcastFeedbackSlice } from "src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.slice";
+import { archivedConventionRequestSlice } from "src/core-logic/domain/convention/archivedConventionRequest.slice";
 import { conventionSlice } from "src/core-logic/domain/convention/convention.slice";
 import { conventionActionSlice } from "src/core-logic/domain/convention/convention-action/conventionAction.slice";
 import { conventionDraftSlice } from "src/core-logic/domain/convention/convention-draft/conventionDraft.slice";
@@ -49,6 +50,7 @@ const topics = [
   "api-consumer-renew",
   "api-consumer-revoke",
   "assessment",
+  "archived-convention-request",
   "delete-assessment",
   "auth-global",
   "broadcast-convention-again",
@@ -879,6 +881,24 @@ export const feedbacks: Record<
       title: "Suppression du modèle de convention du modèle de convention",
       message:
         "Une erreur est survenue lors de la suppression du modèle de convention.",
+    },
+  },
+  "archived-convention-request": {
+    "create.success": {
+      action:
+        archivedConventionRequestSlice.actions
+          .saveArchivedConventionRequestSucceeded,
+      title: "La demande a bien été envoyée",
+      message:
+        "Votre demande d'accès à une convention archivée a bien été envoyée.",
+    },
+    "create.error": {
+      action:
+        archivedConventionRequestSlice.actions
+          .saveArchivedConventionRequestFailed,
+      title: "Une erreur s'est produite",
+      message:
+        "Impossible d'enregistrer votre demande pour le moment. Veuillez réessayer ultérieurement ou contacter le support.",
     },
   },
   "convention-form": {

--- a/front/src/core-logic/domain/testHelpers/test.helpers.ts
+++ b/front/src/core-logic/domain/testHelpers/test.helpers.ts
@@ -37,6 +37,7 @@ const defaultFlagsInFront: FeatureFlags = {
   }),
   enableInactiveUsersCleanup: makeBooleanFeatureFlag(false),
   enableInactiveUsersDeletionAutoProcessing: makeBooleanFeatureFlag(false),
+  enableRequestArchivedConvention: makeBooleanFeatureFlag(false),
 };
 
 export const makeStubFeatureFlags = (

--- a/front/src/core-logic/ports/ConventionGateway.ts
+++ b/front/src/core-logic/ports/ConventionGateway.ts
@@ -1,7 +1,7 @@
 import type { Observable } from "rxjs";
 import type {
   ApiConsumerName,
-  ArchivedConventionRequestFormDto,
+  ArchivedConventionRequestDto,
   BeneficiaryConventionListDto,
   ConnectedUserJwt,
   ConventionDraftDto,
@@ -135,7 +135,7 @@ export interface ConventionGateway {
     jwt: string,
   ): Observable<void>;
   saveArchivedConventionRequest$(
-    archivedConventionRequest: ArchivedConventionRequestFormDto,
+    archivedConventionRequest: ArchivedConventionRequestDto,
     jwt: ConnectedUserJwt,
   ): Observable<void>;
 }

--- a/front/src/core-logic/ports/ConventionGateway.ts
+++ b/front/src/core-logic/ports/ConventionGateway.ts
@@ -1,6 +1,7 @@
 import type { Observable } from "rxjs";
 import type {
   ApiConsumerName,
+  ArchivedConventionRequestFormDto,
   BeneficiaryConventionListDto,
   ConnectedUserJwt,
   ConventionDraftDto,
@@ -132,5 +133,9 @@ export interface ConventionGateway {
   deleteConventionTemplate$(
     conventionTemplateId: ConventionTemplateId,
     jwt: string,
+  ): Observable<void>;
+  saveArchivedConventionRequest$(
+    archivedConventionRequest: ArchivedConventionRequestFormDto,
+    jwt: ConnectedUserJwt,
   ): Observable<void>;
 }

--- a/front/src/core-logic/storeConfig/store.ts
+++ b/front/src/core-logic/storeConfig/store.ts
@@ -44,6 +44,8 @@ import { connectedUserConventionsEpics } from "src/core-logic/domain/connected-u
 import { connectedUserConventionsToManageSlice } from "src/core-logic/domain/connected-user/conventionsToManage/connectedUserConventionsToManage.slice";
 import { conventionsWithBroadcastFeedbackEpics } from "src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.epics";
 import { conventionsWithBroadcastFeedbackSlice } from "src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.slice";
+import { archivedConventionRequestEpics } from "src/core-logic/domain/convention/archivedConventionRequest.epics";
+import { archivedConventionRequestSlice } from "src/core-logic/domain/convention/archivedConventionRequest.slice";
 import { conventionActionEpics } from "src/core-logic/domain/convention/convention-action/conventionAction.epics";
 import { conventionActionSlice } from "src/core-logic/domain/convention/convention-action/conventionAction.slice";
 import { conventionDraftEpics } from "src/core-logic/domain/convention/convention-draft/conventionDraft.epics";
@@ -98,6 +100,7 @@ const allEpics: AppEpic<any>[] = [
   ...appellationEpics,
   ...assessmentEpics,
   ...authEpics,
+  ...archivedConventionRequestEpics,
   ...conventionActionEpics,
   ...conventionDraftEpics,
   ...conventionEpics,
@@ -157,6 +160,7 @@ const appReducer = combineReducers({
   [appellationSlice.name]: appellationSlice.reducer,
   [assessmentSlice.name]: assessmentSlice.reducer,
   [authSlice.name]: authSlice.reducer,
+  [archivedConventionRequestSlice.name]: archivedConventionRequestSlice.reducer,
   [conventionSlice.name]: conventionSlice.reducer,
   [conventionDraftSlice.name]: conventionDraftSlice.reducer,
   [conventionTemplateSlice.name]: conventionTemplateSlice.reducer,

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
@@ -1,7 +1,13 @@
 import type { ConventionId } from "../convention/convention.dto";
 import type { AppellationAndRomeDto } from "../romeAndAppellationDtos/romeAndAppellation.dto";
 import type { SiretDto } from "../siret/siret";
+import type { Flavor } from "../typeFlavors";
 import type { Firstname, Lastname } from "../user/user.dto";
+
+export type ArchivedConventionRequestId = Flavor<
+  string,
+  "ArchivedConventionRequestId"
+>;
 
 export const archivedConventionRequestReasons = [
   "legalDispute",
@@ -25,6 +31,7 @@ export type ArchivedConventionRequestReasonFields =
 
 export type ArchivedConventionRequestWithConventionIdFormDto =
   ArchivedConventionRequestReasonFields & {
+    id: ArchivedConventionRequestId;
     conventionSearchMethod: "withConventionId";
     conventionId: ConventionId;
     beneficiaryFirstName?: never;
@@ -36,13 +43,14 @@ export type ArchivedConventionRequestWithConventionIdFormDto =
 
 export type ArchivedConventionRequestWithConventionDetailsFormDto =
   ArchivedConventionRequestReasonFields & {
+    id: ArchivedConventionRequestId;
     conventionSearchMethod: "withConventionDetails";
     conventionId?: never;
     beneficiaryFirstName: Firstname;
     beneficiaryLastName: Lastname;
     siret: SiretDto;
     immersionDate: string;
-    immersionAppellation?: AppellationAndRomeDto;
+    immersionAppellation: AppellationAndRomeDto;
   };
 
 export type ArchivedConventionRequestFormDto =

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
@@ -1,0 +1,50 @@
+import type { ConventionId } from "../convention/convention.dto";
+import type { AppellationAndRomeDto } from "../romeAndAppellationDtos/romeAndAppellation.dto";
+import type { SiretDto } from "../siret/siret";
+import type { Firstname, Lastname } from "../user/user.dto";
+
+export const archivedConventionRequestReasons = [
+  "legalDispute",
+  "urssafOrInspectionControl",
+  "rpeAdvisorAccessToBeneficiaryHistory",
+  "other",
+] as const;
+
+export type ArchivedConventionRequestReason =
+  (typeof archivedConventionRequestReasons)[number];
+
+export type ArchivedConventionRequestReasonFields =
+  | {
+      reason: Exclude<ArchivedConventionRequestReason, "other">;
+      otherReason?: never;
+    }
+  | {
+      reason: Extract<ArchivedConventionRequestReason, "other">;
+      otherReason: string;
+    };
+
+export type ArchivedConventionRequestWithConventionIdFormDto =
+  ArchivedConventionRequestReasonFields & {
+    conventionSearchMethod: "withConventionId";
+    conventionId: ConventionId;
+    beneficiaryFirstName?: never;
+    beneficiaryLastName?: never;
+    siret?: never;
+    immersionDate?: never;
+    immersionAppellation?: never;
+  };
+
+export type ArchivedConventionRequestWithConventionDetailsFormDto =
+  ArchivedConventionRequestReasonFields & {
+    conventionSearchMethod: "withConventionDetails";
+    conventionId?: never;
+    beneficiaryFirstName: Firstname;
+    beneficiaryLastName: Lastname;
+    siret: SiretDto;
+    immersionDate: string;
+    immersionAppellation?: AppellationAndRomeDto;
+  };
+
+export type ArchivedConventionRequestFormDto =
+  | ArchivedConventionRequestWithConventionIdFormDto
+  | ArchivedConventionRequestWithConventionDetailsFormDto;

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.dto.ts
@@ -9,6 +9,10 @@ export type ArchivedConventionRequestId = Flavor<
   "ArchivedConventionRequestId"
 >;
 
+export type WithArchivedConventionRequestId = {
+  archivedConventionRequestId: ArchivedConventionRequestId;
+};
+
 export const archivedConventionRequestReasons = [
   "legalDispute",
   "urssafOrInspectionControl",
@@ -29,7 +33,7 @@ export type ArchivedConventionRequestReasonFields =
       otherReason: string;
     };
 
-export type ArchivedConventionRequestWithConventionIdFormDto =
+export type ArchivedConventionRequestWithConventionIdDto =
   ArchivedConventionRequestReasonFields & {
     id: ArchivedConventionRequestId;
     conventionSearchMethod: "withConventionId";
@@ -41,7 +45,7 @@ export type ArchivedConventionRequestWithConventionIdFormDto =
     immersionAppellation?: never;
   };
 
-export type ArchivedConventionRequestWithConventionDetailsFormDto =
+export type ArchivedConventionRequestWithConventionDetailsDto =
   ArchivedConventionRequestReasonFields & {
     id: ArchivedConventionRequestId;
     conventionSearchMethod: "withConventionDetails";
@@ -53,6 +57,6 @@ export type ArchivedConventionRequestWithConventionDetailsFormDto =
     immersionAppellation: AppellationAndRomeDto;
   };
 
-export type ArchivedConventionRequestFormDto =
-  | ArchivedConventionRequestWithConventionIdFormDto
-  | ArchivedConventionRequestWithConventionDetailsFormDto;
+export type ArchivedConventionRequestDto =
+  | ArchivedConventionRequestWithConventionIdDto
+  | ArchivedConventionRequestWithConventionDetailsDto;

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
@@ -16,9 +16,13 @@ import {
 } from "../zodUtils";
 import {
   type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestId,
   type ArchivedConventionRequestReasonFields,
   archivedConventionRequestReasons,
 } from "./archivedConventionRequest.dto";
+
+const archivedConventionRequestIdSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestId> =
+  z.uuid(localization.invalidUuid);
 
 const archivedConventionRequestReasonsWithoutOther =
   archivedConventionRequestReasons.filter((reason) => reason !== "other");
@@ -43,21 +47,19 @@ const archivedConventionRequestReasonSchema: ZodSchemaWithInputMatchingOutput<Ar
   ]);
 
 const archivedConventionRequestWithConventionIdSchema = z.object({
+  id: archivedConventionRequestIdSchema,
   conventionSearchMethod: z.literal("withConventionId"),
   conventionId: conventionIdSchema,
 });
 
 const archivedConventionRequestWithConventionDetailsSchema = z.object({
+  id: archivedConventionRequestIdSchema,
   conventionSearchMethod: z.literal("withConventionDetails"),
   beneficiaryFirstName: firstnameMandatorySchema,
   beneficiaryLastName: lastnameMandatorySchema,
   siret: siretSchema,
   immersionDate: zStringMinLength1Max255,
-  immersionAppellation: appellationAndRomeDtoSchema
-    .optional()
-    .refine((value) => value !== undefined, {
-      message: "Ce champ est obligatoire. Veuillez choisir un métier.",
-    }),
+  immersionAppellation: appellationAndRomeDtoSchema,
 });
 
 export const archivedConventionRequestSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestFormDto> =

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { conventionIdSchema } from "../convention/convention.schema";
+import { appellationAndRomeDtoSchema } from "../romeAndAppellationDtos/romeAndAppellation.schema";
+import { siretSchema } from "../siret/siret.schema";
+import {
+  firstnameMandatorySchema,
+  lastnameMandatorySchema,
+} from "../user/user.schema";
+import {
+  makeHardenedStringSchema,
+  zStringMinLength1Max255,
+} from "../utils/string.schema";
+import {
+  localization,
+  type ZodSchemaWithInputMatchingOutput,
+} from "../zodUtils";
+import {
+  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestReasonFields,
+  archivedConventionRequestReasons,
+} from "./archivedConventionRequest.dto";
+
+const archivedConventionRequestReasonsWithoutOther =
+  archivedConventionRequestReasons.filter((reason) => reason !== "other");
+
+const otherReasonSchema = makeHardenedStringSchema({
+  min: 10,
+  max: 100,
+  minMessage: localization.minCharacters(10),
+});
+
+const archivedConventionRequestReasonSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestReasonFields> =
+  z.discriminatedUnion("reason", [
+    z.object({
+      reason: z.literal("other"),
+      otherReason: otherReasonSchema,
+    }),
+    z.object({
+      reason: z.enum(archivedConventionRequestReasonsWithoutOther, {
+        error: localization.invalidEnum,
+      }),
+    }),
+  ]);
+
+const archivedConventionRequestWithConventionIdSchema = z.object({
+  conventionSearchMethod: z.literal("withConventionId"),
+  conventionId: conventionIdSchema,
+});
+
+const archivedConventionRequestWithConventionDetailsSchema = z.object({
+  conventionSearchMethod: z.literal("withConventionDetails"),
+  beneficiaryFirstName: firstnameMandatorySchema,
+  beneficiaryLastName: lastnameMandatorySchema,
+  siret: siretSchema,
+  immersionDate: zStringMinLength1Max255,
+  immersionAppellation: appellationAndRomeDtoSchema
+    .optional()
+    .refine((value) => value !== undefined, {
+      message: "Ce champ est obligatoire. Veuillez choisir un métier.",
+    }),
+});
+
+export const archivedConventionRequestSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestFormDto> =
+  z
+    .discriminatedUnion("conventionSearchMethod", [
+      archivedConventionRequestWithConventionIdSchema,
+      archivedConventionRequestWithConventionDetailsSchema,
+    ])
+    .and(archivedConventionRequestReasonSchema);

--- a/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
+++ b/shared/src/archivedConventionRequest/archivedConventionRequest.schema.ts
@@ -15,7 +15,7 @@ import {
   type ZodSchemaWithInputMatchingOutput,
 } from "../zodUtils";
 import {
-  type ArchivedConventionRequestFormDto,
+  type ArchivedConventionRequestDto,
   type ArchivedConventionRequestId,
   type ArchivedConventionRequestReasonFields,
   archivedConventionRequestReasons,
@@ -62,7 +62,7 @@ const archivedConventionRequestWithConventionDetailsSchema = z.object({
   immersionAppellation: appellationAndRomeDtoSchema,
 });
 
-export const archivedConventionRequestSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestFormDto> =
+export const archivedConventionRequestSchema: ZodSchemaWithInputMatchingOutput<ArchivedConventionRequestDto> =
   z
     .discriminatedUnion("conventionSearchMethod", [
       archivedConventionRequestWithConventionIdSchema,

--- a/shared/src/auth/auth.dto.ts
+++ b/shared/src/auth/auth.dto.ts
@@ -21,6 +21,7 @@ export const allowedLoginSources = [
   "beneficiaryDashboard",
   "beneficiaryDashboardDiscussions",
   "beneficiaryDashboardConventions",
+  "archivedConventionRequest",
 ] as const;
 
 export type ExternalId = Flavor<string, "ExternalId">;

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -1245,6 +1245,12 @@ export const domElementIds = {
     reasonSelect: "im-archived-convention-request__reason-select",
     otherReasonInput: "im-archived-convention-request__other-reason-input",
     submitButton: "im-archived-convention-request__submit-button",
+    success: {
+      goToMyAccountButton:
+        "im-archived-convention-request-success__go-to-my-account-button",
+      newRequestButton:
+        "im-archived-convention-request-success__new-request-button",
+    },
     login: {
       proConnectButton:
         "im-login-form__inclusion-connect-button--archived-convention-request",

--- a/shared/src/domElementIds.ts
+++ b/shared/src/domElementIds.ts
@@ -98,6 +98,9 @@ export const domElementIds = {
       agencyformConvention: buildFooterNavLinkId(
         "footer-nav-top-agency-form-convention",
       ),
+      archivedConventionRequest: buildFooterNavLinkId(
+        "footer-nav-top-archived-convention-request",
+      ),
       linkedin: buildFooterNavLinkId("footer-nav-top-linkedin"),
     },
     links: {
@@ -1225,6 +1228,35 @@ export const domElementIds = {
     },
     displayPhoneContactButton:
       "im-beneficiary-discussion_display-phone-contact-button",
+  },
+  archivedConventionRequest: {
+    form: "im-archived-convention-request__form",
+    conventionSearchMethod:
+      "im-archived-convention-request__convention-search-method",
+    conventionIdInput: "im-archived-convention-request__convention-id-input",
+    beneficiaryFirstNameInput:
+      "im-archived-convention-request__beneficiary-first-name-input",
+    beneficiaryLastNameInput:
+      "im-archived-convention-request__beneficiary-last-name-input",
+    siretInput: "im-archived-convention-request__siret-input",
+    immersionDateInput: "im-archived-convention-request__immersion-date-input",
+    appellationAutocomplete:
+      "im-archived-convention-request__appellation-autocomplete",
+    reasonSelect: "im-archived-convention-request__reason-select",
+    otherReasonInput: "im-archived-convention-request__other-reason-input",
+    submitButton: "im-archived-convention-request__submit-button",
+    login: {
+      proConnectButton:
+        "im-login-form__inclusion-connect-button--archived-convention-request",
+      byEmailButton:
+        "im-login-form__connect-button--archived-convention-request-email",
+      navigateToHome:
+        "im-login-form__navigate-to-home-button--archived-convention-request",
+      retryButton:
+        "im-login-form__retry-login-button--archived-convention-request",
+      contactSupport:
+        "im-login-form__contact-support-link--archived-convention-request",
+    },
   },
   conventionTemplate: {
     login: {

--- a/shared/src/email/EmailParamsByEmailType.ts
+++ b/shared/src/email/EmailParamsByEmailType.ts
@@ -3,6 +3,7 @@ import type {
   DelegationAgencyKind,
   DelegationConventionReminderKind,
 } from "../agency/agency.dto";
+import type { ArchivedConventionRequestId } from "../archivedConventionRequest/archivedConventionRequest.dto";
 import type {
   AssessmentDtoCompleted,
   AssessmentDtoPartiallyCompleted,
@@ -97,6 +98,9 @@ export type EmailParamsByEmailType = {
       agencyName: string;
       adminEmails: Email[];
     }[];
+  };
+  ARCHIVED_CONVENTION_REQUEST_RECEIVED: {
+    archivedConventionRequestId: ArchivedConventionRequestId;
   };
   AGENCY_WAS_ACTIVATED: {
     agencyName: string;

--- a/shared/src/email/emailTemplatesByName.ts
+++ b/shared/src/email/emailTemplatesByName.ts
@@ -470,6 +470,35 @@ export const emailTemplatesByName =
         };
       },
     },
+    ARCHIVED_CONVENTION_REQUEST_RECEIVED: {
+      niceName: "Convention - Demande archivée accusé de réception",
+      tags: [
+        "template:demandeArchiveAccuseReception",
+        "theme:convention",
+        "role:utilisateurInitiateur",
+      ],
+      createEmailVariables: ({ archivedConventionRequestId }) => ({
+        subject: "Nous avons bien reçu votre demande de convention archivée",
+        greetings: `<strong>Identifiant de la demande d'accès à une convention archivée : ${archivedConventionRequestId}</strong>`,
+        content: `
+          Bonjour,
+
+          Nous vous confirmons la bonne réception de votre demande d'accès à une convention d'immersion archivée.
+
+          <strong>Que va-t-il se passer ensuite ?</strong>
+
+          <ul>
+          <li>Notre équipe va examiner votre demande (motif et informations fournies) pour s'assurer que nous pouvons vous transmettre ces documents de manière légitime.</li>
+          <li>Si votre demande est validée, la convention ainsi que le bilan d'immersion vous seront envoyés directement par email d'ici quelques jours.</li>
+          </ul>
+
+          Si nous avons besoin d'informations complémentaires pour retrouver votre convention, nous vous contacterons à cette adresse.
+
+          Vous n'avez aucune autre action à réaliser pour le moment.
+        `,
+        subContent: defaultSignature("immersion"),
+      }),
+    },
     AGENCY_WAS_ACTIVATED: {
       niceName: "Espace prescripteur - Admin agence - Agence activée",
       tags: [

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -685,7 +685,7 @@ export const errors = {
       ),
     unknownReason: ({ reason }: { reason: string }) =>
       new Error(
-        `La raison de demande de convention archivée est inconnue : ${reason}`,
+        `La raison de la demande de convention archivée est inconnue : ${reason}`,
       ),
     incomplete: ({ id }: { id: string }) =>
       new Error(`La demande de convention archivée est incomplète pour ${id}`),

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -679,6 +679,10 @@ export const errors = {
       ),
   },
   archivedConventionRequest: {
+    notFound: ({ id }: { id: string }) =>
+      new NotFoundError(
+        `Aucune demande de convention archivée trouvée avec l'identifiant '${id}'.`,
+      ),
     unknownReason: ({ reason }: { reason: string }) =>
       new Error(
         `La raison de demande de convention archivée est inconnue : ${reason}`,

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -678,6 +678,14 @@ export const errors = {
         `Aucun modèle de convention trouvé avec l'identifiant '${conventionTemplateId}'.`,
       ),
   },
+  archivedConventionRequest: {
+    unknownReason: ({ reason }: { reason: string }) =>
+      new Error(`La raison de demande de convention archivée est inconnue : ${reason}`),
+    incomplete: ({ id }: { id: string }) =>
+      new Error(
+        `La demande de convention archivée est incomplète pour ${id}`,
+      ),
+  },
   establishment: {
     badPagination: ({
       page,

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -680,11 +680,11 @@ export const errors = {
   },
   archivedConventionRequest: {
     unknownReason: ({ reason }: { reason: string }) =>
-      new Error(`La raison de demande de convention archivée est inconnue : ${reason}`),
-    incomplete: ({ id }: { id: string }) =>
       new Error(
-        `La demande de convention archivée est incomplète pour ${id}`,
+        `La raison de demande de convention archivée est inconnue : ${reason}`,
       ),
+    incomplete: ({ id }: { id: string }) =>
+      new Error(`La demande de convention archivée est incomplète pour ${id}`),
   },
   establishment: {
     badPagination: ({

--- a/shared/src/featureFlag/featureFlags.dto.ts
+++ b/shared/src/featureFlag/featureFlags.dto.ts
@@ -17,6 +17,7 @@ export const featureFlagNames = [
   "enableAgencyDashboardHighlight",
   "enableInactiveUsersCleanup",
   "enableInactiveUsersDeletionAutoProcessing",
+  "enableRequestArchivedConvention",
 ] as const;
 
 const _insureAllFeatureFlagsAreInList = (
@@ -88,6 +89,7 @@ export type FeatureFlags = {
   enableAgencyDashboardHighlight: FeatureFlagHighlight;
   enableInactiveUsersCleanup: FeatureFlagBoolean;
   enableInactiveUsersDeletionAutoProcessing: FeatureFlagBoolean;
+  enableRequestArchivedConvention: FeatureFlagBoolean;
 };
 
 export type SetFeatureFlagParam = {

--- a/shared/src/featureFlag/featureFlags.schema.ts
+++ b/shared/src/featureFlag/featureFlags.schema.ts
@@ -118,4 +118,5 @@ export const featureFlagsSchema: ZodSchemaWithInputMatchingOutput<FeatureFlags> 
     enableAgencyDashboardHighlight: featureFlagHighlightSchema,
     enableInactiveUsersCleanup: featureFlagBooleanSchema,
     enableInactiveUsersDeletionAutoProcessing: featureFlagBooleanSchema,
+    enableRequestArchivedConvention: featureFlagBooleanSchema,
   });

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -16,6 +16,8 @@ export * from "./agency/publicAgency.schema";
 export * from "./agency-group/agencyGroup";
 export * from "./apiConsumer/ApiConsumer";
 export * from "./apiConsumer/apiConsumer.schema";
+export * from "./archivedConventionRequest/archivedConventionRequest.dto";
+export * from "./archivedConventionRequest/archivedConventionRequest.schema";
 export * from "./assertions";
 export * from "./assessment/AssessmentDtoBuilder";
 export * from "./assessment/assessment.dto";

--- a/shared/src/routes/convention.routes.ts
+++ b/shared/src/routes/convention.routes.ts
@@ -1,13 +1,13 @@
 import { defineRoute, defineRoutes } from "shared-routes";
 import z from "zod";
 import { apiConsumerReadSchema } from "../apiConsumer/apiConsumer.schema";
+import { archivedConventionRequestSchema } from "../archivedConventionRequest/archivedConventionRequest.schema";
 import {
   assessmentDtoSchema,
   deleteAssessmentRequestDtoSchema,
   legacyAssessmentDtoSchema,
   signAssessmentRequestDtoSchema,
 } from "../assessment/assessment.schema";
-import { archivedConventionRequestSchema } from "../archivedConventionRequest/archivedConventionRequest.schema";
 import { broadcastFeedbackSchema } from "../broadcast/broadcastFeedback.schema";
 import { addConventionInputSchema } from "../convention/addConventionInput";
 import {

--- a/shared/src/routes/convention.routes.ts
+++ b/shared/src/routes/convention.routes.ts
@@ -7,6 +7,7 @@ import {
   legacyAssessmentDtoSchema,
   signAssessmentRequestDtoSchema,
 } from "../assessment/assessment.schema";
+import { archivedConventionRequestSchema } from "../archivedConventionRequest/archivedConventionRequest.schema";
 import { broadcastFeedbackSchema } from "../broadcast/broadcastFeedback.schema";
 import { addConventionInputSchema } from "../convention/addConventionInput";
 import {
@@ -253,6 +254,18 @@ export const conventionMagicLinkRoutes = defineRoutes({
       401: httpErrorSchema,
       403: httpErrorSchema,
       404: httpErrorSchema,
+    },
+  }),
+
+  createArchivedConventionRequest: defineRoute({
+    url: "/auth/archived-convention",
+    method: "post",
+    requestBodySchema: archivedConventionRequestSchema,
+    ...withAuthorizationHeaders,
+    responses: {
+      201: expressEmptyResponseBody,
+      400: httpErrorSchema,
+      401: httpErrorSchema,
     },
   }),
 });

--- a/shared/src/routes/routes.ts
+++ b/shared/src/routes/routes.ts
@@ -40,6 +40,7 @@ const allowedLoginSourcesRoutes: Record<AllowedLoginSource, string> = {
   beneficiaryDashboard: "tableau-de-bord-beneficiaire",
   beneficiaryDashboardDiscussions: "tableau-de-bord-beneficiaire/discussions",
   beneficiaryDashboardConventions: "tableau-de-bord-beneficiaire/conventions",
+  archivedConventionRequest: "demande-convention-archivee",
 };
 
 export const legacyFrontRoutes = {
@@ -239,7 +240,10 @@ export const {
     { ...connectedUserParams, siret: param.query.optional.string },
     () => `/${legacyFrontRoutes.addAgency}`,
   ),
-
+  archivedConventionRequest: defineRoute(
+    connectedUserParams,
+    () => `/${legacyFrontRoutes.archivedConventionRequest}`,
+  ),
   admin,
   ...restOfAdminRoutes,
   adminConventions,

--- a/shared/src/zodUtils.ts
+++ b/shared/src/zodUtils.ts
@@ -27,6 +27,7 @@ export const localization = {
   invalidValidationFormatDate:
     "Le format de la date de validation est invalide.",
   invalidApprovalFormatDate: "Le format de la date d'approbation est invalide",
+  minCharacters: (min: number) => `Le minimum est de ${min} caractères`,
   maxCharacters: (max: number) => `Le maximum est de ${max} caractères`,
   mustBeSignedByEveryone: "La confirmation de votre accord est obligatoire.",
   required: "Ce champ est obligatoire",


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Je n'utilise la feature flag que pour cacher le lien d'accès au formulaire de demande de convention archivée.
On peut toujours y accéder par url direct, et l'api n'est pas bloquée tant que l'utilisateur est connecté.
