### PR TITLE
#5376 - Étendre la recherche des conventions avec erreurs de synchro + ajouter davantage d'infos sur les résultats

### DIFF
--- a/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
@@ -852,7 +852,7 @@ describe("authenticatedConventionRoutes", () => {
           data: [],
           pagination: {
             currentPage: 1,
-            totalPages: 0,
+            totalPages: 1,
             numberPerPage: 10,
             totalRecords: 0,
           },

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -458,6 +458,17 @@ export class InMemoryConventionQueries implements ConventionQueries {
     pagination: Required<PaginationQueryParams>;
     filters?: ConventionsWithErroredBroadcastFeedbackFilters;
   }): Promise<DataWithPagination<ConventionWithBroadcastFeedback>> {
+    if (userAgencyIds.length === 0)
+      return {
+        data: [],
+        pagination: {
+          totalRecords: 0,
+          currentPage: 1,
+          totalPages: 1,
+          numberPerPage: pagination.perPage,
+        },
+      };
+
     const userConventions = this.conventionRepository.conventions.filter(
       (convention) => userAgencyIds.includes(convention.agencyId),
     );
@@ -477,6 +488,7 @@ export class InMemoryConventionQueries implements ConventionQueries {
           },
           lastBroadcastFeedback,
           agencyReferent: convention.agencyReferent ?? null,
+          agencyId: convention.agencyId,
         };
       }),
     );

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -523,7 +523,13 @@ export class InMemoryConventionQueries implements ConventionQueries {
         }
 
         if (filters.search) {
-          if (result.id.toLowerCase() !== filters.search.toLowerCase())
+          const convention = userConventions.find(
+            (conventionDto) => conventionDto.id === result.id,
+          );
+          if (
+            !convention ||
+            !matchesConventionSearch(convention, filters.search)
+          )
             return false;
         }
 

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -476,6 +476,7 @@ export class InMemoryConventionQueries implements ConventionQueries {
             lastname: convention.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback,
+          agencyReferent: convention.agencyReferent ?? null,
         };
       }),
     );

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2859,6 +2859,35 @@ describe("Pg implementation of ConventionQueries", () => {
       const agency = new AgencyDtoBuilder().withId(agencyIdA).build();
       const conventionWithManagedError = new ConventionDtoBuilder()
         .withId(conventionIdA)
+        .withBeneficiaryFirstName("Camille")
+        .withBeneficiaryLastName("Desmoulins")
+        .withSiret("14915000000000")
+        .withBusinessName("France Merguez")
+        .withBeneficiaryEmail("camille.desmoulins@example.com")
+        .withEstablishmentRepresentativeEmail("christine.dupont@example.com")
+        .withEstablishmentTutorEmail("establishment.tutor@example.com")
+        .withBeneficiaryRepresentative({
+          firstName: "Jean",
+          lastName: "Dupont",
+          email: "jean.dupont@example.com",
+          role: "beneficiary-representative",
+          phone: "+33123456789",
+        })
+        .withBeneficiaryCurrentEmployer({
+          firstName: "Mon",
+          lastName: "Employeur",
+          email: "current.employer@example.com",
+          job: "Employeur",
+          role: "beneficiary-current-employer",
+          phone: "+33123456789",
+          businessSiret: "12345678901234",
+          businessName: "France Merguez",
+          businessAddress: "123 Rue de la Paix, 75000 Paris, France",
+        })
+        .withAgencyReferent({
+          firstname: "John",
+          lastname: "Doe",
+        })
         .withAgencyId(agencyIdA)
         .withStatus("READY_TO_SIGN")
         .withDateSubmission("2025-01-02T00:00:00.000Z")
@@ -3145,14 +3174,59 @@ describe("Pg implementation of ConventionQueries", () => {
         });
       });
 
