### PR TITLE
#5431 - Ajouter le détail des dates de relance SMS et email dans la pop-in de relance lorsque aucune relance n'est autorisée

### DIFF
--- a/front/src/app/components/convention/SendReminderModal.tsx
+++ b/front/src/app/components/convention/SendReminderModal.tsx
@@ -79,7 +79,11 @@ export const SendReminderModal = ({
     ? isEmailDisabled && isSmsDisabled
     : isEmailDisabled;
 
+  const isBothChannelsBlocked =
+    hasMobilePhone && isEmailDisabled && isSmsDisabled;
+
   const emailLastSentAt = lastReminderDateByNotificationKind?.email;
+  const smsLastSentAt = lastReminderDateByNotificationKind?.sms;
 
   const handleCancel = () => {
     setNotificationKind(undefined);
@@ -140,16 +144,25 @@ export const SendReminderModal = ({
       ]}
     >
       {isAllChannelsBlocked && emailLastSentAt ? (
-        <p>
-          {formatBlockedReminderMessage(
-            getFirstChannelAvailableAgainLastSentAt({
-              emailLastSentAt,
-              smsLastSentAt: lastReminderDateByNotificationKind?.sms,
-            }),
-            now,
-            recipientFullName,
-          )}
-        </p>
+        isBothChannelsBlocked && smsLastSentAt ? (
+          <BothChannelsBlockedReminderMessage
+            recipientFullName={recipientFullName}
+            emailLastSentAt={emailLastSentAt}
+            smsLastSentAt={smsLastSentAt}
+            now={now}
+          />
+        ) : (
+          <p>
+            {formatBlockedReminderMessage(
+              getFirstChannelAvailableAgainLastSentAt({
+                emailLastSentAt,
+                smsLastSentAt,
+              }),
+              now,
+              recipientFullName,
+            )}
+          </p>
+        )
       ) : (
         <>
           {description}
@@ -209,6 +222,53 @@ export const SendReminderModal = ({
       )}
     </modal.Component>,
     document.body,
+  );
+};
+
+const BothChannelsBlockedReminderMessage = ({
+  recipientFullName,
+  emailLastSentAt,
+  smsLastSentAt,
+  now,
+}: {
+  recipientFullName?: string;
+  emailLastSentAt: DateTimeIsoString;
+  smsLastSentAt: DateTimeIsoString;
+  now: Date;
+}) => {
+  const recipientPart = recipientFullName ? ` à ${recipientFullName}` : "";
+  const earliestLastSentAt = getFirstChannelAvailableAgainLastSentAt({
+    emailLastSentAt,
+    smsLastSentAt,
+  });
+
+  return (
+    <>
+      <p>Une relance a déjà été envoyée{recipientPart} :</p>
+      <ul>
+        <li>
+          par SMS le{" "}
+          {toDisplayedDate({ date: new Date(smsLastSentAt), withHours: true })}
+        </li>
+        <li>
+          par email le{" "}
+          {toDisplayedDate({
+            date: new Date(emailLastSentAt),
+            withHours: true,
+          })}
+        </li>
+      </ul>
+      <p>
+        Afin d’éviter les envois excessifs, vous ne pourrez effectuer un nouvel
+        envoi que dans{" "}
+        {formatHoursCooldownTimeRemaining({
+          lastActionAt: new Date(earliestLastSentAt),
+          minHours: CONVENTION_MANUAL_REMINDER_COOLDOWN_IN_HOURS,
+          now,
+        })}
+        .
+      </p>
+    </>
   );
 };
 

--- a/front/src/app/components/convention/SendReminderModal.tsx
+++ b/front/src/app/components/convention/SendReminderModal.tsx
@@ -1,3 +1,4 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import type { ModalProps } from "@codegouvfr/react-dsfr/Modal";
 import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import { type ComponentType, type ReactNode, useState } from "react";
@@ -244,7 +245,9 @@ const BothChannelsBlockedReminderMessage = ({
 
   return (
     <>
-      <p>Une relance a déjà été envoyée{recipientPart} :</p>
+      <p className={fr.cx("fr-mb-0")}>
+        Une relance a déjà été envoyée{recipientPart} :
+      </p>
       <ul>
         <li>
           par SMS le{" "}

--- a/front/src/app/components/convention/SendReminderModal.tsx
+++ b/front/src/app/components/convention/SendReminderModal.tsx
@@ -80,9 +80,6 @@ export const SendReminderModal = ({
     ? isEmailDisabled && isSmsDisabled
     : isEmailDisabled;
 
-  const isBothChannelsBlocked =
-    hasMobilePhone && isEmailDisabled && isSmsDisabled;
-
   const emailLastSentAt = lastReminderDateByNotificationKind?.email;
   const smsLastSentAt = lastReminderDateByNotificationKind?.sms;
 
@@ -119,6 +116,33 @@ export const SendReminderModal = ({
     (selectedNotificationKind === "email" && isEmailDisabled) ||
     (selectedNotificationKind === "sms" && isSmsDisabled);
 
+  const renderBlockedReminderContent = (
+    blockedEmailLastSentAt: DateTimeIsoString,
+  ) => {
+    if (hasMobilePhone && smsLastSentAt)
+      return (
+        <BothChannelsBlockedReminderMessage
+          recipientFullName={recipientFullName}
+          emailLastSentAt={blockedEmailLastSentAt}
+          smsLastSentAt={smsLastSentAt}
+          now={now}
+        />
+      );
+
+    return (
+      <p>
+        {formatBlockedReminderMessage(
+          getFirstChannelAvailableAgainLastSentAt({
+            emailLastSentAt: blockedEmailLastSentAt,
+            smsLastSentAt,
+          }),
+          now,
+          recipientFullName,
+        )}
+      </p>
+    );
+  };
+
   return createPortal(
     <modal.Component
       title={title}
@@ -145,25 +169,7 @@ export const SendReminderModal = ({
       ]}
     >
       {isAllChannelsBlocked && emailLastSentAt ? (
-        isBothChannelsBlocked && smsLastSentAt ? (
-          <BothChannelsBlockedReminderMessage
-            recipientFullName={recipientFullName}
-            emailLastSentAt={emailLastSentAt}
-            smsLastSentAt={smsLastSentAt}
-            now={now}
-          />
-        ) : (
-          <p>
-            {formatBlockedReminderMessage(
-              getFirstChannelAvailableAgainLastSentAt({
-                emailLastSentAt,
-                smsLastSentAt,
-              }),
-              now,
-              recipientFullName,
-            )}
-          </p>
-        )
+        renderBlockedReminderContent(emailLastSentAt)
       ) : (
         <>
           {description}


### PR DESCRIPTION
Closes #5431

## Contexte
Dans la pop-in de relance (cf. #5118), quand une relance SMS **et** une relance email ont toutes deux été effectuées il y a moins de 24h, la pop-in n'affichait qu'un seul message générique sans préciser la date de chaque canal.

## Solution
Quand les deux canaux sont bloqués (relance envoyée il y a moins de 24h), la pop-in affiche désormais le détail des deux dates :

```
Une relance a déjà été envoyée à {prénom nom} :
- par SMS le DD/MM/YYYY à HHhMM (heure de Paris)
- par email le DD/MM/YYYY à HHhMM (heure de Paris)

Afin d'éviter les envois excessifs, vous ne pourrez effectuer un nouvel envoi que dans XhXX.
```

Le cas où un seul canal est disponible (ex : pas de téléphone renseigné) garde le message existant, inchangé.

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer
Pas de test unitaire ajouté pour l'instant (aucun fichier de test n'existait déjà pour ce composant) — à discuter si besoin.

Made with [Cursor](https://cursor.com)