### PR TITLE
#5340 - Retirer les informations de déconnexion inutiles (idToken) du front

### DIFF
--- a/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
+++ b/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
@@ -707,7 +707,7 @@ describe("auth router", () => {
       });
 
       describe("when provider is 'ftConnect'", () => {
-        it("when ftConnect, returns a correct logout url with status 200", async () => {
+        it("when ftConnect, returns an error with status 400", async () => {
           inMemoryUow.ongoingOAuthRepository.ongoingOAuths = [
             {
               fromUri: "uri",

--- a/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
+++ b/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
@@ -378,7 +378,6 @@ describe("auth router", () => {
 
           expectToEqual(params, {
             token: expect.any(String),
-            idToken: "",
             provider: "email",
           });
 
@@ -625,10 +624,17 @@ describe("auth router", () => {
     describe(`${displayRouteName(
       authRoutes.getOAuthLogoutUrl,
     )} returns the logout url`, () => {
+      const user = new UserBuilder()
+        .withProConnectInfos({ externalId: "id", siret: "00000000000000" })
+        .build();
+
+      beforeEach(() => {
+        inMemoryUow.userRepository.users = [user];
+      });
+
       describe("when provider is 'proConnect'", () => {
         it("returns 401 if authorization header is missing", async () => {
           const response = await authRoutesClient.getOAuthLogoutUrl({
-            queryParams: { idToken: "fake-id-token", provider: "proConnect" },
             headers: { authorization: "" },
           });
 
@@ -642,6 +648,8 @@ describe("auth router", () => {
         });
 
         it("returns 401 when user does not exist", async () => {
+          inMemoryUow.userRepository.users = [];
+
           const token = generateConnectedUserJwt({
             userId: "missing-user-id",
             version: currentJwtVersions.connectedUser,
@@ -649,10 +657,6 @@ describe("auth router", () => {
 
           const response = await authRoutesClient.getOAuthLogoutUrl({
             headers: { authorization: token },
-            queryParams: {
-              idToken: "fake-id-token",
-              provider: "proConnect",
-            },
           });
 
           expectHttpResponseToEqual(response, {
@@ -665,11 +669,6 @@ describe("auth router", () => {
         });
 
         it("returns a correct logout url with status 200", async () => {
-          const user = new UserBuilder()
-            .withProConnectInfos({ externalId: "id", siret: "00000000000000" })
-            .build();
-
-          inMemoryUow.userRepository.users = [user];
           const state = "fake-state";
           inMemoryUow.ongoingOAuthRepository.ongoingOAuths = [
             {
@@ -681,7 +680,7 @@ describe("auth router", () => {
               nonce: "fake-nonce",
               externalId: user.proConnect?.externalId,
               usedAt: null,
-              idToken: null,
+              idToken: "idtoken",
             },
           ];
 
@@ -692,10 +691,6 @@ describe("auth router", () => {
 
           const response = await authRoutesClient.getOAuthLogoutUrl({
             headers: { authorization: token },
-            queryParams: {
-              idToken: "fake-id-token",
-              provider: "proConnect",
-            },
           });
 
           expectHttpResponseToEqual(response, {
@@ -703,7 +698,7 @@ describe("auth router", () => {
               appConfig.proConnectConfig.providerBaseUri
             }${fakeProConnectLogoutUri}?${queryParamsAsString({
               postLogoutRedirectUrl: appConfig.immersionFacileBaseUrl,
-              idToken: "fake-id-token",
+              idToken: "idtoken",
               state,
             })}`,
             status: 200,
@@ -713,20 +708,38 @@ describe("auth router", () => {
 
       describe("when provider is 'ftConnect'", () => {
         it("when ftConnect, returns a correct logout url with status 200", async () => {
-          const response = await authRoutesClient.getOAuthLogoutUrl({
-            headers: { authorization: "fake-token" },
-            queryParams: {
-              idToken: "fake-id-token",
+          inMemoryUow.ongoingOAuthRepository.ongoingOAuths = [
+            {
+              fromUri: "uri",
+              userId: user.id,
+              accessToken: "yolo",
               provider: "ftConnect",
+              state,
+              nonce: "fake-nonce",
+              externalId: user.proConnect?.externalId,
+              usedAt: null,
+              idToken: "id-token",
             },
+          ];
+
+          const token = generateConnectedUserJwt({
+            userId: user.id,
+            version: currentJwtVersions.connectedUser,
+          });
+
+          const response = await authRoutesClient.getOAuthLogoutUrl({
+            headers: { authorization: token },
           });
 
           expectHttpResponseToEqual(response, {
-            body: `https://fake-ft-connect-logout-url?${queryParamsAsString({
-              id_token_hint: "fake-id-token",
-              redirect_uri: "fake-redirect-uri",
-            })}`,
-            status: 200,
+            body: {
+              message: errors.auth.accessTokenErrorType({
+                actualType: "ftConnect",
+                expectedType: "proConnect",
+              }).message,
+              status: 400,
+            },
+            status: 400,
           });
         });
       });

--- a/back/src/adapters/primary/routers/auth/createAuthRouter.ts
+++ b/back/src/adapters/primary/routers/auth/createAuthRouter.ts
@@ -60,19 +60,13 @@ export const createAuthRouter = (deps: AppDependencies) => {
   );
 
   authSharedRouter.getOAuthLogoutUrl(
-    (req: Request<any, any, any, any>, res: Response, next: NextFunction) => {
-      if (req.query.provider === "ftConnect") {
-        return next();
-      }
-      return deps.connectedUserAuthMiddleware(req, res, next);
-    },
+    (req: Request<any, any, any, any>, res: Response, next: NextFunction) =>
+      deps.connectedUserAuthMiddleware(req, res, next),
     (req, res) =>
       sendHttpResponse(req, res, () =>
         deps.useCases.getOAuthLogoutUrl.execute(
-          req.query,
-          req.query.provider === "ftConnect"
-            ? undefined
-            : getGenericAuthOrThrow(req.payloads?.currentUser),
+          undefined,
+          getGenericAuthOrThrow(req.payloads?.currentUser),
         ),
       ),
   );

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -882,7 +882,6 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         proConnectOAuthGateway: gateways.proConnectOAuthGateway,
-        ftConnectGateway: gateways.ftConnectGateway,
       },
     }),
     createAssessment: makeCreateAssessment({

--- a/back/src/config/bootstrap/magicLinkUrl.ts
+++ b/back/src/config/bootstrap/magicLinkUrl.ts
@@ -12,7 +12,6 @@ import {
   type User,
 } from "shared";
 import type { EmailOrProConnectOngoingAuth } from "../../domains/core/authentication/connected-user/entities/OngoingOAuth";
-import type { GetAccessTokenResult } from "../../domains/core/authentication/connected-user/port/OAuthGateway";
 import type {
   GenerateConnectedUserJwt,
   GenerateConventionJwt,
@@ -85,7 +84,6 @@ export type GenerateConnectedUserLoginUrl = ReturnType<
 
 export type GenerateConnectedUserLoginUrlParams = {
   user: User;
-  accessToken: GetAccessTokenResult | undefined;
   ongoingOAuth: EmailOrProConnectOngoingAuth;
   now: Date;
 };
@@ -94,7 +92,6 @@ export const makeGenerateConnectedUserLoginUrl =
   (config: AppConfig, generateConnectedUserJwt: GenerateConnectedUserJwt) =>
   ({
     user,
-    accessToken,
     ongoingOAuth,
     now,
   }: GenerateConnectedUserLoginUrlParams): AbsoluteUrl => {
@@ -113,7 +110,6 @@ export const makeGenerateConnectedUserLoginUrl =
     const queryParams = queryParamsAsString<ConnectedUserQueryParams>({
       ...params,
       token: jwt,
-      idToken: accessToken?.idToken ?? "",
       provider: ongoingOAuth.provider,
     });
 

--- a/back/src/domains/core/authentication/connected-user/entities/OngoingOAuth.ts
+++ b/back/src/domains/core/authentication/connected-user/entities/OngoingOAuth.ts
@@ -4,12 +4,12 @@ import type {
   ExtractFromExisting,
   FederatedIdentityProvider,
   Flavor,
-  IdToken,
   OAuthState,
 } from "shared";
 
 export type OAuthJwt = Flavor<string, "OAuthJwt">;
 export type OAuthNonce = Flavor<string, "OAuthNonce">;
+export type IdToken = Flavor<string, "IdToken">;
 
 type OngoingAuthCommon = {
   userId?: string;

--- a/back/src/domains/core/authentication/connected-user/port/OAuthGateway.ts
+++ b/back/src/domains/core/authentication/connected-user/port/OAuthGateway.ts
@@ -1,12 +1,5 @@
-import type {
-  AbsoluteUrl,
-  Email,
-  ExternalId,
-  IdToken,
-  SiretDto,
-  WithIdToken,
-} from "shared";
-import type { OAuthJwt } from "../entities/OngoingOAuth";
+import type { AbsoluteUrl, Email, ExternalId, SiretDto } from "shared";
+import type { IdToken, OAuthJwt } from "../entities/OngoingOAuth";
 
 export type GetAccessTokenParams = {
   code: string;
@@ -51,7 +44,8 @@ export type GetLoginUrlParams = {
   state: string;
 };
 
-export type GetLogoutUrlParams = WithIdToken & {
+export type GetLogoutUrlParams = {
+  idToken: IdToken;
   state: string;
 };
 

--- a/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.ts
@@ -135,7 +135,6 @@ const saveEmailAuthenticationDataAndReturnRedirectURI = async ({
       user: newOrUpdatedUser,
       ongoingOAuth: updatedOngoingOAuth,
       now: timeGateway.now(),
-      accessToken: undefined,
     }),
   };
 };
@@ -180,7 +179,6 @@ const saveProConnectAuthenticationDataAndReturnRedirectURI = async ({
     provider: updatedOngoingOAuth.provider,
     redirectUri: deps.generateConnectedUserLoginUrl({
       user: newOrUpdatedUser,
-      accessToken,
       ongoingOAuth: updatedOngoingOAuth,
       now: deps.timeGateway.now(),
     }),

--- a/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.unit.test.ts
@@ -9,7 +9,6 @@ import {
   expectPromiseToFailWithError,
   expectToEqual,
   frontRoutes,
-  type IdToken,
   makeRouteAbsoluteUrl,
   type OAuthSuccessLoginParams,
   type SiretDto,
@@ -38,7 +37,7 @@ import {
   fakeProviderConfig,
   InMemoryProConnectOAuthGateway,
 } from "../adapters/oauth-gateway/InMemoryOAuthGateway";
-import type { OngoingOAuth } from "../entities/OngoingOAuth";
+import type { IdToken, OngoingOAuth } from "../entities/OngoingOAuth";
 import type {
   FTConnectGetAccessTokenPayload,
   ProConnectGetAccessTokenPayload,
@@ -390,7 +389,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
           keys(allowedLoginSources),
         )("generates an app token and returns a redirection url which includes token and user data for %s", async (source) => {
           const allowedRoute = allowedLoginSources[source];
-          const { initialOngoingOAuth, idToken, userId } =
+          const { initialOngoingOAuth, userId } =
             makeSuccessfulAuthenticationConditions(allowedRoute({}).href);
 
           const response = await afterOAuthSuccessRedirection.execute({
@@ -400,7 +399,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
 
           expectToEqual(response, {
             provider: "proConnect",
-            redirectUri: `http://fake-connected-user${allowedRoute({ token: `jwt-${userId}`, idToken, provider: "proConnect" }).href}`,
+            redirectUri: `http://fake-connected-user${allowedRoute({ token: `jwt-${userId}`, provider: "proConnect" }).href}`,
           });
         });
       });
@@ -814,7 +813,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
         });
         expectToEqual(result, {
           provider: "email",
-          redirectUri: `http://fake-connected-user/admin?token=jwt-${userId}&idToken=&provider=email`,
+          redirectUri: `http://fake-connected-user/admin?token=jwt-${userId}&provider=email`,
         });
       });
 
@@ -922,7 +921,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
 
         expectToEqual(redirectedUrl, {
           provider: "email",
-          redirectUri: `http://fake-connected-user${allowedRoute({ token: "jwt-new-user-id", idToken: "", provider: "email" }).href}`,
+          redirectUri: `http://fake-connected-user${allowedRoute({ token: "jwt-new-user-id", provider: "email" }).href}`,
         });
       });
     });

--- a/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.ts
@@ -1,6 +1,5 @@
 import { type AbsoluteUrl, type ConnectedUser, errors } from "shared";
 import { useCaseBuilder } from "../../../useCaseBuilder";
-import type { FtConnectGateway } from "../../ft-connect/port/FtConnectGateway";
 import type { OAuthGateway } from "../port/OAuthGateway";
 
 export type GetOAuthLogoutUrl = ReturnType<typeof makeGetOAuthLogoutUrl>;
@@ -10,7 +9,6 @@ export const makeGetOAuthLogoutUrl = useCaseBuilder("GetOAuthLogoutUrl")
   .withCurrentUser<ConnectedUser | undefined>()
   .withDeps<{
     proConnectOAuthGateway: OAuthGateway;
-    ftConnectGateway: FtConnectGateway;
   }>()
   .build(async ({ uow, deps: { proConnectOAuthGateway }, currentUser }) => {
     if (!currentUser) throw errors.user.unauthorized();

--- a/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.ts
@@ -1,10 +1,4 @@
-import {
-  type AbsoluteUrl,
-  type ConnectedUser,
-  errors,
-  type LogoutQueryParams,
-  logoutQueryParamsSchema,
-} from "shared";
+import { type AbsoluteUrl, type ConnectedUser, errors } from "shared";
 import { useCaseBuilder } from "../../../useCaseBuilder";
 import type { FtConnectGateway } from "../../ft-connect/port/FtConnectGateway";
 import type { OAuthGateway } from "../port/OAuthGateway";
@@ -12,36 +6,28 @@ import type { OAuthGateway } from "../port/OAuthGateway";
 export type GetOAuthLogoutUrl = ReturnType<typeof makeGetOAuthLogoutUrl>;
 
 export const makeGetOAuthLogoutUrl = useCaseBuilder("GetOAuthLogoutUrl")
-  .withInput<LogoutQueryParams>(logoutQueryParamsSchema)
   .withOutput<AbsoluteUrl>()
   .withCurrentUser<ConnectedUser | undefined>()
   .withDeps<{
     proConnectOAuthGateway: OAuthGateway;
     ftConnectGateway: FtConnectGateway;
   }>()
-  .build(
-    async ({
-      inputParams,
-      uow,
-      deps: { proConnectOAuthGateway, ftConnectGateway },
-      currentUser,
-    }) => {
-      if (inputParams.provider === "ftConnect") {
-        return ftConnectGateway.getLogoutUrl({
-          idToken: inputParams.idToken,
-          state: "NOT NECESSARY",
-        });
-      }
+  .build(async ({ uow, deps: { proConnectOAuthGateway }, currentUser }) => {
+    if (!currentUser) throw errors.user.unauthorized();
 
-      if (!currentUser) throw errors.user.unauthorized();
-
-      const ongoingOAuth = await uow.ongoingOAuthRepository.findByUserId(
-        currentUser.id,
-      );
-      if (!ongoingOAuth) throw errors.auth.missingOAuth({});
-      return proConnectOAuthGateway.getLogoutUrl({
-        idToken: inputParams.idToken,
-        state: ongoingOAuth.state,
+    const ongoingOAuth = await uow.ongoingOAuthRepository.findByUserId(
+      currentUser.id,
+    );
+    if (!ongoingOAuth) throw errors.auth.missingOAuth({});
+    if (ongoingOAuth.provider !== "proConnect")
+      throw errors.auth.accessTokenErrorType({
+        actualType: ongoingOAuth.provider,
+        expectedType: "proConnect",
       });
-    },
-  );
+    if (!ongoingOAuth.idToken)
+      throw errors.auth.missingIdToken(ongoingOAuth.state);
+    return proConnectOAuthGateway.getLogoutUrl({
+      idToken: ongoingOAuth.idToken,
+      state: ongoingOAuth.state,
+    });
+  });

--- a/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.unit.test.ts
@@ -57,10 +57,7 @@ describe("GetOAuthLogoutUrl", () => {
       it("throws when it does not find the ongoingOAuth", async () => {
         uow.ongoingOAuthRepository.ongoingOAuths = [];
         await expectPromiseToFailWithError(
-          getOAuthLogoutUrl.execute(
-            { idToken: "whatever", provider: "proConnect" },
-            connectedUser,
-          ),
+          getOAuthLogoutUrl.execute(undefined, connectedUser),
           errors.auth.missingOAuth({}),
         );
       });
@@ -81,10 +78,7 @@ describe("GetOAuthLogoutUrl", () => {
         };
         uow.ongoingOAuthRepository.ongoingOAuths = [ongoingOAuth];
         expectToEqual(
-          await getOAuthLogoutUrl.execute(
-            { idToken, provider: "proConnect" },
-            connectedUser,
-          ),
+          await getOAuthLogoutUrl.execute(undefined, connectedUser),
           `${
             fakeProviderConfig.providerBaseUri
           }${fakeProConnectLogoutUri}?${queryParamsAsString({
@@ -97,21 +91,47 @@ describe("GetOAuthLogoutUrl", () => {
       });
     });
 
-    describe("when provider is 'ftConnect'", () => {
-      it("returns the ftConnect logout url", async () => {
-        const idToken = "fake-id-token";
+    describe("wrong paths", () => {
+      it("fails on FtConnect provider", async () => {
+        const ongoingOAuth: OngoingOAuth = {
+          fromUri: "/uri",
+          state: "some-state",
+          nonce: "some-nonce",
+          provider: "ftConnect",
+          accessToken: "fake-access-token",
+          userId: user.id,
+          usedAt: null,
+          idToken: "token",
+        };
+        uow.ongoingOAuthRepository.ongoingOAuths = [ongoingOAuth];
 
-        const logoutUrl = await getOAuthLogoutUrl.execute(
-          { idToken, provider: "ftConnect" },
-          connectedUser,
+        await expectPromiseToFailWithError(
+          getOAuthLogoutUrl.execute(undefined, connectedUser),
+          errors.auth.accessTokenErrorType({
+            actualType: ongoingOAuth.provider,
+            expectedType: "proConnect",
+          }),
         );
+      });
 
-        expectToEqual(
-          logoutUrl,
-          `https://fake-ft-connect-logout-url?${queryParamsAsString({
-            id_token_hint: idToken,
-            redirect_uri: "fake-redirect-uri",
-          })}`,
+      it("fails on email provider", async () => {
+        const ongoingOAuth: OngoingOAuth = {
+          fromUri: "/uri",
+          state: "some-state",
+          nonce: "some-nonce",
+          provider: "email",
+          userId: user.id,
+          usedAt: null,
+          email: "mail@mail.com",
+        };
+        uow.ongoingOAuthRepository.ongoingOAuths = [ongoingOAuth];
+
+        await expectPromiseToFailWithError(
+          getOAuthLogoutUrl.execute(undefined, connectedUser),
+          errors.auth.accessTokenErrorType({
+            actualType: ongoingOAuth.provider,
+            expectedType: "proConnect",
+          }),
         );
       });
     });

--- a/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/GetOAuthLogoutUrl.unit.test.ts
@@ -11,7 +11,6 @@ import {
   type InMemoryUnitOfWork,
 } from "../../../unit-of-work/adapters/createInMemoryUow";
 import { InMemoryUowPerformer } from "../../../unit-of-work/adapters/InMemoryUowPerformer";
-import { InMemoryFtConnectGateway } from "../../ft-connect/adapters/ft-connect-gateway/InMemoryFtConnectGateway";
 import {
   fakeProConnectLogoutUri,
   fakeProviderConfig,
@@ -48,7 +47,6 @@ describe("GetOAuthLogoutUrl", () => {
           proConnectOAuthGateway: new InMemoryProConnectOAuthGateway(
             fakeProviderConfig,
           ),
-          ftConnectGateway: new InMemoryFtConnectGateway(),
         },
       });
     });
@@ -132,6 +130,25 @@ describe("GetOAuthLogoutUrl", () => {
             actualType: ongoingOAuth.provider,
             expectedType: "proConnect",
           }),
+        );
+      });
+
+      it("fails on missing idToken provider", async () => {
+        const ongoingOAuth: OngoingOAuth = {
+          fromUri: "/uri",
+          state: "some-state",
+          nonce: "some-nonce",
+          provider: "proConnect",
+          accessToken: "fake-access-token",
+          userId: user.id,
+          usedAt: null,
+          idToken: null,
+        };
+        uow.ongoingOAuthRepository.ongoingOAuths = [ongoingOAuth];
+
+        await expectPromiseToFailWithError(
+          getOAuthLogoutUrl.execute(undefined, connectedUser),
+          errors.auth.missingIdToken(ongoingOAuth.state),
         );
       });
     });

--- a/back/src/domains/core/authentication/connected-user/use-cases/RenewExpiredJwt.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/RenewExpiredJwt.ts
@@ -197,7 +197,6 @@ const onConnectedUserDomainJwtPayload = async ({
         generateConnectedUserLoginUrl: deps.generateConnectedUserLoginUrl,
       })({
         user,
-        accessToken: undefined,
         ongoingOAuth,
         now: deps.timeGateway.now(),
       }),

--- a/back/src/domains/core/authentication/connected-user/use-cases/RenewExpiredJwt.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/RenewExpiredJwt.unit.test.ts
@@ -649,7 +649,6 @@ describe("RenewExpiredJwt use case", () => {
         {
           id: shortLinks[0],
           url: fakeGenerateConnectedUserUrlFn({
-            accessToken: undefined,
             user,
             ongoingOAuth: emailUsedOnGoingOAuth,
             now: timeGateway.now(),

--- a/back/src/domains/core/authentication/ft-connect/dto/AccessToken.dto.ts
+++ b/back/src/domains/core/authentication/ft-connect/dto/AccessToken.dto.ts
@@ -1,4 +1,4 @@
-import type { IdToken } from "shared";
+import type { IdToken } from "../../connected-user/entities/OngoingOAuth";
 
 export type AccessTokenDto = {
   value: string;

--- a/back/src/domains/core/authentication/ft-connect/dto/FtConnect.dto.ts
+++ b/back/src/domains/core/authentication/ft-connect/dto/FtConnect.dto.ts
@@ -5,11 +5,11 @@ import {
   type FederatedIdentityProvider,
   type FtConnectToken,
   type FtExternalId,
-  type IdToken,
   type InternshipKind,
   type PhoneNumber,
 } from "shared";
 import type { EntityFromDto } from "../../../../../utils/EntityFromDto";
+import type { IdToken } from "../../connected-user/entities/OngoingOAuth";
 import type { FtConnectImmersionAdvisorDto } from "./FtConnectAdvisor.dto";
 import type { FtConnectUserDto } from "./FtConnectUserDto";
 

--- a/back/src/utils/jwtTestHelper.ts
+++ b/back/src/utils/jwtTestHelper.ts
@@ -50,7 +50,6 @@ export const fakeGenerateMagicLinkUrlFn: GenerateConventionMagicLinkUrl = ({
 };
 
 export const fakeGenerateConnectedUserUrlFn: GenerateConnectedUserLoginUrl = ({
-  accessToken,
   user,
   ongoingOAuth,
 }) => {
@@ -62,7 +61,6 @@ export const fakeGenerateConnectedUserUrlFn: GenerateConnectedUserLoginUrl = ({
     {
       ...params,
       token: `jwt-${user.id}` as ConnectedUserJwt,
-      idToken: accessToken?.idToken ?? "",
       provider: ongoingOAuth.provider,
     },
   )}`;

--- a/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
+++ b/front/src/app/pages/auth/ConnectedPrivateRoutePage.tsx
@@ -165,7 +165,7 @@ export const ConnectedPrivateRoutePage = ({
   );
 
   useEffect(() => {
-    const { token, provider, idToken = "" } = route.params;
+    const { token, provider } = route.params;
 
     if (
       token &&
@@ -178,7 +178,6 @@ export const ConnectedPrivateRoutePage = ({
           federatedIdentity: {
             provider,
             token,
-            idToken,
           },
           feedbackTopic: "auth-global",
         }),

--- a/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
@@ -6,7 +6,6 @@ import type {
   ConnectedUser,
   ConnectedUserJwt,
   InitiateLoginByEmailParams,
-  LogoutQueryParams,
   OAuthSuccessLoginParams,
   RenewExpiredJwtRequestDto,
   UserId,
@@ -39,20 +38,19 @@ export class HttpAuthGateway implements AuthGateway {
   }
 
   public getLogoutUrl$({
-    idToken,
-    authToken,
-    provider,
-  }: LogoutQueryParams & { authToken: string }): Observable<AbsoluteUrl> {
+    jwt,
+  }: {
+    jwt: ConnectedUserJwt;
+  }): Observable<AbsoluteUrl> {
     return from(
       this.httpClient
         .getOAuthLogoutUrl({
-          queryParams: { idToken, provider },
-          headers: { authorization: authToken },
+          headers: { authorization: jwt },
         })
         .then((response) =>
           match(response)
             .with({ status: 200 }, ({ body }) => body)
-            .with({ status: 401 }, logBodyAndThrow)
+            .with({ status: P.union(400, 401) }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
     );

--- a/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
+++ b/front/src/core-logic/adapters/AuthGateway/HttpAuthGateway.ts
@@ -50,7 +50,7 @@ export class HttpAuthGateway implements AuthGateway {
         .then((response) =>
           match(response)
             .with({ status: 200 }, ({ body }) => body)
-            .with({ status: P.union(400, 401) }, logBodyAndThrow)
+            .with({ status: P.union(400, 401, 403) }, logBodyAndThrow)
             .otherwise(otherwiseThrow),
         ),
     );

--- a/front/src/core-logic/domain/auth/auth.epics.ts
+++ b/front/src/core-logic/domain/auth/auth.epics.ts
@@ -133,11 +133,13 @@ const getLogoutUrl$ = (
 ): Observable<AbsoluteUrl | undefined> => {
   const { federatedIdentity } = authState;
   if (!federatedIdentity) return throwError(() => errors.auth.missingOAuth({}));
+  if (federatedIdentity.provider !== "proConnect")
+    return throwError(() =>
+      errors.auth.unsupportedProvider({ actual: federatedIdentity.provider }),
+    );
   return action.payload.mode === "device-and-oauth"
     ? authGateway.getLogoutUrl$({
-        idToken: federatedIdentity.idToken,
-        authToken: federatedIdentity.token,
-        provider: federatedIdentity.provider,
+        jwt: federatedIdentity.token,
       })
     : of(undefined);
 };

--- a/front/src/core-logic/domain/auth/auth.epics.ts
+++ b/front/src/core-logic/domain/auth/auth.epics.ts
@@ -133,15 +133,14 @@ const getLogoutUrl$ = (
 ): Observable<AbsoluteUrl | undefined> => {
   const { federatedIdentity } = authState;
   if (!federatedIdentity) return throwError(() => errors.auth.missingOAuth({}));
-  if (federatedIdentity.provider !== "proConnect")
-    return throwError(() =>
-      errors.auth.unsupportedProvider({ actual: federatedIdentity.provider }),
-    );
-  return action.payload.mode === "device-and-oauth"
+  if (action.payload.mode === "device-only") return of(undefined);
+  return federatedIdentity.provider === "proConnect"
     ? authGateway.getLogoutUrl$({
         jwt: federatedIdentity.token,
       })
-    : of(undefined);
+    : throwError(() =>
+        errors.auth.unsupportedProvider({ actual: federatedIdentity.provider }),
+      );
 };
 
 const logoutEpic: AuthEpic = (

--- a/front/src/core-logic/domain/auth/auth.selectors.ts
+++ b/front/src/core-logic/domain/auth/auth.selectors.ts
@@ -5,7 +5,7 @@ import { connectedUserSelectors } from "../connected-user/connectedUser.selector
 
 const rootAuthSelector = createRootSelector((state) => state.auth);
 
-const currentFederatedIdentity = createSelector(
+const federatedIdentity = createSelector(
   rootAuthSelector,
   (auth) => auth.federatedIdentity,
 );
@@ -30,7 +30,7 @@ const requestedEmail = createSelector(
 );
 
 const isConnectedUser = createSelector(
-  currentFederatedIdentity,
+  federatedIdentity,
   (federatedIdentity) =>
     federatedIdentity?.provider === "proConnect" ||
     federatedIdentity?.provider === "email",
@@ -38,7 +38,7 @@ const isConnectedUser = createSelector(
 
 const connectedUserJwt = createSelector(
   isConnectedUser,
-  currentFederatedIdentity,
+  federatedIdentity,
   (isConnectedUser, federatedIdentity) =>
     isConnectedUser
       ? (federatedIdentity?.token as ConnectedUserJwt)
@@ -53,7 +53,7 @@ const isAdminConnected = createSelector(
 );
 
 export const authSelectors = {
-  federatedIdentity: currentFederatedIdentity,
+  federatedIdentity,
   isAdminConnected,
   isConnectedUser,
   connectedUserJwt,

--- a/front/src/core-logic/domain/auth/auth.test.ts
+++ b/front/src/core-logic/domain/auth/auth.test.ts
@@ -29,10 +29,9 @@ import { feedbacksSelectors } from "../feedback/feedback.selectors";
 import type { PayloadWithFeedbackTopic } from "../feedback/feedback.slice";
 
 describe("Auth slice", () => {
-  const connectedUserFederatedIdentity: FederatedIdentity = {
+  const proConnectFederatedIdentity: FederatedIdentity = {
     provider: "proConnect",
     token: "123",
-    idToken: "id-token",
   };
 
   let store: ReduxStore;
@@ -54,25 +53,25 @@ describe("Auth slice", () => {
 
     store.dispatch(
       authSlice.actions.federatedIdentityProvided({
-        federatedIdentity: connectedUserFederatedIdentity,
+        federatedIdentity: proConnectFederatedIdentity,
         feedbackTopic: "auth-global",
       }),
     );
 
     expectAuthStateToBe({
       afterLoginRedirectionUrl: null,
-      federatedIdentity: connectedUserFederatedIdentity,
+      federatedIdentity: proConnectFederatedIdentity,
       isLoading: false,
       isRequestingLoginByEmail: false,
       isRequestingRenewExpiredJwt: false,
       requestedEmail: null,
     });
 
-    expectFederatedIdentityInDevice(connectedUserFederatedIdentity);
+    expectFederatedIdentityInDevice(proConnectFederatedIdentity);
 
     expectAuthStateToBe({
       afterLoginRedirectionUrl: null,
-      federatedIdentity: connectedUserFederatedIdentity,
+      federatedIdentity: proConnectFederatedIdentity,
       isLoading: false,
       isRequestingLoginByEmail: false,
       isRequestingRenewExpiredJwt: false,
@@ -80,213 +79,229 @@ describe("Auth slice", () => {
     });
   });
 
-  it.each([
-    {
-      provider: "proConnect",
-      federatedIdentity: connectedUserFederatedIdentity,
-    },
-  ])("when provider = '$provider', deletes federatedIdentity & partialConventionInUrl stored in device and in store, then redirects to provider logout page", ({
-    federatedIdentity,
-  }) => {
-    ({ store, dependencies } = createTestStore({
-      auth: {
-        isRequestingLoginByEmail: false,
-        isRequestingRenewExpiredJwt: false,
-        federatedIdentity: federatedIdentity,
-        afterLoginRedirectionUrl: null,
-        isLoading: true,
-        requestedEmail: null,
-      },
-      connectedUser: {
-        currentUser: new ConnectedUserBuilder().build(),
-        isLoading: false,
-        agenciesToReview: [],
-      },
-    }));
-    dependencies.localDeviceRepository.set(
-      "federatedIdentity",
-      federatedIdentity,
-    );
-
-    store.dispatch(
-      authSlice.actions.fetchLogoutUrlRequested({
-        mode: "device-and-oauth",
-        feedbackTopic: "auth-global",
-      }),
-    );
-
-    dependencies.authGateway.getLogoutUrlResponse$.next(
-      "http://yolo-logout.com",
-    );
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-
-    expectFederatedIdentityInDevice(undefined);
-    expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
-
-    expectToEqual(dependencies.navigationGateway.wentToUrls, [
-      "http://yolo-logout.com",
-    ]);
-  });
-
-  it("deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page.", () => {
-    ({ store, dependencies } = createTestStore({
-      auth: {
-        isRequestingLoginByEmail: false,
-        federatedIdentity: connectedUserFederatedIdentity,
-        afterLoginRedirectionUrl: null,
-        isLoading: true,
-        isRequestingRenewExpiredJwt: false,
-        requestedEmail: null,
-      },
-      connectedUser: {
-        currentUser: new ConnectedUserBuilder().build(),
-        isLoading: false,
-        agenciesToReview: [],
-      },
-    }));
-    dependencies.localDeviceRepository.set(
-      "federatedIdentity",
-      connectedUserFederatedIdentity,
-    );
-    store.dispatch(
-      authSlice.actions.fetchLogoutUrlRequested({
-        mode: "device-only",
-        feedbackTopic: "auth-global",
-      }),
-    );
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-
-    expectFederatedIdentityInDevice(undefined);
-    expectToEqual(dependencies.navigationGateway.wentToUrls, []);
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-    expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
-  });
-
-  it("deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page (when provider is not 'proConnect')", () => {
-    ({ store, dependencies } = createTestStore({
-      auth: {
-        isRequestingLoginByEmail: false,
-        federatedIdentity: connectedUserFederatedIdentity,
-        afterLoginRedirectionUrl: null,
-        isLoading: true,
-        isRequestingRenewExpiredJwt: false,
-        requestedEmail: null,
-      },
-      connectedUser: {
-        currentUser: null,
-        isLoading: false,
-        agenciesToReview: [],
-      },
-    }));
-    dependencies.localDeviceRepository.set(
-      "federatedIdentity",
-      connectedUserFederatedIdentity,
-    );
-
-    store.dispatch(
-      authSlice.actions.fetchLogoutUrlRequested({
-        mode: "device-only",
-        feedbackTopic: "auth-global",
-      }),
-    );
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-
-    expectFederatedIdentityInDevice(undefined);
-    expectToEqual(dependencies.navigationGateway.wentToUrls, []);
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-    expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
-  });
-
-  it("deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page (when provider is not 'proConnect')", () => {
-    ({ store, dependencies } = createTestStore({
-      auth: {
-        isRequestingLoginByEmail: false,
-        federatedIdentity: connectedUserFederatedIdentity,
-        afterLoginRedirectionUrl: null,
-        isLoading: true,
-        isRequestingRenewExpiredJwt: false,
-        requestedEmail: null,
-      },
-      connectedUser: {
-        currentUser: new ConnectedUserBuilder().build(),
-        isLoading: false,
-        agenciesToReview: [],
-      },
-    }));
-    dependencies.localDeviceRepository.set(
-      "federatedIdentity",
-      connectedUserFederatedIdentity,
-    );
-
-    store.dispatch(
-      authSlice.actions.fetchLogoutUrlRequested({
-        mode: "device-and-oauth",
-        feedbackTopic: "auth-global",
-      }),
-    );
-
-    dependencies.authGateway.getLogoutUrlResponse$.error(new Error("Error"));
-
-    expectAuthStateToBe({
-      afterLoginRedirectionUrl: null,
-      federatedIdentity: null,
-      isLoading: true,
-      isRequestingLoginByEmail: false,
-      isRequestingRenewExpiredJwt: false,
-      requestedEmail: null,
-    });
-
-    expectFederatedIdentityInDevice(undefined);
-    expectToEqual(dependencies.navigationGateway.wentToUrls, []);
-    expectToEqual(
-      feedbacksSelectors.feedbacks(store.getState())["auth-global"],
+  describe("fetchLogoutUrlRequested", () => {
+    it.each([
       {
-        on: "delete",
-        level: "error",
-        title: "Une erreur est survenue lors de la déconnexion",
-        message: "Vous n'avez pas pu vous déconnecter.",
+        provider: "proConnect",
+        federatedIdentity: proConnectFederatedIdentity,
       },
-    );
+    ])("when provider = '$provider', deletes federatedIdentity & partialConventionInUrl stored in device and in store, then redirects to provider logout page", ({
+      federatedIdentity,
+    }) => {
+      ({ store, dependencies } = createTestStore({
+        auth: {
+          isRequestingLoginByEmail: false,
+          isRequestingRenewExpiredJwt: false,
+          federatedIdentity: federatedIdentity,
+          afterLoginRedirectionUrl: null,
+          isLoading: true,
+          requestedEmail: null,
+        },
+        connectedUser: {
+          currentUser: new ConnectedUserBuilder().build(),
+          isLoading: false,
+          agenciesToReview: [],
+        },
+      }));
+      dependencies.localDeviceRepository.set(
+        "federatedIdentity",
+        federatedIdentity,
+      );
+
+      store.dispatch(
+        authSlice.actions.fetchLogoutUrlRequested({
+          mode: "device-and-oauth",
+          feedbackTopic: "auth-global",
+        }),
+      );
+
+      dependencies.authGateway.getLogoutUrlResponse$.next(
+        "http://yolo-logout.com",
+      );
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+
+      expectFederatedIdentityInDevice(undefined);
+      expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
+
+      expectToEqual(dependencies.navigationGateway.wentToUrls, [
+        "http://yolo-logout.com",
+      ]);
+    });
+
+    it("with provider proConnect - deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page", () => {
+      ({ store, dependencies } = createTestStore({
+        auth: {
+          isRequestingLoginByEmail: false,
+          federatedIdentity: proConnectFederatedIdentity,
+          afterLoginRedirectionUrl: null,
+          isLoading: true,
+          isRequestingRenewExpiredJwt: false,
+          requestedEmail: null,
+        },
+        connectedUser: {
+          currentUser: new ConnectedUserBuilder().build(),
+          isLoading: false,
+          agenciesToReview: [],
+        },
+      }));
+      dependencies.localDeviceRepository.set(
+        "federatedIdentity",
+        proConnectFederatedIdentity,
+      );
+      store.dispatch(
+        authSlice.actions.fetchLogoutUrlRequested({
+          mode: "device-only",
+          feedbackTopic: "auth-global",
+        }),
+      );
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+
+      expectFederatedIdentityInDevice(undefined);
+      expectToEqual(dependencies.navigationGateway.wentToUrls, []);
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+      expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
+    });
+
+    it("with provider email - deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page ", () => {
+      const emailFederatedIdentity: FederatedIdentity = {
+        provider: "email",
+        token: "token",
+      };
+
+      ({ store, dependencies } = createTestStore({
+        auth: {
+          isRequestingLoginByEmail: false,
+          federatedIdentity: emailFederatedIdentity,
+          afterLoginRedirectionUrl: null,
+          isLoading: true,
+          isRequestingRenewExpiredJwt: false,
+          requestedEmail: null,
+        },
+        connectedUser: {
+          currentUser: null,
+          isLoading: false,
+          agenciesToReview: [],
+        },
+      }));
+      dependencies.localDeviceRepository.set(
+        "federatedIdentity",
+        emailFederatedIdentity,
+      );
+
+      store.dispatch(
+        authSlice.actions.fetchLogoutUrlRequested({
+          mode: "device-only",
+          feedbackTopic: "auth-global",
+        }),
+      );
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+
+      expectFederatedIdentityInDevice(undefined);
+      expectToEqual(dependencies.navigationGateway.wentToUrls, []);
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+      expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
+      expectToEqual(
+        feedbacksSelectors.feedbacks(store.getState())["auth-global"],
+        {
+          on: "delete",
+          level: "error",
+          title: "Une erreur est survenue lors de la déconnexion",
+          message: "Vous n'avez pas pu vous déconnecter.",
+        },
+      );
+    });
+
+    it("on getLogoutUrlResponse error - deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page", () => {
+      ({ store, dependencies } = createTestStore({
+        auth: {
+          isRequestingLoginByEmail: false,
+          federatedIdentity: proConnectFederatedIdentity,
+          afterLoginRedirectionUrl: null,
+          isLoading: true,
+          isRequestingRenewExpiredJwt: false,
+          requestedEmail: null,
+        },
+        connectedUser: {
+          currentUser: new ConnectedUserBuilder().build(),
+          isLoading: false,
+          agenciesToReview: [],
+        },
+      }));
+      dependencies.localDeviceRepository.set(
+        "federatedIdentity",
+        proConnectFederatedIdentity,
+      );
+
+      store.dispatch(
+        authSlice.actions.fetchLogoutUrlRequested({
+          mode: "device-and-oauth",
+          feedbackTopic: "auth-global",
+        }),
+      );
+
+      dependencies.authGateway.getLogoutUrlResponse$.error(new Error("Error"));
+
+      expectAuthStateToBe({
+        afterLoginRedirectionUrl: null,
+        federatedIdentity: null,
+        isLoading: true,
+        isRequestingLoginByEmail: false,
+        isRequestingRenewExpiredJwt: false,
+        requestedEmail: null,
+      });
+
+      expectFederatedIdentityInDevice(undefined);
+      expectToEqual(dependencies.navigationGateway.wentToUrls, []);
+      expectToEqual(
+        feedbacksSelectors.feedbacks(store.getState())["auth-global"],
+        {
+          on: "delete",
+          level: "error",
+          title: "Une erreur est survenue lors de la déconnexion",
+          message: "Vous n'avez pas pu vous déconnecter.",
+        },
+      );
+    });
   });
 
   it("retrieves federatedIdentity if stored in device", () => {
@@ -301,20 +316,20 @@ describe("Auth slice", () => {
 
     dependencies.localDeviceRepository.set(
       "federatedIdentity",
-      connectedUserFederatedIdentity,
+      proConnectFederatedIdentity,
     );
     store.dispatch(rootAppSlice.actions.appIsReady());
 
     expectAuthStateToBe({
       afterLoginRedirectionUrl: null,
-      federatedIdentity: connectedUserFederatedIdentity,
+      federatedIdentity: proConnectFederatedIdentity,
       isLoading: false,
       isRequestingLoginByEmail: false,
       isRequestingRenewExpiredJwt: false,
       requestedEmail: null,
     });
 
-    expectFederatedIdentityInDevice(connectedUserFederatedIdentity);
+    expectFederatedIdentityInDevice(proConnectFederatedIdentity);
     const user: ConnectedUser = {
       id: "123",
       email: "mail@mail.com",
@@ -336,7 +351,7 @@ describe("Auth slice", () => {
 
     expectAuthStateToBe({
       afterLoginRedirectionUrl: null,
-      federatedIdentity: connectedUserFederatedIdentity,
+      federatedIdentity: proConnectFederatedIdentity,
       isLoading: false,
       isRequestingLoginByEmail: false,
       isRequestingRenewExpiredJwt: false,
@@ -537,7 +552,7 @@ describe("Auth slice", () => {
         isLoading: true,
       });
       dependencies.authGateway.confirmLoginByMagicLinkResponse$.next({
-        ...connectedUserFederatedIdentity,
+        ...proConnectFederatedIdentity,
         redirectUri,
       });
       expectAuthStateToBe({

--- a/front/src/core-logic/domain/auth/auth.test.ts
+++ b/front/src/core-logic/domain/auth/auth.test.ts
@@ -186,7 +186,7 @@ describe("Auth slice", () => {
       expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
     });
 
-    it("with provider email - deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for without redirects to provider logout page ", () => {
+    it("with provider email and mode device-and-oauth - deletes federatedIdentity & partialConventionInUrl stored in device and in store when asked for and provides error feedback ", () => {
       const emailFederatedIdentity: FederatedIdentity = {
         provider: "email",
         token: "token",
@@ -214,7 +214,7 @@ describe("Auth slice", () => {
 
       store.dispatch(
         authSlice.actions.fetchLogoutUrlRequested({
-          mode: "device-only",
+          mode: "device-and-oauth",
           feedbackTopic: "auth-global",
         }),
       );
@@ -231,14 +231,6 @@ describe("Auth slice", () => {
       expectFederatedIdentityInDevice(undefined);
       expectToEqual(dependencies.navigationGateway.wentToUrls, []);
 
-      expectAuthStateToBe({
-        afterLoginRedirectionUrl: null,
-        federatedIdentity: null,
-        isLoading: true,
-        isRequestingLoginByEmail: false,
-        isRequestingRenewExpiredJwt: false,
-        requestedEmail: null,
-      });
       expect(connectedUserSelectors.currentUser(store.getState())).toBe(null);
       expectToEqual(
         feedbacksSelectors.feedbacks(store.getState())["auth-global"],

--- a/front/src/core-logic/domain/connected-user/connectedUser.test.ts
+++ b/front/src/core-logic/domain/connected-user/connectedUser.test.ts
@@ -78,7 +78,6 @@ describe("InclusionConnected", () => {
   const inclusionConnectedFederatedIdentity: FederatedIdentity = {
     provider: "proConnect",
     token: "fake-token",
-    idToken: "inclusion-connect-id-token",
   };
 
   beforeEach(() => {
@@ -152,7 +151,6 @@ describe("InclusionConnected", () => {
           federatedIdentity: {
             token: "some-existing-token",
             provider: "proConnect",
-            idToken: "inclusion-connect-id-token",
           },
           isLoading: true,
           isRequestingRenewExpiredJwt: false,

--- a/front/src/core-logic/domain/rootApp/rootApp.test.ts
+++ b/front/src/core-logic/domain/rootApp/rootApp.test.ts
@@ -52,7 +52,6 @@ describe("rootApp epic", () => {
     dependencies.localDeviceRepository.set("federatedIdentity", {
       provider: "proConnect",
       token,
-      idToken: "id-token",
     });
 
     expect(store.getState().auth.federatedIdentity).toBeNull();

--- a/front/src/core-logic/ports/AuthGateway.ts
+++ b/front/src/core-logic/ports/AuthGateway.ts
@@ -5,7 +5,6 @@ import type {
   ConnectedUser,
   ConnectedUserJwt,
   InitiateLoginByEmailParams,
-  LogoutQueryParams,
   OAuthSuccessLoginParams,
   RenewExpiredJwtRequestDto,
   UserId,
@@ -14,9 +13,7 @@ import type {
 
 export interface AuthGateway {
   loginByEmail$: (params: InitiateLoginByEmailParams) => Observable<void>;
-  getLogoutUrl$(
-    payload: LogoutQueryParams & { authToken: string },
-  ): Observable<AbsoluteUrl>;
+  getLogoutUrl$(payload: { jwt: ConnectedUserJwt }): Observable<AbsoluteUrl>;
   getConnectedUser$(params: {
     jwt: ConnectedUserJwt;
     userId?: UserId;

--- a/shared/src/auth/auth.dto.ts
+++ b/shared/src/auth/auth.dto.ts
@@ -56,7 +56,6 @@ export const allowedLoginSources: Record<
 
 export type ExternalId = Flavor<string, "ExternalId">;
 
-export type IdToken = Flavor<string, "IdToken">;
 export type IdentityProvider = Extract<
   FederatedIdentityProvider,
   "proConnect" | "email"
@@ -89,14 +88,6 @@ export type InitiateLoginByOAuthParams = WithRedirectUri & {
 
 export type InitiateLoginByEmailParams = WithRedirectUri & {
   email: Email;
-};
-
-export type LogoutQueryParams = WithIdToken & {
-  provider: FederatedIdentityProvider;
-};
-
-export type WithIdToken = {
-  idToken: IdToken;
 };
 
 export type AfterOAuthSuccessRedirectionResponse = {

--- a/shared/src/auth/auth.routes.ts
+++ b/shared/src/auth/auth.routes.ts
@@ -15,7 +15,6 @@ import {
   afterOAuthSuccessRedirectionResponseSchema,
   initiateLoginByEmailParamsSchema,
   initiateLoginByOAuthParamsSchema,
-  logoutQueryParamsSchema,
   oAuthSuccessLoginParamsSchema,
 } from "./auth.schema";
 
@@ -88,10 +87,10 @@ export const authRoutes = defineRoutes({
   getOAuthLogoutUrl: defineRoute({
     method: "get",
     url: "/logout/oauth",
-    queryParamsSchema: logoutQueryParamsSchema,
     ...withAuthorizationHeaders,
     responses: {
       200: absoluteUrlSchema,
+      400: httpErrorSchema,
       401: httpErrorSchema,
     },
   }),

--- a/shared/src/auth/auth.routes.ts
+++ b/shared/src/auth/auth.routes.ts
@@ -92,6 +92,7 @@ export const authRoutes = defineRoutes({
       200: absoluteUrlSchema,
       400: httpErrorSchema,
       401: httpErrorSchema,
+      403: httpErrorSchema,
     },
   }),
   renewExpiredJwt: defineRoute({

--- a/shared/src/auth/auth.schema.ts
+++ b/shared/src/auth/auth.schema.ts
@@ -5,8 +5,6 @@ import {
   type AllowedLoginSource,
   type FederatedIdentityProvider,
   frontRoutes,
-  type LogoutQueryParams,
-  type OAuthProviderForLogin,
 } from "..";
 import { absoluteUrlSchema } from "../AbsoluteUrl";
 import { emailSchema } from "../email/email.schema";
@@ -83,15 +81,6 @@ export const oAuthSuccessLoginParamsSchema: ZodSchemaWithInputMatchingOutput<OAu
   z.object({
     code: z.string(),
     state: z.string(),
-  });
-
-const oAuthProviderForLoginSchema: ZodSchemaWithInputMatchingOutput<OAuthProviderForLogin> =
-  z.enum(["proConnect", "ftConnect"]);
-
-export const logoutQueryParamsSchema: ZodSchemaWithInputMatchingOutput<LogoutQueryParams> =
-  z.object({
-    idToken: z.string(),
-    provider: oAuthProviderForLoginSchema,
   });
 
 export const afterOAuthSuccessRedirectionResponseSchema: ZodSchemaWithInputMatchingOutput<AfterOAuthSuccessRedirectionResponse> =

--- a/shared/src/errors/errors.ts
+++ b/shared/src/errors/errors.ts
@@ -332,10 +332,16 @@ export const errors = {
       new ForbiddenError(
         `Le renouvellement d'une connexion du type ${provider} n'est pas supportée. Veuillez vous reconnecter manuellement.`,
       ),
+    missingIdToken: (state: OAuthState) =>
+      new ForbiddenError(
+        `L'authentification avec le state '${state}' n'a pas d'idToken.`,
+      ),
     missingOAuth: ({ state }: { state?: OAuthState }) =>
       new ForbiddenError(
         `Il n'y a pas d'authentification en cours ${state ? `avec l'état '${state}'` : ""}.`,
       ),
+    unsupportedProvider: ({ actual }: { actual: FederatedIdentityProvider }) =>
+      new ForbiddenError(`L'authentification '${actual}' n'est pas supportée.`),
     unusedOAuth: () =>
       new ForbiddenError(
         "Le renouvellement d'une connexion non utilisée n'est pas autorisé.",

--- a/shared/src/federatedIdentities/federatedIdentity.dto.ts
+++ b/shared/src/federatedIdentities/federatedIdentity.dto.ts
@@ -1,4 +1,3 @@
-import type { IdToken } from "../auth/auth.dto";
 import type { ConnectedUserJwt } from "../tokens/jwt.dto";
 import type { Flavor } from "../typeFlavors";
 
@@ -20,18 +19,11 @@ type GenericFederatedIdentity<
   Provider extends FederatedIdentityProvider,
   T extends FtConnectToken | ConnectedUserJwt,
   P = void,
-> = Provider extends "ftConnect"
-  ? {
-      provider: Provider;
-      token: T;
-      payload?: P;
-    }
-  : {
-      provider: Provider;
-      token: T;
-      payload?: P;
-      idToken: IdToken;
-    };
+> = {
+  provider: Provider;
+  token: T;
+  payload?: P;
+};
 
 export const authFailed = "AuthFailed";
 

--- a/shared/src/routes/routes.ts
+++ b/shared/src/routes/routes.ts
@@ -41,7 +41,6 @@ type AcquisitionParamsKeys = keyof typeof acquisitionParams;
 
 const connectedUserParams = {
   token: param.query.optional.string,
-  idToken: param.query.optional.string,
   provider: param.query.optional.string,
   alreadyUsedAuthentication: param.query.optional.string,
 } satisfies Record<

--- a/shared/src/user/user.dto.ts
+++ b/shared/src/user/user.dto.ts
@@ -2,7 +2,7 @@ import type {
   WithAgencyDashboards,
   WithAgencyRights,
 } from "../agency/agency.dto";
-import type { IdentityProvider, WithIdToken } from "../auth/auth.dto";
+import type { IdentityProvider } from "../auth/auth.dto";
 import type { ProConnectInfos } from "../auth/proConnect/proConnect.dto";
 import type { Email } from "../email/email.dto";
 import type {
@@ -60,4 +60,4 @@ export type ConnectedUser = UserWithRights & WithDashboards;
 export type ConnectedUserQueryParams = {
   token: ConnectedUserJwt;
   provider: IdentityProvider;
-} & WithIdToken;
+};


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

<!-- Optionnel : indiquer les zones qui méritent une attention particulière -->