-      it("should filter by search (convention ID)", async () => {
+      it.each([
+        {
+          searchLabel: "convention ID",
+          searchFilter: "aaaaac99-9c0b",
+        },
+        { searchLabel: "beneficiary firstname", searchFilter: "cam" },
+        { searchLabel: "beneficiary lastname", searchFilter: "moulins" },
+        { searchLabel: "fullname", searchFilter: "camille desmoulins" },
+        {
+          searchLabel: "beneficiary email",
+          searchFilter: "camil",
+        },
+        {
+          searchLabel: "business name",
+          searchFilter: "france",
+        },
+        { searchLabel: "siret", searchFilter: "1491" },
+        {
+          searchLabel: "establishment representative email",
+          searchFilter: "christine.d",
+        },
+        {
+          searchLabel: "beneficiary current employer email",
+          searchFilter: "current",
+        },
+        {
+          searchLabel: "beneficiary representative email",
+          searchFilter: "jean.d",
+        },
+        {
+          searchLabel: "establishment tutor email",
+          searchFilter: "establishment.tutor",
+        },
+        {
+          searchLabel: "agency referent firstname",
+          searchFilter: "john",
+        },
+        {
+          searchLabel: "agency referent lastname",
+          searchFilter: "do",
+        },
+        {
+          searchLabel: "agency referent fullname",
+          searchFilter: "john d",
+        },
+      ])("should filter by $searchLabel", async ({ searchFilter }) => {
         const result =
           await conventionQueries.getConventionsWithErroredBroadcastFeedbackForAgencyUser(
             {
               userAgencyIds: [agencyIdA],
               pagination: { page: 1, perPage: 10 },
               filters: {
-                search: conventionWithManagedError.id as SearchTextAlphaNumeric,
+                search: searchFilter,
               },
             },
           );

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -1312,6 +1312,72 @@ describe("Pg implementation of ConventionQueries", () => {
       expectToEqual(result.data, [conventionB]);
     });
 
+    it("should filter conventions by beneficiary representative email", async () => {
+      const conventionWithBeneficiaryRepresentative = new ConventionDtoBuilder(
+        conventionA,
+      )
+        .withBeneficiaryRepresentative({
+          firstName: "Jean",
+          lastName: "Repr",
+          email: "beneficiary.representative@convention-a.com",
+          role: "beneficiary-representative",
+          phone: "+33123456789",
+        })
+        .build();
+      await conventionRepository.update(
+        conventionWithBeneficiaryRepresentative,
+        anyConventionUpdatedAt,
+      );
+
+      const result = await conventionQueries.getPaginatedConventions({
+        pagination: { page: 1, perPage: 10 },
+        filters: {
+          search: "beneficiary.representative@convention-a",
+        },
+        sort: {
+          by: "dateSubmission",
+          direction: "desc",
+        },
+      });
+
+      expectToEqual(result.data, [conventionWithBeneficiaryRepresentative]);
+    });
+
+    it("should filter conventions by beneficiary current employer email", async () => {
+      const conventionWithBeneficiaryCurrentEmployer = new ConventionDtoBuilder(
+        conventionA,
+      )
+        .withBeneficiaryCurrentEmployer({
+          firstName: "Mon",
+          lastName: "Employeur",
+          email: "current.employer@convention-a.com",
+          job: "Employeur",
+          role: "beneficiary-current-employer",
+          phone: "+33123456789",
+          businessSiret: "12345678901234",
+          businessName: "Business A Employer",
+          businessAddress: "123 Rue de la Paix, 75000 Paris, France",
+        })
+        .build();
+      await conventionRepository.update(
+        conventionWithBeneficiaryCurrentEmployer,
+        anyConventionUpdatedAt,
+      );
+
+      const result = await conventionQueries.getPaginatedConventions({
+        pagination: { page: 1, perPage: 10 },
+        filters: {
+          search: "current.employer",
+        },
+        sort: {
+          by: "dateSubmission",
+          direction: "desc",
+        },
+      });
+
+      expectToEqual(result.data, [conventionWithBeneficiaryCurrentEmployer]);
+    });
+
     it("should filter conventions by date range", async () => {
       const result = await conventionQueries.getPaginatedConventions({
         pagination: { page: 1, perPage: 10 },

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2128,6 +2128,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: convention.agencyId,
             },
           ],
           pagination: {
@@ -2309,6 +2310,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: cancelledConvention.agencyId,
             },
           ],
           pagination: {
@@ -2571,6 +2573,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionB.agencyId,
             },
           ],
           pagination: {
@@ -2739,6 +2742,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   },
                 },
                 agencyReferent: null,
+                agencyId: convention1.agencyId,
               },
             ],
             pagination: {
@@ -2770,6 +2774,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   },
                 },
                 agencyReferent: null,
+                agencyId: convention3.agencyId,
               },
               {
                 id: convention2.id,
@@ -2788,6 +2793,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   },
                 },
                 agencyReferent: null,
+                agencyId: convention2.agencyId,
               },
               {
                 id: convention1.id,
@@ -2806,6 +2812,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   },
                 },
                 agencyReferent: null,
+                agencyId: convention1.agencyId,
               },
             ],
             pagination: {
@@ -2837,6 +2844,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   },
                 },
                 agencyReferent: null,
+                agencyId: convention1.agencyId,
               },
             ],
             pagination: {
@@ -3018,6 +3026,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionInReviewWithManagedError.agencyId,
             },
             {
               id: conventionWithManagedError.id,
@@ -3039,6 +3048,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: conventionWithManagedError.agencyReferent ?? null,
+              agencyId: conventionWithManagedError.agencyId,
             },
           ],
           pagination: {
@@ -3084,6 +3094,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionWithUnmanagedError.agencyId,
             },
           ],
           pagination: {
@@ -3130,6 +3141,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionInReviewWithManagedError.agencyId,
             },
           ],
           pagination: {
@@ -3176,6 +3188,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: conventionWithManagedError.agencyReferent ?? null,
+              agencyId: conventionWithManagedError.agencyId,
             },
           ],
           pagination: {
@@ -3266,6 +3279,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: conventionWithManagedError.agencyReferent ?? null,
+              agencyId: conventionWithManagedError.agencyId,
             },
           ],
           pagination: {
@@ -3334,6 +3348,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: conventionWithManagedError.agencyReferent ?? null,
+              agencyId: conventionWithManagedError.agencyId,
             },
           ],
           pagination: {
@@ -3437,6 +3452,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionAfter2025.agencyId,
             },
             {
               id: conventionInReviewWithManagedError.id,
@@ -3461,6 +3477,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionInReviewWithManagedError.agencyId,
             },
             {
               id: conventionWithUnmanagedError.id,
@@ -3484,6 +3501,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: null,
+              agencyId: conventionWithUnmanagedError.agencyId,
             },
             {
               id: conventionWithManagedError.id,
@@ -3505,6 +3523,7 @@ describe("Pg implementation of ConventionQueries", () => {
                 },
               },
               agencyReferent: conventionWithManagedError.agencyReferent ?? null,
+              agencyId: conventionWithManagedError.agencyId,
             },
           ],
           pagination: {

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2127,6 +2127,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
           ],
           pagination: {
@@ -2307,6 +2308,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
           ],
           pagination: {
@@ -2568,6 +2570,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
           ],
           pagination: {
@@ -2735,6 +2738,7 @@ describe("Pg implementation of ConventionQueries", () => {
                     ),
                   },
                 },
