### PR TITLE
#5466 - Fix du déclenchement des workflows quand une PR passe de draft à ready for review

### DIFF
--- a/.github/workflows/validation-pr.yml
+++ b/.github/workflows/validation-pr.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - synchronize
+      - ready_for_review
 concurrency:
   group: review-app-${{ github.event.number }}
   cancel-in-progress: true
@@ -50,7 +51,7 @@ jobs:
         with:
           script: |
             const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/review-app-trigger.yml`;
-            
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -58,10 +59,9 @@ jobs:
               body: `📌 Deploy a review app for this PR:
 
               ➡️ [Click here to deploy review app](${workflowUrl}?ref=${context.payload.pull_request.head.ref})
-            
+
               When clicking the link above:
               1. Click the "Run workflow" button
               2. Enter this PR number: ${context.issue.number}
               3. Click "Run workflow" to start the deployment`
             });
-


### PR DESCRIPTION
Fixes #5466

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)