### PR TITLE
#5386 - Suspension temporaire de la fermeture automatique des agences inactives

### DIFF
--- a/back/scalingo/cron.json
+++ b/back/scalingo/cron.json
@@ -75,10 +75,6 @@
     {
       "command": "0 15 * * 6 pnpm back run trigger-delete-old-closed-agencies-without-conventions",
       "size": "M"
-    },
-    {
-      "command": "0 7 1 * * pnpm back run trigger-close-inactive-agencies-without-recent-conventions",
-      "size": "M"
     }
   ]
 }


### PR DESCRIPTION
Fixes #5386

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Après déploiement, le job `trigger-close-inactive-agencies-without-recent-conventions` ne sera plus planifié. Le script reste disponible pour un lancement manuel. Pour réactiver : remettre l'entrée dans `back/scalingo/cron.json`.