+                agencyReferent: null,
               },
             ],
             pagination: {
@@ -2765,6 +2769,7 @@ describe("Pg implementation of ConventionQueries", () => {
                     ),
                   },
                 },
+                agencyReferent: null,
               },
               {
                 id: convention2.id,
@@ -2782,6 +2787,7 @@ describe("Pg implementation of ConventionQueries", () => {
                     ),
                   },
                 },
+                agencyReferent: null,
               },
               {
                 id: convention1.id,
@@ -2799,6 +2805,7 @@ describe("Pg implementation of ConventionQueries", () => {
                     ),
                   },
                 },
+                agencyReferent: null,
               },
             ],
             pagination: {
@@ -2829,6 +2836,7 @@ describe("Pg implementation of ConventionQueries", () => {
                     ),
                   },
                 },
+                agencyReferent: null,
               },
             ],
             pagination: {
@@ -3009,6 +3017,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
             {
               id: conventionWithManagedError.id,
@@ -3029,6 +3038,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: conventionWithManagedError.agencyReferent ?? null,
             },
           ],
           pagination: {
@@ -3073,6 +3083,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
           ],
           pagination: {
@@ -3118,6 +3129,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
           ],
           pagination: {
@@ -3163,6 +3175,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: conventionWithManagedError.agencyReferent ?? null,
             },
           ],
           pagination: {
@@ -3252,6 +3265,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: conventionWithManagedError.agencyReferent ?? null,
             },
           ],
           pagination: {
@@ -3319,6 +3333,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: conventionWithManagedError.agencyReferent ?? null,
             },
           ],
           pagination: {
@@ -3421,6 +3436,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
             {
               id: conventionInReviewWithManagedError.id,
@@ -3444,6 +3460,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
             {
               id: conventionWithUnmanagedError.id,
@@ -3466,6 +3483,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
             },
             {
               id: conventionWithManagedError.id,
@@ -3486,6 +3504,7 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: conventionWithManagedError.agencyReferent ?? null,
             },
           ],
           pagination: {

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -2524,6 +2524,8 @@ describe("Pg implementation of ConventionQueries", () => {
                   ),
                 },
               },
+              agencyReferent: null,
+              agencyId: cancelledConvention.agencyId,
             },
           ],
           pagination: {

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -523,7 +523,7 @@ export class PgConventionQueries implements ConventionQueries {
           totalRecords: 0,
           currentPage: 1,
           totalPages: 1,
-          numberPerPage: 0,
+          numberPerPage: pagination.perPage,
         },
       };
 

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -597,6 +597,7 @@ export class PgConventionQueries implements ConventionQueries {
                     lastname: row.agencyReferentLastName,
                   }
                 : null,
+            agencyId: row.agencyId,
           },
           logger,
         }),

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -861,6 +861,26 @@ const filterSearchForBroadcastFeedback =
     return builder.where((eb) =>
       eb.or([
         sql<any>`CAST(${eb.ref("cf.conventionId")} AS text) LIKE ${pattern}`,
+        // Search in beneficiary names
+        sql<any>`${eb.ref("cf.bLastName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.bFirstName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.bFirstName")} || ' ' || ${eb.ref("cf.bLastName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.bLastName")} || ' ' || ${eb.ref("cf.bFirstName")} ILIKE ${pattern}`,
+        // Search in establishment business name
+        sql<any>`${eb.ref("cf.businessName")} ILIKE ${pattern}`,
+        // Search in establishment SIRET
+        sql<any>`${eb.ref("cf.siret")} LIKE ${pattern}`,
+        // Search in actor emails
+        sql<any>`${eb.ref("cf.bEmail")} LIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.erEmail")} LIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.etEmail")} LIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.brEmail")} IS NOT NULL AND ${eb.ref("cf.brEmail")} LIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.bceEmail")} IS NOT NULL AND ${eb.ref("cf.bceEmail")} LIKE ${pattern}`,
+        // Search agency referent names
+        sql<any>`${eb.ref("cf.agencyReferentFirstName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.agencyReferentLastName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.agencyReferentFirstName")} || ' ' || ${eb.ref("cf.agencyReferentLastName")} ILIKE ${pattern}`,
+        sql<any>`${eb.ref("cf.agencyReferentLastName")} || ' ' || ${eb.ref("cf.agencyReferentFirstName")} ILIKE ${pattern}`,
       ]),
     );
   };

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -590,6 +590,13 @@ export class PgConventionQueries implements ConventionQueries {
                 ? row.subscriberErrorFeedback
                 : undefined,
             },
+            agencyReferent:
+              row.agencyReferentFirstName && row.agencyReferentLastName
+                ? {
+                    firstname: row.agencyReferentFirstName,
+                    lastname: row.agencyReferentLastName,
+                  }
+                : null,
           },
           logger,
         }),

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -823,11 +823,7 @@ const filterExcludeUnvalidatedConventionsWithoutPriorSuccessfulBroadcast =
           eb
             .selectFrom("broadcast_feedbacks as bf_ok")
             .select(sql`1`.as("__"))
