### PR TITLE
#5570 - Ne plus afficher dans les conventions à vérifier les conventions annulées, rejetées ou obsolètes jamais créées chez France Travail

### DIFF
--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -35,6 +35,10 @@ import { createLogger } from "../../../utils/logger";
 import type { InMemoryAgencyRepository } from "../../agency/adapters/InMemoryAgencyRepository";
 import type { InMemoryUserRepository } from "../../core/authentication/connected-user/adapters/InMemoryUserRepository";
 import type { InMemoryBroadcastFeedbacksRepository } from "../../core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository";
+import {
+  broadcastToFtServiceName,
+  broadcastToPartnersServiceName,
+} from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type { InMemoryBannedEstablishmentRepository } from "../../establishment/adapters/InMemoryBannedEstablishmentRepository";
 import type { BannedEstablishment } from "../../establishment/ports/BannedEstablishmentRepository";
 import type { AssessmentEntity } from "../entities/AssessmentEntity";
@@ -503,7 +507,10 @@ export class InMemoryConventionQueries implements ConventionQueries {
           this.broadcastFeedbacksRepository.broadcastFeedbacks.some(
             (bf) =>
               bf.requestParams.conventionId === result.id &&
-              !bf.subscriberErrorFeedback,
+              ((bf.serviceName === broadcastToFtServiceName &&
+                bf.response?.httpStatus === 201) ||
+                (bf.serviceName === broadcastToPartnersServiceName &&
+                  !bf.subscriberErrorFeedback)),
           );
         if (
           isUnvalidatedConventionStatus(result.status) &&

--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -36,7 +36,7 @@ import type { InMemoryAgencyRepository } from "../../agency/adapters/InMemoryAge
 import type { InMemoryUserRepository } from "../../core/authentication/connected-user/adapters/InMemoryUserRepository";
 import type { InMemoryBroadcastFeedbacksRepository } from "../../core/saved-errors/adapters/InMemoryBroadcastFeedbacksRepository";
 import {
-  broadcastToFtServiceName,
+  broadcastToFtConsumerName,
   broadcastToPartnersServiceName,
 } from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type { InMemoryBannedEstablishmentRepository } from "../../establishment/adapters/InMemoryBannedEstablishmentRepository";
@@ -507,7 +507,7 @@ export class InMemoryConventionQueries implements ConventionQueries {
           this.broadcastFeedbacksRepository.broadcastFeedbacks.some(
             (bf) =>
               bf.requestParams.conventionId === result.id &&
-              ((bf.serviceName === broadcastToFtServiceName &&
+              ((bf.consumerName === broadcastToFtConsumerName &&
                 bf.response?.httpStatus === 201) ||
                 (bf.serviceName === broadcastToPartnersServiceName &&
                   !bf.subscriberErrorFeedback)),

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -32,6 +32,7 @@ import type { AgencyRepository } from "../../agency/ports/AgencyRepository";
 import { PgUserRepository } from "../../core/authentication/connected-user/adapters/PgUserRepository";
 import { PgBroadcastFeedbacksRepository } from "../../core/saved-errors/adapters/PgBroadcastFeedbacksRepository";
 import {
+  broadcastToFtConsumerName,
   broadcastToFtServiceName,
   broadcastToPartnersServiceName,
 } from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
@@ -2095,7 +2096,7 @@ describe("Pg implementation of ConventionQueries", () => {
       it("includes convention in unvalidated status when a prior FT broadcast has httpStatus 201", async () => {
         const priorSuccessBroadcast: BroadcastFeedback = {
           consumerId: null,
-          consumerName: "any-consumer-name",
+          consumerName: broadcastToFtConsumerName,
           conventionId: cancelledConventionId,
           agencyId: agencyIdA,
           serviceName: broadcastToFtServiceName,

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -31,6 +31,10 @@ import { PgAgencyRepository } from "../../agency/adapters/PgAgencyRepository";
 import type { AgencyRepository } from "../../agency/ports/AgencyRepository";
 import { PgUserRepository } from "../../core/authentication/connected-user/adapters/PgUserRepository";
 import { PgBroadcastFeedbacksRepository } from "../../core/saved-errors/adapters/PgBroadcastFeedbacksRepository";
+import {
+  broadcastToFtServiceName,
+  broadcastToPartnersServiceName,
+} from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import { createInMemoryUow } from "../../core/unit-of-work/adapters/createInMemoryUow";
 import { createAssessmentEntity } from "../entities/AssessmentEntity";
 import type { AssessmentRepository } from "../ports/AssessmentRepository";
@@ -2059,8 +2063,7 @@ describe("Pg implementation of ConventionQueries", () => {
         consumerName: "any-consumer-name",
         conventionId: cancelledConventionId,
         agencyId: agencyIdA,
-        serviceName:
-          "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
+        serviceName: broadcastToFtServiceName,
         occurredAt: "2024-07-01T00:00:00.000Z",
         handledByAgency: false,
         requestParams: {
@@ -2089,14 +2092,13 @@ describe("Pg implementation of ConventionQueries", () => {
         await broadcastFeedbacksRepository.save(errorBroadcast);
       });
 
-      it("includes convention in unvalidated status when a prior broadcast succeeded", async () => {
+      it("includes convention in unvalidated status when a prior FT broadcast has httpStatus 201", async () => {
         const priorSuccessBroadcast: BroadcastFeedback = {
           consumerId: null,
           consumerName: "any-consumer-name",
           conventionId: cancelledConventionId,
           agencyId: agencyIdA,
-          serviceName:
-            "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
+          serviceName: broadcastToFtServiceName,
           occurredAt: "2024-06-01T00:00:00.000Z",
           handledByAgency: false,
           requestParams: {
@@ -2104,7 +2106,7 @@ describe("Pg implementation of ConventionQueries", () => {
             conventionStatus: "CANCELLED",
           },
           response: {
-            httpStatus: 200,
+            httpStatus: 201,
           },
         };
 
@@ -2167,6 +2169,132 @@ describe("Pg implementation of ConventionQueries", () => {
             totalPages: 1,
             numberPerPage: 10,
             totalRecords: 0,
+          },
+        });
+      });
+
+      it("excludes convention in unvalidated status when prior FT broadcast has httpStatus 200", async () => {
+        const priorBroadcastWithHttp200: BroadcastFeedback = {
+          consumerId: null,
+          consumerName: "any-consumer-name",
+          conventionId: cancelledConventionId,
+          agencyId: agencyIdA,
+          serviceName: broadcastToFtServiceName,
+          occurredAt: "2024-06-01T00:00:00.000Z",
+          handledByAgency: false,
+          requestParams: {
+            conventionId: cancelledConventionId,
+            conventionStatus: "CANCELLED",
+          },
+          response: {
+            httpStatus: 200,
+          },
+        };
+
+        await broadcastFeedbacksRepository.save(priorBroadcastWithHttp200);
+
+        const result =
+          await conventionQueries.getConventionsWithErroredBroadcastFeedbackForAgencyUser(
+            {
+              userAgencyIds: [agencyIdA],
+              pagination: { page: 1, perPage: 10 },
+              filters: { broadcastErrorKind: "functional" },
+            },
+          );
+
+        expectToEqual(result, {
+          data: [],
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            numberPerPage: 10,
+            totalRecords: 0,
+          },
+        });
+      });
+
+      it("includes convention in unvalidated status when a prior partner broadcast has no subscriber error", async () => {
+        const partnerErrorBroadcast: BroadcastFeedback = {
+          consumerId: null,
+          consumerName: "partner-consumer",
+          conventionId: cancelledConventionId,
+          agencyId: agencyIdA,
+          serviceName: broadcastToPartnersServiceName,
+          occurredAt: "2024-07-02T00:00:00.000Z",
+          handledByAgency: false,
+          requestParams: {
+            conventionId: cancelledConventionId,
+            conventionStatus: "CANCELLED",
+          },
+          subscriberErrorFeedback: {
+            message:
+              "Aucun dossier trouvé pour les critères d'identité transmis",
+            error: { code: "ANY_FUNCTIONAL_ERROR" },
+          },
+          response: {
+            httpStatus: 500,
+            body: { error: "ANY_FUNCTIONAL_ERROR" },
+          },
+        };
+        const priorPartnerBroadcastWithoutError: BroadcastFeedback = {
+          consumerId: null,
+          consumerName: "partner-consumer",
+          conventionId: cancelledConventionId,
+          agencyId: agencyIdA,
+          serviceName: broadcastToPartnersServiceName,
+          occurredAt: "2024-06-01T00:00:00.000Z",
+          handledByAgency: false,
+          requestParams: {
+            conventionId: cancelledConventionId,
+            conventionStatus: "CANCELLED",
+          },
+          response: {
+            httpStatus: 200,
+          },
+        };
+
+        await broadcastFeedbacksRepository.save(
+          priorPartnerBroadcastWithoutError,
+        );
+        await broadcastFeedbacksRepository.save(partnerErrorBroadcast);
+
+        const result =
+          await conventionQueries.getConventionsWithErroredBroadcastFeedbackForAgencyUser(
+            {
+              userAgencyIds: [agencyIdA],
+              pagination: { page: 1, perPage: 10 },
+              filters: { broadcastErrorKind: "functional" },
+            },
+          );
+
+        expectToEqual(result, {
+          data: [
+            {
+              id: cancelledConvention.id,
+              status: "CANCELLED",
+              beneficiary: {
+                firstname:
+                  cancelledConvention.signatories.beneficiary.firstName,
+                lastname: cancelledConvention.signatories.beneficiary.lastName,
+              },
+              lastBroadcastFeedback: {
+                ...partnerErrorBroadcast,
+                subscriberErrorFeedback: {
+                  message:
+                    partnerErrorBroadcast.subscriberErrorFeedback?.message ??
+                    "",
+                  error: JSON.stringify(
+                    partnerErrorBroadcast.subscriberErrorFeedback?.error,
+                  ),
+                },
+              },
+            },
+          ],
+          pagination: {
+            currentPage: 1,
+            totalPages: 1,
+            numberPerPage: 10,
+            totalRecords: 1,
           },
         });
       });

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -41,6 +41,10 @@ import {
 } from "../../../config/pg/kysely/kyselyUtils";
 import type { Database } from "../../../config/pg/kysely/model/database";
 import { createLogger } from "../../../utils/logger";
+import {
+  broadcastToFtServiceName,
+  broadcastToPartnersServiceName,
+} from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type {
   ConventionQueries,
   GetConventionIdsParams,
@@ -793,7 +797,13 @@ const filterExcludeUnvalidatedConventionsWithoutPriorSuccessfulBroadcast =
               "=",
               eb.ref("cf.conventionId"),
             )
-            .where("bf_ok.subscriber_error_feedback", "is", null),
+            .where(
+              sql<boolean>`(
+                (bf_ok.service_name = ${broadcastToFtServiceName} AND bf_ok.response @> '{"httpStatus": 201}'::jsonb)
+                OR
+                (bf_ok.service_name = ${broadcastToPartnersServiceName} AND bf_ok.subscriber_error_feedback IS NULL)
+              )`,
+            ),
         ),
       ]),
     );

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -42,7 +42,7 @@ import {
 import type { Database } from "../../../config/pg/kysely/model/database";
 import { createLogger } from "../../../utils/logger";
 import {
-  broadcastToFtServiceName,
+  broadcastToFtConsumerName,
   broadcastToPartnersServiceName,
 } from "../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type {
@@ -799,7 +799,7 @@ const filterExcludeUnvalidatedConventionsWithoutPriorSuccessfulBroadcast =
             )
             .where(
               sql<boolean>`(
-                (bf_ok.service_name = ${broadcastToFtServiceName} AND bf_ok.response @> '{"httpStatus": 201}'::jsonb)
+                (bf_ok.consumer_name = ${broadcastToFtConsumerName} AND bf_ok.response @> '{"httpStatus": 201}'::jsonb)
                 OR
                 (bf_ok.service_name = ${broadcastToPartnersServiceName} AND bf_ok.subscriber_error_feedback IS NULL)
               )`,

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.ts
@@ -12,7 +12,10 @@ import {
 import z from "zod";
 import { toPartnerAgencyKind } from "../../../../utils/agency";
 import { isAxiosError } from "../../../../utils/axiosUtils";
-import { broadcastToFtServiceName } from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
+import {
+  broadcastToFtConsumerName,
+  broadcastToFtServiceName,
+} from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import type { TimeGateway } from "../../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../../core/useCaseBuilder";
 import {
@@ -133,7 +136,7 @@ export const makeBroadcastToFranceTravailOnConventionUpdates = useCaseBuilder(
 
     await uow.broadcastFeedbacksRepository.save({
       consumerId: null,
-      consumerName: "France Travail",
+      consumerName: broadcastToFtConsumerName,
       conventionId: inputParams.convention.id,
       agencyId: inputParams.convention.agencyId,
       serviceName: broadcastToFtServiceName,

--- a/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/BroadcastToFranceTravailOnConventionUpdates.unit.test.ts
@@ -19,7 +19,10 @@ import {
   toAgencyWithRights,
   toPartnerAgencyKind,
 } from "../../../../utils/agency";
-import { broadcastToFtServiceName } from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
+import {
+  broadcastToFtConsumerName,
+  broadcastToFtServiceName,
+} from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
 import { CustomTimeGateway } from "../../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
@@ -352,7 +355,7 @@ describe("BroadcastToFranceTravailOnConventionUpdates", () => {
     expectToEqual(uow.broadcastFeedbacksRepository.broadcastFeedbacks, [
       {
         consumerId: null,
-        consumerName: "France Travail",
+        consumerName: broadcastToFtConsumerName,
         conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
         agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,
@@ -395,7 +398,7 @@ describe("BroadcastToFranceTravailOnConventionUpdates", () => {
     expectToEqual(uow.broadcastFeedbacksRepository.broadcastFeedbacks, [
       {
         consumerId: null,
-        consumerName: "France Travail",
+        consumerName: broadcastToFtConsumerName,
         conventionId: conventionLinkedToFTWithoutFederatedIdentity.id,
         agencyId: conventionLinkedToFTWithoutFederatedIdentity.agencyId,
         serviceName: broadcastToFtServiceName,

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -10,6 +10,7 @@ import {
 } from "shared";
 import { toAgencyWithRights } from "../../../../utils/agency";
 import {
+  broadcastToFtConsumerName,
   broadcastToFtServiceName,
   broadcastToPartnersServiceName,
 } from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
@@ -399,7 +400,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
 
     const priorSuccessBroadcast: BroadcastFeedback = {
       consumerId: null,
-      consumerName: "any-consumer-name",
+      consumerName: broadcastToFtConsumerName,
       conventionId: cancelledConventionId,
       agencyId: agencyId1,
       serviceName: broadcastToFtServiceName,

--- a/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
+++ b/back/src/domains/convention/use-cases/broadcast/GetConventionsWithErroredBroadcastFeedback.unit.test.ts
@@ -10,6 +10,10 @@ import {
 } from "shared";
 import { toAgencyWithRights } from "../../../../utils/agency";
 import {
+  broadcastToFtServiceName,
+  broadcastToPartnersServiceName,
+} from "../../../core/saved-errors/ports/BroadcastFeedbacksRepository";
+import {
   createInMemoryUow,
   type InMemoryUnitOfWork,
 } from "../../../core/unit-of-work/adapters/createInMemoryUow";
@@ -376,8 +380,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
       consumerName: "any-consumer-name",
       conventionId: cancelledConventionId,
       agencyId: agencyId1,
-      serviceName:
-        "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
+      serviceName: broadcastToFtServiceName,
       occurredAt: "2024-07-01T14:00:00.000Z",
       handledByAgency: false,
       requestParams: {
@@ -399,8 +402,63 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
       consumerName: "any-consumer-name",
       conventionId: cancelledConventionId,
       agencyId: agencyId1,
-      serviceName:
-        "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated",
+      serviceName: broadcastToFtServiceName,
+      occurredAt: "2024-07-01T08:00:00.000Z",
+      handledByAgency: false,
+      requestParams: {
+        conventionId: cancelledConventionId,
+        conventionStatus: "CANCELLED",
+      },
+      response: {
+        httpStatus: 201,
+      },
+    };
+
+    const priorBroadcastWithHttp200: BroadcastFeedback = {
+      consumerId: null,
+      consumerName: "any-consumer-name",
+      conventionId: cancelledConventionId,
+      agencyId: agencyId1,
+      serviceName: broadcastToFtServiceName,
+      occurredAt: "2024-07-01T08:00:00.000Z",
+      handledByAgency: false,
+      requestParams: {
+        conventionId: cancelledConventionId,
+        conventionStatus: "CANCELLED",
+      },
+      response: {
+        httpStatus: 200,
+      },
+    };
+
+    const partnerErrorBroadcast: BroadcastFeedback = {
+      consumerId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      consumerName: "partner-consumer",
+      conventionId: cancelledConventionId,
+      agencyId: agencyId1,
+      serviceName: broadcastToPartnersServiceName,
+      occurredAt: "2024-07-01T14:00:00.000Z",
+      handledByAgency: false,
+      requestParams: {
+        conventionId: cancelledConventionId,
+        conventionStatus: "CANCELLED",
+      },
+      subscriberErrorFeedback: {
+        message: "Aucun dossier trouvé pour les critères d'identité transmis",
+        error: { code: "ANY_FUNCTIONAL_ERROR" },
+      },
+      response: {
+        httpStatus: 500,
+        body: { error: "ANY_FUNCTIONAL_ERROR" },
+      },
+    };
+
+    const priorPartnerBroadcastWithoutError: BroadcastFeedback = {
+      consumerId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      consumerName: "partner-consumer",
+      conventionId: cancelledConventionId,
+      agencyId: agencyId1,
+      serviceName: broadcastToPartnersServiceName,
       occurredAt: "2024-07-01T08:00:00.000Z",
       handledByAgency: false,
       requestParams: {
@@ -417,7 +475,7 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
       uow.broadcastFeedbacksRepository.broadcastFeedbacks = [errorBroadcast];
     });
 
-    it("includes convention in unvalidated status when a prior broadcast succeeded", async () => {
+    it("includes convention in unvalidated status when a prior FT broadcast has httpStatus 201", async () => {
       uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
         priorSuccessBroadcast,
         errorBroadcast,
@@ -467,6 +525,66 @@ describe("GetConventionsWithErroredBroadcastFeedback", () => {
           totalRecords: 0,
           currentPage: 1,
           totalPages: 0,
+          numberPerPage: 10,
+        },
+      });
+    });
+
+    it("excludes convention in unvalidated status when prior FT broadcast has httpStatus 200", async () => {
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        priorBroadcastWithHttp200,
+        errorBroadcast,
+      ];
+
+      const result = await useCase.execute(
+        {
+          pagination: { page: 1, perPage: 10 },
+          filters: { broadcastErrorKind: "functional" },
+        },
+        user1,
+      );
+
+      expectToEqual(result, {
+        data: [],
+        pagination: {
+          totalRecords: 0,
+          currentPage: 1,
+          totalPages: 0,
+          numberPerPage: 10,
+        },
+      });
+    });
+
+    it("includes convention in unvalidated status when a prior partner broadcast has no subscriber error", async () => {
+      uow.broadcastFeedbacksRepository.broadcastFeedbacks = [
+        priorPartnerBroadcastWithoutError,
+        partnerErrorBroadcast,
+      ];
+
+      const result = await useCase.execute(
+        {
+          pagination: { page: 1, perPage: 10 },
+          filters: { broadcastErrorKind: "functional" },
+        },
+        user1,
+      );
+
+      expectToEqual(result, {
+        data: [
+          {
+            id: cancelledConventionId,
+            status: "CANCELLED",
+            beneficiary: {
+              firstname: cancelledConvention.signatories.beneficiary.firstName,
+              lastname: cancelledConvention.signatories.beneficiary.lastName,
+            },
+            lastBroadcastFeedback: partnerErrorBroadcast,
+          },
+        ],
+        pagination: {
+          totalRecords: 1,
+          currentPage: 1,
+          totalPages: 1,
           numberPerPage: 10,
         },
       });

--- a/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
+++ b/back/src/domains/core/saved-errors/ports/BroadcastFeedbacksRepository.ts
@@ -10,6 +10,8 @@ export const broadcastToPartnersServiceName =
 export const broadcastToFtServiceName =
   "FranceTravailGateway.notifyOnConventionUpdatedOrAssessmentCreated";
 
+export const broadcastToFtConsumerName = "France Travail";
+
 export interface BroadcastFeedbacksRepository {
   save: (broadcastFeedback: BroadcastFeedback) => Promise<void>;
   markPartnersErroredConventionAsHandled: (id: ConventionId) => Promise<void>;


### PR DESCRIPTION
Fixes #5570

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

