### PR TITLE
#5516 - déplacer la fonctionnalité marquer les vieilles conventions comme obsolètes dans le bon dossier des fonctionnalités de convention

### DIFF
--- a/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.test.ts
+++ b/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.test.ts
@@ -3,14 +3,14 @@ import {
   expectToEqual,
   reasonableSchedule,
 } from "shared";
-import { makeCreateNewEvent } from "../core/events/ports/EventBus";
-import { CustomTimeGateway } from "../core/time-gateway/adapters/CustomTimeGateway";
+import { makeCreateNewEvent } from "../../core/events/ports/EventBus";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
   type InMemoryUnitOfWork,
-} from "../core/unit-of-work/adapters/createInMemoryUow";
-import { InMemoryUowPerformer } from "../core/unit-of-work/adapters/InMemoryUowPerformer";
-import { TestUuidGenerator } from "../core/uuid-generator/adapters/UuidGeneratorImplementations";
+} from "../../core/unit-of-work/adapters/createInMemoryUow";
+import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import { TestUuidGenerator } from "../../core/uuid-generator/adapters/UuidGeneratorImplementations";
 import {
   type MarkOldConventionAsDeprecated,
   makeMarkOldConventionAsDeprecated,

--- a/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.ts
+++ b/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.ts
@@ -1,7 +1,7 @@
 import type { ZodSchemaWithInputMatchingOutput } from "shared";
 import { z } from "zod";
-import type { CreateNewEvent } from "../core/events/ports/EventBus";
-import { useCaseBuilder } from "../core/useCaseBuilder";
+import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 const markOldConventionAsDeprecatedSchema: ZodSchemaWithInputMatchingOutput<{
   deprecateSince: Date;

--- a/back/src/scripts/scheduledScripts/markOldConventionAsDeprecated.ts
+++ b/back/src/scripts/scheduledScripts/markOldConventionAsDeprecated.ts
@@ -1,7 +1,7 @@
 import { subMonths } from "date-fns";
 import { AppConfig } from "../../config/bootstrap/appConfig";
 import { createMakeProductionPgPool } from "../../config/pg/pgPool";
-import { makeMarkOldConventionAsDeprecated } from "../../domains/convention/MarkOldConventionAsDeprecated";
+import { makeMarkOldConventionAsDeprecated } from "../../domains/convention/use-cases/MarkOldConventionAsDeprecated";
 import { makeCreateNewEvent } from "../../domains/core/events/ports/EventBus";
 import { RealTimeGateway } from "../../domains/core/time-gateway/adapters/RealTimeGateway";
 import { createDbRelatedSystems } from "../../domains/core/unit-of-work/adapters/createDbRelatedSystems";


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
