### PR TITLE
#5475 - Ne plus conserver les informations d’un brouillon après avoir quitté le formulaire

### DIFF
--- a/back/src/scripts/seed/conventionDraftSeed.ts
+++ b/back/src/scripts/seed/conventionDraftSeed.ts
@@ -18,7 +18,7 @@ export const conventionDraftSeed = async (uow: UnitOfWork) => {
         lastName: "Doe",
         email: "john.doe@example.com",
         phone: "0202020202",
-        birthdate: new Date("2000-10-10T00:00:00.000Z").toISOString(),
+        birthdate: "2000-10-10",
       },
       establishmentRepresentative: {
         firstName: "Bob",

--- a/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
+++ b/front/src/app/components/forms/convention/ConventionFormWrapper.tsx
@@ -201,6 +201,7 @@ export const ConventionFormWrapper = ({
     dispatch(feedbackSlice.actions.clearFeedbacksTriggered());
     return () => {
       dispatch(conventionSlice.actions.clearFetchedConvention());
+      dispatch(conventionDraftSlice.actions.clearFetchedConventionDraft());
       dispatch(
         conventionSlice.actions.showSummaryChangeRequested({
           showSummary: false,

--- a/front/src/core-logic/domain/convention/convention-draft/conventionDraft.slice.ts
+++ b/front/src/core-logic/domain/convention/convention-draft/conventionDraft.slice.ts
@@ -47,6 +47,10 @@ export const conventionDraftSlice = createSlice({
     ) => {
       state.isLoading = false;
     },
+    clearFetchedConventionDraft: (state) => {
+      state.conventionDraft = initialConventionDraftState.conventionDraft;
+      state.isLoading = initialConventionDraftState.isLoading;
+    },
     saveConventionDraftThenRedirectRequested: (
       state,
       _action: PayloadActionWithFeedbackTopic<

--- a/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
+++ b/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
@@ -28,16 +28,18 @@ describe("ConventionDraft slice", () => {
     internshipKind: "immersion",
   };
 
+  const conventionDraftStateInitial: ConventionDraftState = {
+    isLoading: false,
+    conventionDraft: null,
+  };
+
   beforeEach(() => {
     ({ store, dependencies } = createTestStore());
   });
 
   describe("Fetch convention draft", () => {
     it("fetches a convention draft successfully", () => {
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       store.dispatch(
         conventionDraftSlice.actions.fetchConventionDraftRequested({
@@ -62,10 +64,7 @@ describe("ConventionDraft slice", () => {
     it("stores error when fetching convention draft fails", () => {
       const errorMessage = "Convention draft not found";
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       store.dispatch(
         conventionDraftSlice.actions.fetchConventionDraftRequested({
@@ -82,10 +81,7 @@ describe("ConventionDraft slice", () => {
         new Error(errorMessage),
       );
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       expectToEqual(
         feedbacksSelectors.feedbacks(store.getState())["convention-draft"],
@@ -117,19 +113,13 @@ describe("ConventionDraft slice", () => {
         conventionDraftSlice.actions.clearFetchedConventionDraft(),
       );
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
     });
   });
 
   describe("save convention draft", () => {
     it("fetches convention draft successfully before sharing", () => {
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       store.dispatch(
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
@@ -147,10 +137,7 @@ describe("ConventionDraft slice", () => {
 
       dependencies.conventionGateway.saveConventionDraftResult$.next();
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
       expectToEqual(
         feedbacksSelectors.feedbacks(store.getState())["convention-draft"],
         {
@@ -165,10 +152,7 @@ describe("ConventionDraft slice", () => {
     it("handles error when fetching convention draft fails before sharing", () => {
       const errorMessage = "Erreur lors de l'envoi de l'email";
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       store.dispatch(
         conventionDraftSlice.actions.saveConventionDraftThenRedirectRequested({
@@ -188,10 +172,7 @@ describe("ConventionDraft slice", () => {
         new Error(errorMessage),
       );
 
-      expectConventionDraftState({
-        isLoading: false,
-        conventionDraft: null,
-      });
+      expectConventionDraftState(conventionDraftStateInitial);
 
       expectToEqual(
         feedbacksSelectors.feedbacks(store.getState())["convention-draft"],

--- a/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
+++ b/front/src/core-logic/domain/convention/convention-draft/conventionDraft.test.ts
@@ -99,6 +99,31 @@ describe("ConventionDraft slice", () => {
     });
   });
 
+  describe("Clear fetched convention draft", () => {
+    it("resets the convention draft state", () => {
+      store.dispatch(
+        conventionDraftSlice.actions.fetchConventionDraftRequested({
+          conventionDraftId,
+          feedbackTopic: "convention-draft",
+        }),
+      );
+      dependencies.conventionGateway.conventionDraft$.next(conventionDraft);
+      expectConventionDraftState({
+        isLoading: false,
+        conventionDraft: conventionDraft,
+      });
+
+      store.dispatch(
+        conventionDraftSlice.actions.clearFetchedConventionDraft(),
+      );
+
+      expectConventionDraftState({
+        isLoading: false,
+        conventionDraft: null,
+      });
+    });
+  });
+
   describe("save convention draft", () => {
     it("fetches convention draft successfully before sharing", () => {
       expectConventionDraftState({


### PR DESCRIPTION
Fixes #5475

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
