### PR TITLE
#5366 - Ne pas envoyer de rappel de complétion de bilan si la convention a été annulée entre temps

### DIFF
--- a/back/src/domains/establishment/use-cases/AssessmentReminder.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.ts
@@ -12,7 +12,6 @@ import {
   immersionFacileNoReplyEmailSender,
   localization,
   makeRouteAbsoluteUrl,
-  unvalidatedConventionStatuses,
 } from "shared";
 import { z } from "zod";
 import type { AppConfig } from "../../../config/bootstrap/appConfig";
@@ -83,7 +82,7 @@ export const makeAssessmentReminder = useCaseBuilder("AssessmentReminder")
       outOfTrx: deps.outOfTrx,
     });
 
-    const remindedConventionsCount = await executeInSequence(
+    const potentialRemindedConventions = await executeInSequence(
       conventionIdsToRemind,
       (conventionId) =>
         sendAssessmentReminderIfNeeded({
@@ -98,7 +97,7 @@ export const makeAssessmentReminder = useCaseBuilder("AssessmentReminder")
     );
 
     return {
-      numberOfConventionsReminded: remindedConventionsCount.filter(
+      numberOfConventionsReminded: potentialRemindedConventions.filter(
         (wasReminded) => wasReminded,
       ).length,
     };
@@ -119,10 +118,7 @@ const sendAssessmentReminderIfNeeded = async ({
     await uow.conventionQueries.getConventionById(conventionId);
   if (!convention) throw errors.convention.notFound({ conventionId });
 
-  if (
-    unvalidatedConventionStatuses.some((status) => status === convention.status)
-  )
-    return false;
+  if (convention.status === "CANCELLED") return false;
 
   await sendAssessmentReminders({
     uow,

--- a/back/src/domains/establishment/use-cases/AssessmentReminder.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.ts
@@ -12,6 +12,7 @@ import {
   immersionFacileNoReplyEmailSender,
   localization,
   makeRouteAbsoluteUrl,
+  unvalidatedConventionStatuses,
 } from "shared";
 import { z } from "zod";
 import type { AppConfig } from "../../../config/bootstrap/appConfig";
@@ -82,26 +83,59 @@ export const makeAssessmentReminder = useCaseBuilder("AssessmentReminder")
       outOfTrx: deps.outOfTrx,
     });
 
-    await executeInSequence(conventionIdsToRemind, async (conventionId) => {
-      const convention =
-        await uow.conventionQueries.getConventionById(conventionId);
-      if (!convention)
-        throw errors.convention.notFound({ conventionId: conventionId });
-      await sendAssessmentReminders({
-        uow,
-        convention,
-        now,
-        generateConventionMagicLinkUrl: deps.generateConventionMagicLinkUrl,
-        saveNotificationAndRelatedEvent: deps.saveNotificationAndRelatedEvent,
-        shortLinkIdGeneratorGateway: deps.shortLinkIdGeneratorGateway,
-        config: deps.config,
-      });
-    });
+    const remindedConventionsCount = await executeInSequence(
+      conventionIdsToRemind,
+      (conventionId) =>
+        sendAssessmentReminderIfNeeded({
+          conventionId,
+          uow,
+          now,
+          generateConventionMagicLinkUrl: deps.generateConventionMagicLinkUrl,
+          saveNotificationAndRelatedEvent: deps.saveNotificationAndRelatedEvent,
+          shortLinkIdGeneratorGateway: deps.shortLinkIdGeneratorGateway,
+          config: deps.config,
+        }),
+    );
 
     return {
-      numberOfConventionsReminded: conventionIdsToRemind.length,
+      numberOfConventionsReminded: remindedConventionsCount.filter(
+        (wasReminded) => wasReminded,
+      ).length,
     };
   });
+
+const sendAssessmentReminderIfNeeded = async ({
+  uow,
+  conventionId,
+  now,
+  generateConventionMagicLinkUrl,
+  saveNotificationAndRelatedEvent,
+  shortLinkIdGeneratorGateway,
+  config,
+}: Omit<SendAssessmentReminderParams, "convention"> & {
+  conventionId: ConventionId;
+}): Promise<boolean> => {
+  const convention =
+    await uow.conventionQueries.getConventionById(conventionId);
+  if (!convention) throw errors.convention.notFound({ conventionId });
+
+  if (
+    unvalidatedConventionStatuses.some((status) => status === convention.status)
+  )
+    return false;
+
+  await sendAssessmentReminders({
+    uow,
+    convention,
+    now,
+    generateConventionMagicLinkUrl,
+    saveNotificationAndRelatedEvent,
+    shortLinkIdGeneratorGateway,
+    config,
+  });
+
+  return true;
+};
 
 const getConventionIdsToRemind = async ({
   mode,

--- a/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
+++ b/back/src/domains/establishment/use-cases/AssessmentReminder.unit.test.ts
@@ -140,6 +140,36 @@ describe("AssessmentReminder", () => {
       ]);
       expectObjectInArrayToMatch(uow.outboxRepository.events, []);
     });
+
+    it("when convention is cancelled", async () => {
+      const cancelledConvention = new ConventionDtoBuilder()
+        .withId("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2")
+        .withStatus("CANCELLED")
+        .withStatusJustification("Annulée par le bénéficiaire")
+        .withDateStart(subDays(subMonths(now, 3), 2).toISOString())
+        .withDateEnd(subMonths(now, 3).toISOString())
+        .withSchedule(reasonableSchedule)
+        .withAgencyId(agency.id)
+        .build();
+      await uow.conventionRepository.save(cancelledConvention);
+      const initialEstablishmentNotification: Notification =
+        buildEstablishmentNotificationFrom({
+          convention: cancelledConvention,
+          createdAt: subDays(now, 3).toISOString(),
+        });
+      await uow.notificationRepository.save(initialEstablishmentNotification);
+      shortLinkIdGeneratorGateway.addMoreShortLinkIds(["short-link-id-1"]);
+
+      const { numberOfConventionsReminded } = await assessmentReminder.execute({
+        mode: "3daysAfterInitialAssessmentEmail",
+      });
+
+      expect(numberOfConventionsReminded).toBe(0);
+      expectObjectInArrayToMatch(uow.notificationRepository.notifications, [
+        initialEstablishmentNotification,
+      ]);
+      expectObjectInArrayToMatch(uow.outboxRepository.events, []);
+    });
   });
 
   describe("reminders are sent", () => {


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/gip-inclusion/projects/10?query=sort%3Aupdated-desc+is%3Aopen)