-            .where(
-              sql`(bf_ok.request_params->>'conventionId')::uuid`,
-              "=",
-              eb.ref("cf.conventionId"),
-            )
+            .where("bf_ok.convention_id", "=", eb.ref("cf.conventionId"))
             .where(
               sql<boolean>`(
                 (bf_ok.consumer_name = ${broadcastToFtConsumerName} AND bf_ok.response @> '{"httpStatus": 201}'::jsonb)

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -436,6 +436,14 @@ const createBroadcastFeedbackBaseBuilder = ({
           "beneficiary.id",
           "c.beneficiary_id",
         )
+        .innerJoin("actors as er", "er.id", "c.establishment_representative_id")
+        .leftJoin("actors as br", "br.id", "c.beneficiary_representative_id")
+        .innerJoin("actors as et", "et.id", "c.establishment_tutor_id")
+        .leftJoin(
+          "actors as bce",
+          "bce.id",
+          "c.beneficiary_current_employer_id",
+        )
         .innerJoin("broadcast_feedbacks as bf", (join) =>
           join.on((eb) =>
             eb(
@@ -449,8 +457,17 @@ const createBroadcastFeedbackBaseBuilder = ({
           eb.ref("c.id").as("conventionId"),
           eb.ref("c.agency_id").as("agencyId"),
           eb.ref("c.status").as("status"),
+          eb.ref("c.business_name").as("businessName"),
+          eb.ref("c.siret").as("siret"),
+          eb.ref("c.agency_referent_first_name").as("agencyReferentFirstName"),
+          eb.ref("c.agency_referent_last_name").as("agencyReferentLastName"),
           eb.ref("beneficiary.first_name").as("bFirstName"),
           eb.ref("beneficiary.last_name").as("bLastName"),
+          eb.ref("beneficiary.email").as("bEmail"),
+          eb.ref("er.email").as("erEmail"),
+          eb.ref("et.email").as("etEmail"),
+          eb.ref("br.email").as("brEmail"),
+          eb.ref("bce.email").as("bceEmail"),
           eb.ref("bf.consumer_id").as("consumerId"),
           eb.ref("bf.consumer_name").as("consumerName"),
           eb.ref("bf.service_name").as("serviceName"),

--- a/back/src/domains/convention/adapters/pgConventionSql.ts
+++ b/back/src/domains/convention/adapters/pgConventionSql.ts
@@ -444,15 +444,7 @@ const createBroadcastFeedbackBaseBuilder = ({
           "bce.id",
           "c.beneficiary_current_employer_id",
         )
-        .innerJoin("broadcast_feedbacks as bf", (join) =>
-          join.on((eb) =>
-            eb(
-              sql`(bf.request_params ->> 'conventionId')::uuid`,
-              "=",
-              eb.ref("c.id"),
-            ),
-          ),
-        )
+        .innerJoin("broadcast_feedbacks as bf", "bf.convention_id", "c.id")
         .select((eb) => [
           eb.ref("c.id").as("conventionId"),
           eb.ref("c.agency_id").as("agencyId"),

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.ts
@@ -1,7 +1,8 @@
 import {
   type ConnectedUser,
-  type ConventionWithBroadcastFeedback,
+  type ConventionWithBroadcastFeedbackReadDto,
   type DataWithPagination,
+  errors,
   type GetConventionsWithErroredBroadcastFeedbackParams,
   getConventionsWithErroredBroadcastFeedbackParamsSchema,
   getPaginationParamsForWeb,
@@ -18,20 +19,43 @@ export const makeGetConventionsWithErroredBroadcastFeedback = useCaseBuilder(
   .withInput<GetConventionsWithErroredBroadcastFeedbackParams>(
     getConventionsWithErroredBroadcastFeedbackParamsSchema,
   )
-  .withOutput<DataWithPagination<ConventionWithBroadcastFeedback>>()
+  .withOutput<DataWithPagination<ConventionWithBroadcastFeedbackReadDto>>()
   .withCurrentUser<ConnectedUser>()
   .build(async ({ inputParams, uow, currentUser }) => {
     const { filters } = inputParams;
 
     const pagination = getPaginationParamsForWeb(inputParams.pagination);
 
-    return uow.conventionQueries.getConventionsWithErroredBroadcastFeedbackForAgencyUser(
-      {
-        userAgencyIds: currentUser.agencyRights
-          .filter((agencyRight) => agencyRight.roles.length > 0)
-          .map((agencyRight) => agencyRight.agency.id),
-        pagination,
-        filters,
-      },
-    );
+    const result =
+      await uow.conventionQueries.getConventionsWithErroredBroadcastFeedbackForAgencyUser(
+        {
+          userAgencyIds: currentUser.agencyRights
+            .filter((agencyRight) => agencyRight.roles.length > 0)
+            .map((agencyRight) => agencyRight.agency.id),
+          pagination,
+          filters,
+        },
+      );
+
+    return {
+      ...result,
+      data: result.data.map((conventionWithBroadcastFeedback) => {
+        const agencyName = currentUser.agencyRights.find(
+          (agencyRight) =>
+            agencyRight.agency.id === conventionWithBroadcastFeedback.agencyId,
+        )?.agency.name;
+
+        if (!agencyName) {
+          throw errors.user.noRightsOnAgency({
+            userId: currentUser.id,
+            agencyId: conventionWithBroadcastFeedback.agencyId,
+          });
+        }
+
+        return {
+          ...conventionWithBroadcastFeedback,
+          agencyName,
+        };
+      }),
+    };
   });

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -48,6 +48,37 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
   const convention1 = new ConventionDtoBuilder()
     .withId("convention-id-1")
     .withAgencyId(agencyId1)
+    .withBeneficiaryFirstName("Camille")
+    .withBeneficiaryLastName("Desmoulins")
+    .withSiret("14915000000000")
+    .withBusinessName("France Merguez")
+    .withBeneficiaryEmail("camille.desmoulins@example.com")
+    .withEstablishmentRepresentativeEmail("christine.dupont@example.com")
+    .withEstablishmentTutorEmail("establishment.tutor@example.com")
+    .withBeneficiaryRepresentative({
+      firstName: "Jean",
+      lastName: "Dupont",
+      email: "jean.dupont@example.com",
+      role: "beneficiary-representative",
+      phone: "+33123456789",
+    })
+    .withBeneficiaryCurrentEmployer({
+      firstName: "Mon",
+      lastName: "Employeur",
+      email: "current.employer@example.com",
+      job: "Employeur",
+      role: "beneficiary-current-employer",
+      phone: "+33123456789",
+      businessSiret: "12345678901234",
+      businessName: "France Merguez",
+      businessAddress: "123 Rue de la Paix, 75000 Paris, France",
+    })
+    .withAgencyReferent({
+      firstname: "John",
+      lastname: "Doe",
+    })
+    .withStatus("READY_TO_SIGN")
+    .withDateSubmission("2025-01-02T00:00:00.000Z")
     .build();
 
   const convention2 = new ConventionDtoBuilder()
@@ -307,6 +338,81 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
       {
         pagination: { page: 1, perPage: 10 },
         filters: { search: convention1.id as SearchTextAlphaNumeric },
+      },
+      user1,
+    );
+
+    expectToEqual(result, {
+      data: [
+        {
+          id: convention1.id,
+          status: convention1.status,
+          beneficiary: {
+            firstname: convention1.signatories.beneficiary.firstName,
+            lastname: convention1.signatories.beneficiary.lastName,
+          },
+          lastBroadcastFeedback: managedErrorFeedback,
+        },
+      ],
+      pagination: {
+        totalRecords: 1,
+        currentPage: 1,
+        totalPages: 1,
+        numberPerPage: 10,
+      },
+    });
+  });
+
+  it.each([
+    {
+      searchLabel: "convention ID",
+      searchFilter: "id-1",
+    },
+    { searchLabel: "beneficiary firstname", searchFilter: "cam" },
+    { searchLabel: "beneficiary lastname", searchFilter: "moulins" },
+    { searchLabel: "fullname", searchFilter: "camille desmoulins" },
+    {
+      searchLabel: "beneficiary email",
+      searchFilter: "camil",
+    },
+    {
+      searchLabel: "business name",
+      searchFilter: "france",
+    },
+    { searchLabel: "siret", searchFilter: "1491" },
+    {
+      searchLabel: "establishment representative email",
+      searchFilter: "christine.dupont@example",
+    },
+    {
+      searchLabel: "beneficiary current employer email",
+      searchFilter: "current",
+    },
+    {
+      searchLabel: "beneficiary representative email",
+      searchFilter: "jean",
+    },
+    {
+      searchLabel: "establishment tutor email",
+      searchFilter: "tutor",
+    },
+    {
+      searchLabel: "agency referent firstname",
+      searchFilter: "john",
+    },
+    {
+      searchLabel: "agency referent lastname",
+      searchFilter: "do",
+    },
+    {
+      searchLabel: "agency referent fullname",
+      searchFilter: "john d",
+    },
+  ])("should filter by $searchLabel", async ({ searchFilter }) => {
+    const result = await useCase.execute(
+      {
+        pagination: { page: 1, perPage: 10 },
+        filters: { search: searchFilter },
       },
       user1,
     );

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -139,6 +139,30 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
     ];
   });
 
+  it("should return empty result when user has no agencyRights", async () => {
+    const userWithoutAgencyRights = new ConnectedUserBuilder()
+      .withId(userId1)
+      .withAgencyRights([])
+      .build();
+
+    const result = await useCase.execute(
+      {
+        pagination: { page: 1, perPage: 10 },
+      },
+      userWithoutAgencyRights,
+    );
+
+    expectToEqual(result, {
+      data: [],
+      pagination: {
+        totalRecords: 0,
+        currentPage: 1,
+        totalPages: 1,
+        numberPerPage: 10,
+      },
+    });
+  });
+
   it("should pass through filters when provided", async () => {
     const result = await useCase.execute(
       {
@@ -161,6 +185,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -191,6 +217,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
           agencyReferent: convention2.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
         {
           id: convention1.id,
@@ -201,6 +229,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -237,6 +267,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
           agencyReferent: convention2.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -322,6 +354,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
           agencyReferent: convention2.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
         {
           id: convention1.id,
@@ -332,6 +366,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -363,6 +399,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -439,6 +477,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -473,6 +513,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           },
           lastBroadcastFeedback: managedErrorFeedback,
           agencyReferent: convention1.agencyReferent ?? null,
+          agencyId: agencyId1,
+          agencyName: agency1.name,
         },
       ],
       pagination: {
@@ -620,6 +662,8 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             },
             lastBroadcastFeedback: errorBroadcast,
             agencyReferent: null,
+            agencyId: agencyId1,
+            agencyName: agency1.name,
           },
         ],
         pagination: {

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -84,6 +84,10 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
   const convention2 = new ConventionDtoBuilder()
     .withId("convention-id-2")
     .withAgencyId(agencyId1)
+    .withAgencyReferent({
+      firstname: "Anne",
+      lastname: "Tro",
+    })
     .build();
 
   const managedErrorFeedback: BroadcastFeedback = {
@@ -156,6 +160,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -185,6 +190,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention2.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
+          agencyReferent: convention2.agencyReferent ?? null,
         },
         {
           id: convention1.id,
@@ -194,6 +200,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -229,6 +236,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention2.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
+          agencyReferent: convention2.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -313,6 +321,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention2.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: unmanagedErrorFeedback,
+          agencyReferent: convention2.agencyReferent ?? null,
         },
         {
           id: convention1.id,
@@ -322,6 +331,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -352,6 +362,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -427,6 +438,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -460,6 +472,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
             lastname: convention1.signatories.beneficiary.lastName,
           },
           lastBroadcastFeedback: managedErrorFeedback,
+          agencyReferent: convention1.agencyReferent ?? null,
         },
       ],
       pagination: {
@@ -606,6 +619,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
               lastname: cancelledConvention.signatories.beneficiary.lastName,
             },
             lastBroadcastFeedback: errorBroadcast,
+            agencyReferent: null,
           },
         ],
         pagination: {

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -744,6 +744,9 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
               lastname: cancelledConvention.signatories.beneficiary.lastName,
             },
             lastBroadcastFeedback: partnerErrorBroadcast,
+            agencyReferent: null,
+            agencyId: agencyId1,
+            agencyName: agency1.name,
           },
         ],
         pagination: {

--- a/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
@@ -18,6 +18,7 @@ import {
 import { useDispatch } from "react-redux";
 import {
   activeAgencyStatuses,
+  type ConventionWithBroadcastFeedbackReadDto,
   conventionStatuses,
   domElementIds,
   type FlatGetConventionsWithErroredBroadcastFeedbackParams,
@@ -433,6 +434,7 @@ export const ConventionsWithBroadcastErrorList = ({
               conventionWithBroadcastFeedback.lastBroadcastFeedback
                 ?.subscriberErrorFeedback?.message ?? "",
             )}
+            footer={getBroadcastFeedbackFooter(conventionWithBroadcastFeedback)}
             buttonsRows={[
               {
                 id: domElementIds.manageConventionConnectedUser
@@ -480,3 +482,17 @@ export const ConventionsWithBroadcastErrorList = ({
     </HeadingSection>
   );
 };
+
+const getBroadcastFeedbackFooter = ({
+  agencyName,
+  agencyReferent,
+}: Pick<
+  ConventionWithBroadcastFeedbackReadDto,
+  "agencyName" | "agencyReferent"
+>) =>
+  agencyReferent
+    ? `Conseiller : ${getFormattedFirstnameAndLastname({
+        firstname: agencyReferent.firstname,
+        lastname: agencyReferent.lastname,
+      })} (${agencyName})`
+    : agencyName;

--- a/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
+++ b/front/src/app/components/agency/agency-dashboard/ConventionsWithBroadcastErrorList.tsx
@@ -274,9 +274,10 @@ export const ConventionsWithBroadcastErrorList = ({
         className={fr.cx("fr-grid-row", "fr-search-bar", "fr-mb-4w")}
       >
         <Input
-          label="Rechercher par ID de convention"
+          label="Rechercher"
           nativeInputProps={{
-            placeholder: "ID de convention",
+            placeholder:
+              "Rechercher une convention (ID, nom, prénom, conseiller, email, SIRET, etc.)",
             role: "search",
             name: "search",
             onChange: (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/HttpConventionGateway.ts
@@ -48,7 +48,7 @@ import {
 import type { FetchConventionRequestedPayload } from "src/core-logic/domain/convention/convention.slice";
 import type { ConventionGateway } from "src/core-logic/ports/ConventionGateway";
 import { match, P } from "ts-pattern";
-import type { ConventionWithBroadcastFeedback } from "../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
+import type { ConventionWithBroadcastFeedbackReadDto } from "../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
 
 export class HttpConventionGateway implements ConventionGateway {
   constructor(
@@ -555,7 +555,7 @@ export class HttpConventionGateway implements ConventionGateway {
   public getConventionsWithErroredBroadcastFeedback$(
     params: FlatGetConventionsWithErroredBroadcastFeedbackParams,
     jwt: string,
-  ): Observable<DataWithPagination<ConventionWithBroadcastFeedback>> {
+  ): Observable<DataWithPagination<ConventionWithBroadcastFeedbackReadDto>> {
     return from(
       this.authenticatedHttpClient
         .getConventionsWithErroredBroadcastFeedbackForAgencyUser({

--- a/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
+++ b/front/src/core-logic/adapters/Convention/InMemoryConventionGateway.ts
@@ -40,7 +40,7 @@ import {
 } from "shared";
 import type { FetchConventionRequestedPayload } from "src/core-logic/domain/convention/convention.slice";
 import type { ConventionGateway } from "src/core-logic/ports/ConventionGateway";
-import type { ConventionWithBroadcastFeedback } from "../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
+import type { ConventionWithBroadcastFeedbackReadDto } from "../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
 
 const CONVENTION_VALIDATED_TEST = new ConventionDtoBuilder()
   .withStatus("ACCEPTED_BY_VALIDATOR")
@@ -105,7 +105,7 @@ export class InMemoryConventionGateway implements ConventionGateway {
     new Subject<ConventionLastBroadcastFeedbackResponse>();
 
   public getConventionsWithErroredBroadcastFeedbackResult$ = new Subject<
-    DataWithPagination<ConventionWithBroadcastFeedback>
+    DataWithPagination<ConventionWithBroadcastFeedbackReadDto>
   >();
 
   public getConventionsWithUnfinalizedAssessmentResult$ = new Subject<
@@ -321,7 +321,7 @@ export class InMemoryConventionGateway implements ConventionGateway {
   public getConventionsWithErroredBroadcastFeedback$(
     _params: Required<PaginationQueryParams>,
     _jwt: string,
-  ): Observable<DataWithPagination<ConventionWithBroadcastFeedback>> {
+  ): Observable<DataWithPagination<ConventionWithBroadcastFeedbackReadDto>> {
     return this.getConventionsWithErroredBroadcastFeedbackResult$;
   }
 

--- a/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.slice.ts
+++ b/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.slice.ts
@@ -8,7 +8,7 @@ import type {
   PayloadActionWithFeedbackTopic,
   PayloadActionWithFeedbackTopicError,
 } from "src/core-logic/domain/feedback/feedback.slice";
-import type { ConventionWithBroadcastFeedback } from "../../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
+import type { ConventionWithBroadcastFeedbackReadDto } from "../../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
 
 export type FetchConventionsWithErroredBroadcastFeedbackRequestedPayload = {
   jwt: string;
@@ -17,12 +17,12 @@ export type FetchConventionsWithErroredBroadcastFeedbackRequestedPayload = {
 
 export type ConventionsWithBroadcastFeedbackState = {
   isLoading: boolean;
-  erroredBroadcastConventionsWithPagination: DataWithPagination<ConventionWithBroadcastFeedback> & {
+  erroredBroadcastConventionsWithPagination: DataWithPagination<ConventionWithBroadcastFeedbackReadDto> & {
     filters: FlatGetConventionsWithErroredBroadcastFeedbackParams;
   };
 };
 
-export const initialConventionsWithPagination: DataWithPagination<ConventionWithBroadcastFeedback> & {
+export const initialConventionsWithPagination: DataWithPagination<ConventionWithBroadcastFeedbackReadDto> & {
   filters: FlatGetConventionsWithErroredBroadcastFeedbackParams;
 } = {
   data: [],
@@ -60,7 +60,7 @@ export const conventionsWithBroadcastFeedbackSlice = createSlice({
     getConventionsWithErroredBroadcastFeedbackSucceeded: (
       state,
       action: PayloadActionWithFeedbackTopic<
-        DataWithPagination<ConventionWithBroadcastFeedback>
+        DataWithPagination<ConventionWithBroadcastFeedbackReadDto>
       >,
     ) => {
       state.isLoading = false;

--- a/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
+++ b/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
@@ -7,7 +7,7 @@ import {
   type TestDependencies,
 } from "src/core-logic/storeConfig/createTestStore";
 import type { ReduxStore } from "src/core-logic/storeConfig/store";
-import type { ConventionWithBroadcastFeedback } from "../../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
+import type { ConventionWithBroadcastFeedbackReadDto } from "../../../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
 
 describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
   let store: ReduxStore;
@@ -24,7 +24,7 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
       totalPages: 1,
       numberPerPage: 10,
     };
-    const conventionsWithBroadcastFeedback: ConventionWithBroadcastFeedback[] =
+    const conventionsWithBroadcastFeedback: ConventionWithBroadcastFeedbackReadDto[] =
       [
         {
           id: "1",
@@ -46,6 +46,8 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
             },
           },
           agencyReferent: null,
+          agencyId: "any-agency-id",
+          agencyName: "Agence de test",
         },
       ];
     expectToEqual(
@@ -151,7 +153,7 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
       totalPages: 1,
       numberPerPage: 10,
     };
-    const conventionsWithBroadcastFeedback: ConventionWithBroadcastFeedback[] =
+    const conventionsWithBroadcastFeedback: ConventionWithBroadcastFeedbackReadDto[] =
       [
         {
           id: "1",
@@ -173,6 +175,8 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
             },
           },
           agencyReferent: null,
+          agencyId: "any-agency-id",
+          agencyName: "Agence de test",
         },
       ];
 

--- a/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
+++ b/front/src/core-logic/domain/connected-user/conventionsWithBroadcastFeedback/conventionsWithBroadcastFeedback.test.ts
@@ -45,6 +45,7 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
               conventionId: "1",
             },
           },
+          agencyReferent: null,
         },
       ];
     expectToEqual(
@@ -171,6 +172,7 @@ describe("ConnectedUserConventionsWithBroadcastFeedback", () => {
               conventionId: "1",
             },
           },
+          agencyReferent: null,
         },
       ];
 

--- a/front/src/core-logic/ports/ConventionGateway.ts
+++ b/front/src/core-logic/ports/ConventionGateway.ts
@@ -34,7 +34,7 @@ import type {
   UpdateConventionStatusRequestDto,
   WithConventionId,
 } from "shared";
-import type { ConventionWithBroadcastFeedback } from "../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
+import type { ConventionWithBroadcastFeedbackReadDto } from "../../../../shared/src/convention/conventionWithBroadcastFeedback.dto";
 import type { FetchConventionRequestedPayload } from "../domain/convention/convention.slice";
 
 export interface ConventionGateway {
@@ -117,7 +117,7 @@ export interface ConventionGateway {
   getConventionsWithErroredBroadcastFeedback$(
     params: FlatGetConventionsWithErroredBroadcastFeedbackParams,
     jwt: string,
-  ): Observable<DataWithPagination<ConventionWithBroadcastFeedback>>;
+  ): Observable<DataWithPagination<ConventionWithBroadcastFeedbackReadDto>>;
   getConventionsWithUnfinalizedAssessment$(
     params: FlatGetConventionsWithUnfinalizedAssessmentParams,
     jwt: string,

--- a/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
@@ -1,3 +1,4 @@
+import type { AgencyId } from "../agency/agency.dto";
 import type { ConventionLastBroadcastFeedbackResponse } from "../broadcast/broadcastFeedback.dto";
 import type {
   PaginationQueryParams,
@@ -18,7 +19,13 @@ export type ConventionWithBroadcastFeedback = {
   beneficiary: WithFirstnameAndLastname;
   lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
   agencyReferent: WithOptionalFirstnameAndLastname | null;
+  agencyId: AgencyId;
 };
+
+export type ConventionWithBroadcastFeedbackReadDto =
+  ConventionWithBroadcastFeedback & {
+    agencyName: string;
+  };
 
 export const functionalBroadcastFeedbackErrorMessage = [
   "Aucun dossier trouvé pour les critères d'identité transmis",

--- a/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.dto.ts
@@ -8,6 +8,7 @@ import {
   type ConventionId,
   type ConventionStatus,
   conventionStatusesAllowedForModification,
+  type WithOptionalFirstnameAndLastname,
 } from "./convention.dto";
 import type { WithFirstnameAndLastname } from "./convention.schema";
 
@@ -16,6 +17,7 @@ export type ConventionWithBroadcastFeedback = {
   status: ConventionStatus;
   beneficiary: WithFirstnameAndLastname;
   lastBroadcastFeedback: ConventionLastBroadcastFeedbackResponse;
+  agencyReferent: WithOptionalFirstnameAndLastname | null;
 };
 
 export const functionalBroadcastFeedbackErrorMessage = [

--- a/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
@@ -11,6 +11,7 @@ import {
   conventionIdSchema,
   statusSchema,
   withFirstnameAndLastnameSchema,
+  withOptionalFirstnameAndLastnameSchema,
 } from "./convention.schema";
 import type {
   BroadcastErrorKind,
@@ -26,6 +27,7 @@ export const conventionWithBroadcastFeedbackSchema: ZodSchemaWithInputMatchingOu
     beneficiary: withFirstnameAndLastnameSchema,
     status: statusSchema,
     lastBroadcastFeedback: broadcastFeedbackSchema,
+    agencyReferent: withOptionalFirstnameAndLastnameSchema.nullable(),
   });
 
 export const paginatedConventionWithBroadcastFeedbackSchema =

--- a/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { agencyIdSchema } from "../agency/agency.schema";
 import { broadcastFeedbackSchema } from "../broadcast/broadcastFeedback.schema";
 import {
   createPaginatedSchema,
@@ -17,6 +18,7 @@ import type {
   BroadcastErrorKind,
   ConventionsWithErroredBroadcastFeedbackFilters,
   ConventionWithBroadcastFeedback,
+  ConventionWithBroadcastFeedbackReadDto,
   FlatGetConventionsWithErroredBroadcastFeedbackParams,
   GetConventionsWithErroredBroadcastFeedbackParams,
 } from "./conventionWithBroadcastFeedback.dto";
@@ -28,10 +30,18 @@ export const conventionWithBroadcastFeedbackSchema: ZodSchemaWithInputMatchingOu
     status: statusSchema,
     lastBroadcastFeedback: broadcastFeedbackSchema,
     agencyReferent: withOptionalFirstnameAndLastnameSchema.nullable(),
+    agencyId: agencyIdSchema,
   });
 
+export const conventionWithBroadcastFeedbackSchemaDto: ZodSchemaWithInputMatchingOutput<ConventionWithBroadcastFeedbackReadDto> =
+  conventionWithBroadcastFeedbackSchema.and(
+    z.object({
+      agencyName: z.string(),
+    }),
+  );
+
 export const paginatedConventionWithBroadcastFeedbackSchema =
-  createPaginatedSchema(conventionWithBroadcastFeedbackSchema);
+  createPaginatedSchema(conventionWithBroadcastFeedbackSchemaDto);
 
 export const broadcastErrorKindSchema: ZodSchemaWithInputMatchingOutput<BroadcastErrorKind> =
   z.enum(["functional", "technical"]);

--- a/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
@@ -38,7 +38,7 @@ export const getConventionsWithErroredBroadcastFeedbackFilterSchema: ZodSchemaWi
   z.object({
     broadcastErrorKind: broadcastErrorKindSchema.optional(),
     conventionStatus: z.tuple([statusSchema], statusSchema).optional(),
-    search: searchTextAlphaNumericSchema.optional(),
+    search: z.string().optional(),
   });
 
 export const flatGetConventionsWithErroredBroadcastFeedbackParamsSchema: ZodSchemaWithInputMatchingOutput<FlatGetConventionsWithErroredBroadcastFeedbackParams> =

--- a/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
+++ b/shared/src/convention/conventionWithBroadcastFeedback.schema.ts
@@ -6,6 +6,7 @@ import {
   paginationRequiredQueryParamsSchema,
 } from "../pagination/pagination.schema";
 import { searchTextAlphaNumericSchema } from "../search/searchText.schema";
+import { zStringCanBeEmpty } from "../utils/string.schema";
 import type { ZodSchemaWithInputMatchingOutput } from "../zodUtils";
 import { zToNumber } from "../zodUtils";
 import {
@@ -50,7 +51,7 @@ export const getConventionsWithErroredBroadcastFeedbackFilterSchema: ZodSchemaWi
   z.object({
     broadcastErrorKind: broadcastErrorKindSchema.optional(),
     conventionStatus: z.tuple([statusSchema], statusSchema).optional(),
-    search: z.string().optional(),
+    search: zStringCanBeEmpty.optional(),
   });
 
 export const flatGetConventionsWithErroredBroadcastFeedbackParamsSchema: ZodSchemaWithInputMatchingOutput<FlatGetConventionsWithErroredBroadcastFeedbackParams> =


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

