### PR TITLE
#5518 - Tech - Uniformiser le calcul des rôles des utilisateurs connectés sur une convention

### DIFF
--- a/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/convention.e2e.test.ts
@@ -1163,9 +1163,10 @@ describe("convention e2e", () => {
         status: 403,
         body: {
           status: 403,
-          message: errors.user.noRightsOnAgency({
-            agencyId: peAgency.id,
-            userId: beneficiary.id,
+          message: errors.convention.badRoleStatusChange({
+            roles: ["beneficiary"],
+            status: "REJECTED",
+            conventionId: convention.id,
           }).message,
         },
       });

--- a/back/src/domains/connected-users/helpers/authorization.helper.ts
+++ b/back/src/domains/connected-users/helpers/authorization.helper.ts
@@ -8,6 +8,7 @@ import {
   type ConventionDto,
   type ConventionRelatedJwtPayload,
   errors,
+  getConventionManageAllowedRoles,
   type Role,
   type UserWithAdminRights,
 } from "shared";
@@ -184,54 +185,7 @@ const onConnectedUser = async ({
     }
   }
 
-  if (
-    userWithRights.isBackofficeAdmin &&
-    authorizedRoles.includes("back-office")
-  ) {
-    return;
-  }
-
-  if (
-    userWithRights.email === convention.signatories.beneficiary.email &&
-    authorizedRoles.includes("beneficiary")
-  ) {
-    return;
-  }
-
-  if (
-    userWithRights.email ===
-      convention.signatories.establishmentRepresentative.email &&
-    authorizedRoles.includes("establishment-representative")
-  ) {
-    return;
-  }
-
-  if (
-    userWithRights.email === convention.establishmentTutor.email &&
-    authorizedRoles.includes("establishment-tutor")
-  ) {
-    return;
-  }
-
-  const hasAuthorizedAgencyRole = userWithRights.agencyRights.some(
-    (agencyRight) =>
-      agencyRight.agency.id === convention.agencyId &&
-      agencyRight.roles.some((role) => authorizedRoles.includes(role)),
-  );
-
-  if (hasAuthorizedAgencyRole) {
-    return;
-  }
-
-  const hasAuthorizedEstablishmentRole = userWithRights.establishments?.some(
-    (establishmentRight) =>
-      authorizedRoles.includes(establishmentRight.role) &&
-      establishmentRight.siret === convention.siret,
-  );
-
-  if (hasAuthorizedEstablishmentRole) {
-    return;
-  }
-
+  const roles = getConventionManageAllowedRoles(convention, userWithRights);
+  if (roles.some((role) => authorizedRoles.includes(role))) return;
   throw errorToThrow;
 };

--- a/back/src/domains/convention/entities/Convention.ts
+++ b/back/src/domains/convention/entities/Convention.ts
@@ -18,6 +18,8 @@ import {
   errors,
   type FeatureFlags,
   ForbiddenError,
+  getConventionManageAllowedRoles,
+  isSignatoryRole,
   isValidMobilePhone,
   type Role,
   type Signatories,
@@ -318,26 +320,16 @@ export const getSignatoryRoleAndUserFromJwtPayload = async (
     return { role: jwtPayload.role, userWithRights: undefined };
 
   const userWithRights = await getUserWithRights(uow, jwtPayload.userId);
+  const roles = getConventionManageAllowedRoles(convention, userWithRights);
+  const role = roles.find(isSignatoryRole);
 
-  if (
-    userWithRights.email ===
-    convention.signatories.establishmentRepresentative.email
-  )
-    return {
-      role: convention.signatories.establishmentRepresentative.role,
-      userWithRights,
-    };
+  if (!role)
+    throw errors.convention.connectedUserNotSignatory({
+      userId: userWithRights.id,
+      conventionId: convention.id,
+    });
 
-  if (userWithRights.email === convention.signatories.beneficiary.email)
-    return {
-      role: convention.signatories.beneficiary.role,
-      userWithRights,
-    };
-
-  throw errors.convention.connectedUserNotSignatory({
-    userId: userWithRights.id,
-    conventionId: convention.id,
-  });
+  return { role, userWithRights };
 };
 
 export const signConvention = async ({
@@ -388,7 +380,6 @@ export const extractUserRolesOnConventionFromJwtPayload = async (
   uow: UnitOfWork,
   initialConvention: ConventionDto,
 ): Promise<Role[]> => {
-  const roles: Role[] = [];
   if ("role" in jwtPayload) {
     if (jwtPayload.applicationId !== initialConvention.id)
       throw errors.convention.forbiddenConventionIdMismatch({
@@ -396,33 +387,9 @@ export const extractUserRolesOnConventionFromJwtPayload = async (
         jwtConventionId: jwtPayload.applicationId,
         jwtRole: jwtPayload.role,
       });
-    roles.push(jwtPayload.role);
+    return [jwtPayload.role];
   }
 
-  if ("userId" in jwtPayload) {
-    const userWithRights = await getUserWithRights(uow, jwtPayload.userId);
-
-    if (userWithRights.isBackofficeAdmin) roles.push("back-office");
-
-    if (
-      userWithRights.email === initialConvention.signatories.beneficiary.email
-    )
-      roles.push(initialConvention.signatories.beneficiary.role);
-
-    if (
-      userWithRights.email ===
-      initialConvention.signatories.establishmentRepresentative.email
-    )
-      roles.push(
-        initialConvention.signatories.establishmentRepresentative.role,
-      );
-
-    const userRightOnAgency = userWithRights.agencyRights.find(
-      (agencyRight) => agencyRight.agency.id === initialConvention.agencyId,
-    );
-
-    if (userRightOnAgency) roles.push(...userRightOnAgency.roles);
-  }
-
-  return roles;
+  const userWithRights = await getUserWithRights(uow, jwtPayload.userId);
+  return getConventionManageAllowedRoles(initialConvention, userWithRights);
 };

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.testHelpers.ts
@@ -14,11 +14,13 @@ import {
   errors,
   expectPromiseToFailWithError,
   expectToEqual,
-  type Role,
+  getConventionManageAllowedRoles,
   splitCasesBetweenPassingAndFailing,
+  toAgencyDtoForAgencyUsersAndAdmins,
   type UnauthorizedError,
   type UpdateConventionStatusRequestDto,
   type UserWithAdminRights,
+  type UserWithRights,
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
 import { createConventionMagicLinkPayload } from "../../../utils/jwt";
@@ -46,6 +48,7 @@ const allConnectedTestUsers = [
   "userWithRoleValidator",
   "userWithRoleAgencyAdmin",
   "userWithRoleEstablishmentRepresentative",
+  "userWithRoleBeneficiary",
   "userWithRoleBackofficeAdmin",
   "userWithRoleBackofficeAdminAndValidator",
 ] as const;
@@ -53,6 +56,7 @@ const allConnectedTestUsers = [
 type ConnectedTestUser = (typeof allConnectedTestUsers)[number];
 
 const establishmentRepEmail: Email = "establishmentrep@email.com";
+const beneficiaryEmail: Email = "beneficiary@email.fr";
 
 const userWithRoleBackofficeAdmin: UserWithAdminRights = {
   email: "userWithRoleBackofficeAdmin@mail.com",
@@ -135,6 +139,17 @@ const userWithRoleEstablishmentRepresentative: UserWithAdminRights = {
   },
   createdAt: new Date().toISOString(),
 };
+const userWithRoleBeneficiary: UserWithAdminRights = {
+  email: beneficiaryEmail,
+  firstName: "userWithRoleBeneficiaryFirstName",
+  id: "userWithRoleBeneficiary",
+  lastName: "Beneficiary",
+  proConnect: {
+    externalId: "userWithRoleBeneficiary-external-id",
+    siret: "000001111122222",
+  },
+  createdAt: new Date().toISOString(),
+};
 const makeUserIdMapConnectedUser: Record<
   ConnectedTestUser,
   UserWithAdminRights
@@ -146,6 +161,7 @@ const makeUserIdMapConnectedUser: Record<
   userWithRoleBackofficeAdminAndValidator,
   userWithRoleAgencyAdmin,
   userWithRoleEstablishmentRepresentative,
+  userWithRoleBeneficiary,
 };
 
 const agencyWithoutCounsellorEmail = toAgencyWithRights(
@@ -196,6 +212,25 @@ const agencyWithCounsellorEmails = toAgencyWithRights(
   },
 );
 
+const makeUserWithRights = (userId: ConnectedTestUser): UserWithRights => {
+  const user = makeUserIdMapConnectedUser[userId];
+  const agencyRights = [
+    agencyWithoutCounsellorEmail,
+    agencyWithCounsellorEmails,
+  ].flatMap((agency) => {
+    const rights = agency.usersRights[userId];
+    if (!rights) return [];
+    return [
+      {
+        agency: toAgencyDtoForAgencyUsersAndAdmins(agency, []),
+        roles: rights.roles,
+        isNotifiedByEmail: rights.isNotifiedByEmail,
+      },
+    ];
+  });
+  return { ...user, agencyRights };
+};
+
 type ExtractFromDomainTopics<T extends DomainTopic> = Extract<DomainTopic, T>;
 
 type ConventionDomainTopic = ExtractFromDomainTopics<
@@ -230,6 +265,7 @@ export const setupInitialState = ({
     .withId(conventionWithAgencyOneStepValidationId)
     .withStatus(initialStatus)
     .withEstablishmentRepresentativeEmail(establishmentRepEmail)
+    .withBeneficiaryEmail(beneficiaryEmail)
     .withAgencyId(agencyWithoutCounsellorEmail.id);
 
   const originalConvention = alreadySigned
@@ -241,6 +277,7 @@ export const setupInitialState = ({
       .withId(conventionWithAgencyTwoStepsValidationId)
       .withStatus(initialStatus)
       .withEstablishmentRepresentativeEmail(establishmentRepEmail)
+      .withBeneficiaryEmail(beneficiaryEmail)
       .withAgencyId(agencyWithCounsellorEmails.id);
 
   const conventionWithAgencyTwoStepsValidation: ConventionDto = {
@@ -553,6 +590,19 @@ export const rejectStatusTransitionTests = ({
   const someValidInitialStatus = authorizedInitialStatuses[0];
   const someValidRole = allowedRolesToUpdate[0];
 
+  const conventionAgencyId =
+    updateStatusParams.conventionId === conventionWithAgencyTwoStepsValidationId
+      ? agencyWithCounsellorEmails.id
+      : agencyWithoutCounsellorEmail.id;
+
+  const conventionForRoles = new ConventionDtoBuilder()
+    .withId(updateStatusParams.conventionId)
+    .withStatus(someValidInitialStatus)
+    .withEstablishmentRepresentativeEmail(establishmentRepEmail)
+    .withBeneficiaryEmail(beneficiaryEmail)
+    .withAgencyId(conventionAgencyId)
+    .build();
+
   describe("Rejected", () => {
     const testRejectsStatusUpdate = makeTestRejectsStatusUpdate({
       updateStatusParams,
@@ -580,30 +630,18 @@ export const rejectStatusTransitionTests = ({
       it.each(
         notAllowedConnectedUsersToUpdate.map((userId) => ({ userId })),
       )("Rejected from userId '$userId'", ({ userId }) => {
-        const user = makeUserIdMapConnectedUser[userId];
-        const getRoles = (): Role[] => {
-          if (user.email === establishmentRepEmail)
-            return ["establishment-representative"];
-
-          if (user.isBackofficeAdmin) return ["back-office"];
-
-          return agencyWithoutCounsellorEmail.usersRights[userId]?.roles ?? [];
-        };
-
-        const roles = getRoles();
+        const roles = getConventionManageAllowedRoles(
+          conventionForRoles,
+          makeUserWithRights(userId),
+        );
         return testRejectsStatusUpdate({
           userId,
           initialStatus: someValidInitialStatus,
-          expectedError: roles.length
-            ? errors.convention.badRoleStatusChange({
-                roles,
-                status: updateStatusParams.status,
-                conventionId: updateStatusParams.conventionId,
-              })
-            : errors.user.noRightsOnAgency({
-                agencyId: agencyWithoutCounsellorEmail.id,
-                userId: user.id,
-              }),
+          expectedError: errors.convention.badRoleStatusChange({
+            roles,
+            status: updateStatusParams.status,
+            conventionId: updateStatusParams.conventionId,
+          }),
         });
       });
     }

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.ts
@@ -6,6 +6,7 @@ import {
   type ConventionStatus,
   type DateString,
   errors,
+  getConventionManageAllowedRoles,
   type Role,
   reviewedConventionStatuses,
   type UserWithRights,
@@ -85,7 +86,10 @@ export const makeUpdateConventionStatus = useCaseBuilder(
     const roles =
       "roleInPayload" in roleOrUser
         ? [roleOrUser.roleInPayload]
-        : await rolesFromUser(roleOrUser.userWithRights, convention);
+        : getConventionManageAllowedRoles(
+            convention,
+            roleOrUser.userWithRights,
+          );
 
     const assessment = await uow.assessmentRepository.getByConventionId(
       convention.id,
@@ -219,30 +223,4 @@ const getRoleInPayloadOrUser = async (
   return {
     userWithRights: userWithRights,
   };
-};
-
-const rolesFromUser = async (
-  user: UserWithRights,
-  convention: ConventionDto,
-): Promise<Role[]> => {
-  const roles: Role[] = [];
-  if (user.isBackofficeAdmin) roles.push("back-office");
-
-  if (user.email === convention.signatories.establishmentRepresentative.email)
-    roles.push("establishment-representative");
-
-  const userAgencyRight = user.agencyRights.find(
-    (agencyRight) => agencyRight.agency.id === convention.agencyId,
-  );
-
-  if (!userAgencyRight && roles.length === 0) {
-    throw errors.user.noRightsOnAgency({
-      agencyId: convention.agencyId,
-      userId: user.id,
-    });
-  }
-
-  if (userAgencyRight) roles.push(...userAgencyRight.roles);
-
-  return roles;
 };

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
@@ -42,6 +42,7 @@ describe("UpdateConventionStatus", () => {
       ],
       allowedConnectedUsers: [
         "userWithRoleEstablishmentRepresentative",
+        "userWithRoleBeneficiary",
         "userWithRoleBackofficeAdmin",
         "userWithRoleBackofficeAdminAndValidator",
         "userWithRoleValidator",
@@ -65,6 +66,7 @@ describe("UpdateConventionStatus", () => {
       ],
       allowedConnectedUsers: [
         "userWithRoleEstablishmentRepresentative",
+        "userWithRoleBeneficiary",
         "userWithRoleBackofficeAdmin",
         "userWithRoleBackofficeAdminAndValidator",
         "userWithRoleCounsellor",
@@ -87,7 +89,10 @@ describe("UpdateConventionStatus", () => {
       },
       expectedDomainTopic: "ConventionPartiallySigned",
       allowedMagicLinkRoles: validSignatoryRoles,
-      allowedConnectedUsers: ["userWithRoleEstablishmentRepresentative"],
+      allowedConnectedUsers: [
+        "userWithRoleEstablishmentRepresentative",
+        "userWithRoleBeneficiary",
+      ],
       allowedInitialStatuses: ["READY_TO_SIGN", "PARTIALLY_SIGNED"],
     });
     rejectStatusTransitionTests({
@@ -96,7 +101,10 @@ describe("UpdateConventionStatus", () => {
         conventionId: conventionWithAgencyOneStepValidationId,
       },
       allowedMagicLinkRoles: validSignatoryRoles,
-      allowedConnectedUsers: ["userWithRoleEstablishmentRepresentative"],
+      allowedConnectedUsers: [
+        "userWithRoleEstablishmentRepresentative",
+        "userWithRoleBeneficiary",
+      ],
       allowedInitialStatuses: ["READY_TO_SIGN", "PARTIALLY_SIGNED"],
     });
   });


### PR DESCRIPTION
Fixes #5518

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
