### PR TITLE
#5456 - Supprimer deleteoldclosedagencieswithoutconventions du repo d'agence & ajout date de mise à jour d'agence dans la data agence

### DIFF
--- a/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
+++ b/back/src/adapters/primary/routers/admin/adminRouter.e2e.test.ts
@@ -440,7 +440,7 @@ describe("Admin router", () => {
         .withId("two-steps-validation-agency")
         .build();
 
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validatorInAgency.id]: {
             roles: ["validator"],
@@ -452,7 +452,8 @@ describe("Admin router", () => {
           },
           [toReviewUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
         }),
-      );
+      ];
+
       inMemoryUow.userRepository.users = [
         toReviewUser,
         validatorInAgency,
@@ -479,17 +480,23 @@ describe("Admin router", () => {
       });
 
       expectToEqual(inMemoryUow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [validatorInAgency.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: true,
+        toAgencyWithRights(
+          { ...agency, updatedAt: gateways.timeGateway.now().toISOString() },
+          {
+            [validatorInAgency.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: true,
+            },
+            [counsellorInAgency.id]: {
+              isNotifiedByEmail: false,
+              roles: ["counsellor"],
+            },
+            [toReviewUser.id]: {
+              roles: [updatedRole],
+              isNotifiedByEmail: true,
+            },
           },
-          [counsellorInAgency.id]: {
-            isNotifiedByEmail: false,
-            roles: ["counsellor"],
-          },
-          [toReviewUser.id]: { roles: [updatedRole], isNotifiedByEmail: true },
-        }),
+        ),
       ]);
     });
 
@@ -510,7 +517,7 @@ describe("Admin router", () => {
       ];
 
       const agencyWithOneStep = new AgencyDtoBuilder().build();
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agencyWithOneStep, {
           [validatorInAgency.id]: {
             roles: ["validator"],
@@ -518,7 +525,7 @@ describe("Admin router", () => {
           },
           [toReviewUser.id]: { roles: ["to-review"], isNotifiedByEmail: true },
         }),
-      );
+      ];
 
       const updatedRole: AgencyRole = "counsellor";
 
@@ -656,9 +663,12 @@ describe("Admin router", () => {
       });
 
       expectObjectsToMatch(inMemoryUow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          validator: { roles: ["validator"], isNotifiedByEmail: true },
-        }),
+        toAgencyWithRights(
+          { ...agency, updatedAt: gateways.timeGateway.now().toISOString() },
+          {
+            validator: { roles: ["validator"], isNotifiedByEmail: true },
+          },
+        ),
       ]);
 
       await processEventsForEmailToBeSent(eventCrawler);

--- a/back/src/adapters/primary/routers/agencies/agencies.e2e.test.ts
+++ b/back/src/adapters/primary/routers/agencies/agencies.e2e.test.ts
@@ -256,6 +256,7 @@ describe("Agency routes", () => {
           toAgencyWithRights(
             {
               ...parisMissionLocaleParamsWithoutRefersToAgencyId,
+              updatedAt: gateways.timeGateway.now().toISOString(),
               status: "needsReview",
               refersToAgencyId: null,
               codeSafir: null,
@@ -336,12 +337,17 @@ describe("Agency routes", () => {
 
         expectToEqual(inMemoryUow.userRepository.users, [agencyFtUser]);
         expectToEqual(inMemoryUow.agencyRepository.agencies, [
-          toAgencyWithRights(agencyFt, {
-            [agencyFtUser.id]: {
-              isNotifiedByEmail: false,
-              roles: ["to-review"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agencyFt)
+              .withUpdatedAt(gateways.timeGateway.now())
+              .build(),
+            {
+              [agencyFtUser.id]: {
+                isNotifiedByEmail: false,
+                roles: ["to-review"],
+              },
             },
-          }),
+          ),
         ]);
       });
 
@@ -737,6 +743,7 @@ describe("Agency routes", () => {
               .withId(agency4NeedsReview.id)
               .withStatus("needsReview")
               .withCodeSafir("1234")
+              .withUpdatedAt(gateways.timeGateway.now())
               .build(),
             {
               [validator.id]: {

--- a/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
+++ b/back/src/adapters/primary/routers/auth/auth.e2e.test.ts
@@ -292,9 +292,12 @@ describe("auth router", () => {
         const userId = user!.id;
 
         expectToEqual(inMemoryUow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [userId]: { roles: ["validator"], isNotifiedByEmail: false },
-          }),
+          toAgencyWithRights(
+            { ...agency, updatedAt: gateways.timeGateway.now().toISOString() },
+            {
+              [userId]: { roles: ["validator"], isNotifiedByEmail: false },
+            },
+          ),
         ]);
       });
     });

--- a/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
+++ b/back/src/adapters/primary/routers/convention/authenticatedConventionRoutes.e2e.test.ts
@@ -253,11 +253,11 @@ describe("authenticatedConventionRoutes", () => {
     it("save the event to Broadcast Convention again, than it event triggers calling partners", async () => {
       const convention = new ConventionDtoBuilder().build();
       inMemoryUow.conventionRepository.setConventions([convention]);
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
 
       const response = await httpClient.broadcastConventionAgain({
         headers: { authorization: validToken },

--- a/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
+++ b/back/src/adapters/primary/routers/magicLink/assessment.e2e.test.ts
@@ -87,11 +87,12 @@ describe("Assessment routes", () => {
     );
 
     inMemoryUow.conventionRepository.setConventions([convention]);
-    inMemoryUow.agencyRepository.insert(
+    inMemoryUow.agencyRepository.agencies = [
       toAgencyWithRights(agency, {
         [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
       }),
-    );
+    ];
+
     inMemoryUow.userRepository.users = [validator, backofficeAdminUser];
   });
 

--- a/back/src/adapters/primary/routers/magicLink/conventionMagicLink.e2e.test.ts
+++ b/back/src/adapters/primary/routers/magicLink/conventionMagicLink.e2e.test.ts
@@ -801,11 +801,11 @@ describe("Magic link router", () => {
     it("403 when non-admin sends beneficiary update", async () => {
       inMemoryUow.conventionRepository.setConventions([convention]);
       inMemoryUow.userRepository.users = [validator];
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
 
       const response = await httpClient.editConventionWithFinalStatus({
         headers: { authorization: validatorToken() },
@@ -860,11 +860,11 @@ describe("Magic link router", () => {
         .build();
       inMemoryUow.conventionRepository.setConventions([conventionInReview]);
       inMemoryUow.userRepository.users = [adminUser];
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
 
       const response = await httpClient.editConventionWithFinalStatus({
         headers: {
@@ -934,11 +934,11 @@ describe("Magic link router", () => {
     it("200 updates establishment tutor when validator has agency rights", async () => {
       inMemoryUow.conventionRepository.setConventions([convention]);
       inMemoryUow.userRepository.users = [validator];
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
 
       const response = await httpClient.editConventionWithFinalStatus({
         headers: { authorization: validatorToken() },
@@ -963,11 +963,11 @@ describe("Magic link router", () => {
     it("200 updates beneficiary and saves ConventionWithFinalStatusEdited event", async () => {
       inMemoryUow.conventionRepository.setConventions([convention]);
       inMemoryUow.userRepository.users = [adminUser];
-      inMemoryUow.agencyRepository.insert(
+      inMemoryUow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [adminUser.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
 
       const adminToken = generateConnectedUserJwt({
         userId: adminUser.id,

--- a/back/src/config/bootstrap/createUseCases.ts
+++ b/back/src/config/bootstrap/createUseCases.ts
@@ -213,8 +213,10 @@ export const createUseCases = ({
     verifyEmailAuthCodeJwt,
   },
 }: CreateUsecasesParams) => {
+  const timeGateway = gateways.timeGateway;
+
   const createNewEvent = makeCreateNewEvent({
-    timeGateway: gateways.timeGateway,
+    timeGateway,
     uuidGenerator,
     quarantinedTopics: config.quarantinedTopics,
   });
@@ -238,7 +240,7 @@ export const createUseCases = ({
         addressGateway: gateways.addressApi,
         createNewEvent,
         siretGateway: gateways.siret,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         uuidGenerator,
       },
     });
@@ -266,7 +268,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         franceTravailGateway: gateways.franceTravailGateway,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         options: { resyncMode: false },
       },
     });
@@ -278,7 +280,7 @@ export const createUseCases = ({
       deps: {
         createNewEvent,
         notificationGateway: gateways.notification,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -287,7 +289,7 @@ export const createUseCases = ({
         uowPerformer,
         deps: {
           createNewEvent,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     deleteSubscription: makeDeleteSubscription({ uowPerformer }),
@@ -301,21 +303,21 @@ export const createUseCases = ({
     getConvention: makeGetConvention({ uowPerformer }),
     getBeneficiaryConventionList: makeGetBeneficiaryConventionList({
       uowPerformer,
-      deps: { timeGateway: gateways.timeGateway },
+      deps: { timeGateway },
     }),
 
     saveConventionDraft: makeSaveConventionDraft({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     createArchivedConventionRequest: makeCreateArchivedConventionRequest({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     fetchArchivedConventionRequestToReviewList:
@@ -335,7 +337,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -347,14 +349,14 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     updateConventionStatus: makeUpdateConventionStatus({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -427,7 +429,7 @@ export const createUseCases = ({
         deps: {
           addressGateway: gateways.addressApi,
           uuidGenerator,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           createNewEvent,
           immersionBaseUrl: config.immersionFacileBaseUrl,
           saveNotificationAndRelatedEvent,
@@ -436,7 +438,7 @@ export const createUseCases = ({
       }),
     addEstablishmentLead: makeAddEstablishmentLead({
       uowPerformer,
-      deps: { timeGateway: gateways.timeGateway },
+      deps: { timeGateway },
     }),
 
     // notifications
@@ -476,14 +478,14 @@ export const createUseCases = ({
       deps: {
         saveNotificationAndRelatedEvent,
         immersionBaseUrl: config.immersionFacileBaseUrl,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     addExchangeToDiscussion: makeAddExchangeToDiscussion({
       deps: {
         createNewEvent,
         saveNotificationAndRelatedEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         immersionFacileBaseUrl: config.immersionFacileBaseUrl,
       },
       uowPerformer,
@@ -493,21 +495,21 @@ export const createUseCases = ({
       makeMarkEstablishmentLeadAsRegistrationAccepted({
         uowPerformer,
         deps: {
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     markEstablishmentLeadAsRegistrationRejected:
       makeMarkEstablishmentLeadAsRegistrationRejected({
         uowPerformer,
         deps: {
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
 
     deleteEstablishment: makeDeleteEstablishment({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         saveNotificationAndRelatedEvent,
         createNewEvent,
       },
@@ -521,7 +523,7 @@ export const createUseCases = ({
     registerUserOnEstablishment: makeRegisterUserOnEstablishment({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         createNewEvent,
       },
     }),
@@ -549,7 +551,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -558,7 +560,7 @@ export const createUseCases = ({
       deps: {
         createNewEvent,
         generateApiConsumerJwt,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -588,7 +590,7 @@ export const createUseCases = ({
     getLink: makeGetLink({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -704,7 +706,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         uuidGenerator,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         addressGateway: gateways.addressApi,
       },
     }),
@@ -713,6 +715,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
+        timeGateway,
       },
     }),
 
@@ -720,6 +723,7 @@ export const createUseCases = ({
       makeLinkFranceTravailUsersToTheirAgencies({
         uowPerformer,
         deps: {
+          timeGateway,
           createNewEvent,
         },
       }),
@@ -728,7 +732,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         dashboardGateway: gateways.dashboardGateway,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
 
@@ -738,7 +742,7 @@ export const createUseCases = ({
 
     deleteUser: makeDeleteUser({
       uowPerformer,
-      deps: { timeGateway: gateways.timeGateway, createNewEvent },
+      deps: { timeGateway, createNewEvent },
     }),
 
     getLastBroadcastFeedback: makeGetLastBroadcastFeedback({
@@ -754,18 +758,20 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
+        timeGateway,
       },
     }),
 
     closeAgencyAndTransfertConventions: makeCloseAgencyAndTransferConventions({
       uowPerformer,
-      deps: { createNewEvent },
+      deps: { createNewEvent, timeGateway },
     }),
 
     updateAgencyReferringToUpdatedAgency:
       makeUpdateAgencyReferringToUpdatedAgency({
         uowPerformer,
         deps: {
+          timeGateway,
           createNewEvent,
         },
       }),
@@ -774,6 +780,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
+        timeGateway,
       },
     }),
 
@@ -788,7 +795,7 @@ export const createUseCases = ({
       deps: {
         createNewEvent,
         siretGateway: gateways.siret,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         uuidGenerator,
       },
     }),
@@ -797,6 +804,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
+        timeGateway,
       },
     }),
 
@@ -819,7 +827,7 @@ export const createUseCases = ({
         uowPerformer,
         deps: {
           subscribersGateway: gateways.subscribersGateway,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           consumerNamesUsingRomeV3: config.apiConsumerNamesUsingRomeV3,
         },
       }),
@@ -829,7 +837,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateLink: generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     getAgencyById: makeGetAgencyById({
@@ -839,7 +847,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         config,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
         generateConnectedUserLoginUrl,
         generateConventionMagicLinkUrl,
@@ -868,7 +876,7 @@ export const createUseCases = ({
         generateConnectedUserLoginUrl,
         verifyEmailAuthCodeJwt,
         immersionFacileBaseUrl: config.immersionFacileBaseUrl,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     getOAuthLogoutUrl: makeGetOAuthLogoutUrl({
@@ -891,7 +899,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         createNewEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     getAssessmentByConventionId: makeGetAssessmentByConventionId({
@@ -903,7 +911,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     notifyBeneficiaryThatAssessmentNeedsSignature:
@@ -912,7 +920,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
           config,
         },
@@ -922,7 +930,7 @@ export const createUseCases = ({
       deps: {
         saveNotificationAndRelatedEvent,
         generateConventionMagicLinkUrl,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
         config,
       },
@@ -933,7 +941,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
           config,
         },
@@ -944,18 +952,18 @@ export const createUseCases = ({
     createUserForAgency: makeCreateUserForAgency({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         createNewEvent,
         dashboardGateway: gateways.dashboardGateway,
       },
     }),
     removeUserFromAgency: makeRemoveUserFromAgency({
       uowPerformer,
-      deps: { createNewEvent },
+      deps: { createNewEvent, timeGateway },
     }),
     broadcastConventionAgain: makeBroadcastConventionAgain({
       uowPerformer,
-      deps: { createNewEvent, timeGateway: gateways.timeGateway },
+      deps: { createNewEvent, timeGateway },
     }),
     getApiConsumersByConvention: makeGetApiConsumersByConvention({
       uowPerformer,
@@ -963,14 +971,14 @@ export const createUseCases = ({
     markDiscussionLinkedToConvention: makeMarkDiscussionLinkedToConvention({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     contactRequestReminder: makeContactRequestReminder({
       deps: {
         domain: config.immersionFacileDomain,
         saveNotificationAndRelatedEvent,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
       uowPerformer,
     }),
@@ -989,7 +997,7 @@ export const createUseCases = ({
     updateDiscussionStatus: makeUpdateDiscussionStatus({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         createNewEvent,
       },
     }),
@@ -997,7 +1005,7 @@ export const createUseCases = ({
       makeUpdateMarketingEstablishmentContactList({
         deps: {
           establishmentMarketingGateway: gateways.establishmentMarketingGateway,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           siretGateway: gateways.siret,
         },
         uowPerformer,
@@ -1025,7 +1033,7 @@ export const createUseCases = ({
         createNewEvent,
         uuidGenerator,
         immersionFacileBaseUrl: config.immersionFacileBaseUrl,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         minimumNumberOfDaysBetweenSimilarContactRequests:
           config.minimumNumberOfDaysBetweenSimilarContactRequests,
       },
@@ -1048,7 +1056,7 @@ export const createUseCases = ({
     sendSignatureLink: makeSendSignatureLink({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         config,
         saveNotificationAndRelatedEvent,
         generateConventionMagicLinkUrl,
@@ -1059,7 +1067,7 @@ export const createUseCases = ({
     sendAssessmentLink: makeSendAssessmentLink({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         config,
         saveNotificationAndRelatedEvent,
         generateConventionMagicLinkUrl,
@@ -1070,7 +1078,7 @@ export const createUseCases = ({
     sendAssessmentSignatureReminder: makeSendAssessmentSignatureReminder({
       uowPerformer,
       deps: {
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         config,
         saveNotificationAndRelatedEvent,
         generateConventionMagicLinkUrl,
@@ -1080,12 +1088,12 @@ export const createUseCases = ({
     }),
     getConventionsForAgencyUser: makeGetConventionsForAgencyUser({
       uowPerformer,
-      deps: { timeGateway: gateways.timeGateway },
+      deps: { timeGateway },
     }),
     getConventionsWithUnfinalizedAssessment:
       makeGetConventionsWithUnfinalizedAssessment({
         uowPerformer,
-        deps: { timeGateway: gateways.timeGateway },
+        deps: { timeGateway },
       }),
     transferConventionToAgency: makeTransferConventionToAgency({
       uowPerformer,
@@ -1105,7 +1113,7 @@ export const createUseCases = ({
     }),
     createOrUpdateConventionTemplate: makeCreateOrUpdateConventionTemplate({
       uowPerformer,
-      deps: { timeGateway: gateways.timeGateway, createNewEvent },
+      deps: { timeGateway, createNewEvent },
     }),
     deleteConventionTemplate: makeDeleteConventionTemplate({
       uowPerformer,
@@ -1122,7 +1130,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         config,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
         uuidGenerator,
         saveNotificationAndRelatedEvent,
         generateEmailAuthCodeUrl,
@@ -1136,7 +1144,7 @@ export const createUseCases = ({
       deps: {
         saveNotificationsBatchAndRelatedEvent,
         config,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     notifyBeneficiaryToFollowUpContactRequest:
@@ -1149,7 +1157,7 @@ export const createUseCases = ({
     makeRequestOldConventionDraftsDeletion:
       makeRequestOldConventionDraftsDeletion({
         uowPerformer,
-        deps: { createNewEvent, timeGateway: gateways.timeGateway },
+        deps: { createNewEvent, timeGateway },
       }),
     updateInvalidPhone: makeUpdateInvalidPhone({
       uowPerformer,
@@ -1181,7 +1189,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
           config,
           shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
         },
@@ -1223,7 +1231,7 @@ export const createUseCases = ({
         generateConventionMagicLinkUrl,
         saveNotificationsBatchAndRelatedEvent,
         shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     notifyLastSigneeThatConventionHasBeenSigned:
@@ -1232,7 +1240,7 @@ export const createUseCases = ({
         deps: {
           saveNotificationAndRelatedEvent,
           generateConventionMagicLinkUrl,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     notifyNewConventionNeedsReview: makeNotifyNewConventionNeedsReview({
@@ -1250,7 +1258,7 @@ export const createUseCases = ({
           generateConventionMagicLinkUrl,
           saveNotificationAndRelatedEvent,
           shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
-          timeGateway: gateways.timeGateway,
+          timeGateway,
         },
       }),
     notifySignatoriesThatConventionSubmittedNeedsSignatureAfterNotification:
@@ -1258,7 +1266,7 @@ export const createUseCases = ({
         {
           uowPerformer,
           deps: {
-            timeGateway: gateways.timeGateway,
+            timeGateway,
             shortLinkIdGeneratorGateway: gateways.shortLinkGenerator,
             config,
             saveNotificationAndRelatedEvent,
@@ -1304,7 +1312,7 @@ export const createUseCases = ({
       uowPerformer,
       deps: {
         uuidGenerator,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
     saveApiConsumer: makeSaveApiConsumer({
@@ -1312,7 +1320,7 @@ export const createUseCases = ({
       deps: {
         createNewEvent,
         generateApiConsumerJwt,
-        timeGateway: gateways.timeGateway,
+        timeGateway,
       },
     }),
   } satisfies Record<string, InstantiatedUseCase<any, any, any>>;

--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -1,5 +1,5 @@
 import { isSameDay, parseISO } from "date-fns";
-import { keys, toPairs, uniq, values } from "ramda";
+import { keys, partition, toPairs, uniq, values } from "ramda";
 import {
   type AgencyId,
   type AgencyKind,
@@ -83,6 +83,26 @@ export class InMemoryAgencyRepository implements AgencyRepository {
     if (agency.usersRights !== undefined)
       throwIfAgencyHasNoUsersWhileNotClosedOrRejected(updatedAgency);
     this.#agencies[agency.id] = updatedAgency;
+  }
+
+  public async deleteByIds(ids: AgencyId[]): Promise<AgencyId[]> {
+    const [deleted, toKeep] = partition(
+      (agency) => ids.includes(agency.id),
+      values(this.#agencies).filter(isTruthy),
+    );
+
+    const deletedIds = deleted.map((agency) => agency.id);
+
+    const [presentAgencyIds, missingAgencyIds] = partition(
+      (idToDelete) => deletedIds.includes(idToDelete),
+      ids,
+    );
+
+    if (missingAgencyIds.length)
+      throw errors.agencies.notFound({ missingAgencyIds, presentAgencyIds });
+
+    this.agencies = toKeep;
+    return deletedIds;
   }
 
   public async getById(
@@ -183,12 +203,19 @@ export class InMemoryAgencyRepository implements AgencyRepository {
   public async getAgencyIdsByFilters(
     filters: GetAgencyIdsFilters,
   ): Promise<AgencyId[]> {
+    const { kinds, statuses, updateDate, ...rest } = filters;
+    rest satisfies Record<string, never>;
+
     return Object.values(this.#agencies)
       .filter(isTruthy)
       .filter(
         (agency) =>
-          agencyIsOfKind(agency, filters.kinds) &&
-          agencyIsOfStatus(agency, filters.statuses),
+          ![
+            agencyIsOfKind(agency, kinds),
+            agencyIsOfStatus(agency, statuses),
+            agencyUpdatedAtBefore(agency, updateDate?.to),
+            agencyUpdatedAtAfter(agency, updateDate?.from),
+          ].includes(false),
       )
       .map(({ id }) => id)
       .sort((a, b) => a.localeCompare(b));
@@ -284,12 +311,6 @@ export class InMemoryAgencyRepository implements AgencyRepository {
           sirets.includes(agency.agencySiret),
       )
       .map((agency) => agency.agencySiret);
-  }
-
-  public async deleteOldClosedAgenciesWithoutConventions(_params: {
-    updatedBefore: Date;
-  }): Promise<AgencyId[]> {
-    throw errors.generic.fakeError("Not implemented");
   }
 }
 
@@ -388,6 +409,18 @@ const agencyCreatedAtBefore = (
   if (createdAtBefore === undefined) return true;
   return new Date(agency.createdAt) <= createdAtBefore;
 };
+
+const agencyUpdatedAtBefore = (
+  agency: AgencyWithUsersRights,
+  updatedAtBefore: Date | undefined,
+): boolean =>
+  updatedAtBefore ? new Date(agency.updatedAt) <= updatedAtBefore : true;
+
+const agencyUpdatedAtAfter = (
+  agency: AgencyWithUsersRights,
+  updatedAtAfter: Date | undefined,
+): boolean =>
+  updatedAtAfter ? new Date(agency.updatedAt) >= updatedAtAfter : true;
 
 const agencyDelegationConventionEndsOnDate = (
   agency: AgencyWithUsersRights,

--- a/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/InMemoryAgencyRepository.ts
@@ -67,10 +67,7 @@ export class InMemoryAgencyRepository implements AgencyRepository {
     );
   }
 
-  public async insert(
-    agency: AgencyWithUsersRights,
-    _updatedAt?: DateString,
-  ): Promise<void> {
+  public async insert(agency: AgencyWithUsersRights): Promise<void> {
     if (this.#agencies[agency.id]) throw errors.agency.alreadyExist(agency.id);
     throwIfAgencyHasNoUsersWhileNotClosedOrRejected(agency);
     this.#agencies[agency.id] = agency;
@@ -440,6 +437,7 @@ const agency3: AgencyWithUsersRights = {
   statusJustification: null,
   phoneNumber: "+33600000003",
   createdAt: defaultCreatedAt,
+  updatedAt: defaultCreatedAt,
   delegationAgencyInfo: null,
 };
 
@@ -474,6 +472,7 @@ const agency1: AgencyWithUsersRights = {
   statusJustification: null,
   phoneNumber: "+33600000001",
   createdAt: defaultCreatedAt,
+  updatedAt: defaultCreatedAt,
   delegationAgencyInfo: null,
 };
 
@@ -509,6 +508,7 @@ const testAgencies: AgencyWithUsersRights[] = [
     statusJustification: null,
     phoneNumber: "+33600000000",
     createdAt: defaultCreatedAt,
+    updatedAt: defaultCreatedAt,
     delegationAgencyInfo: null,
   },
   agency1,
@@ -545,6 +545,7 @@ const testAgencies: AgencyWithUsersRights[] = [
     codeSafir: null,
     phoneNumber: "+33600000002",
     createdAt: defaultCreatedAt,
+    updatedAt: defaultCreatedAt,
     delegationAgencyInfo: null,
   },
   agency3,
@@ -579,6 +580,7 @@ const testAgencies: AgencyWithUsersRights[] = [
     codeSafir: null,
     phoneNumber: "+33600000004",
     createdAt: defaultCreatedAt,
+    updatedAt: defaultCreatedAt,
     delegationAgencyInfo: {
       delegationEndDate: new Date("2029-01-01").toISOString(),
       delegationAgencyName: "Delegation Agency 1",
@@ -616,6 +618,7 @@ const testAgencies: AgencyWithUsersRights[] = [
     codeSafir: null,
     phoneNumber: "+33600000005",
     createdAt: defaultCreatedAt,
+    updatedAt: defaultCreatedAt,
     delegationAgencyInfo: {
       delegationEndDate: new Date("2028-01-01").toISOString(),
       delegationAgencyName: "Delegation Agency 2",

--- a/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
@@ -1,11 +1,10 @@
-import { subDays, subMonths } from "date-fns";
+import { addMilliseconds, subDays, subMilliseconds } from "date-fns";
 import type { Pool } from "pg";
 import {
   AgencyDtoBuilder,
   type AgencyWithUsersRights,
   activeAgencyStatuses,
   ConnectedUserBuilder,
-  ConventionDtoBuilder,
   type DelegationAgencyInfo,
   errors,
   expectArraysToEqualIgnoringOrder,
@@ -21,8 +20,6 @@ import {
 } from "../../../config/pg/kysely/kyselyUtils";
 import { makeTestPgPool } from "../../../config/pg/pgPool";
 import { toAgencyWithRights } from "../../../utils/agency";
-import { InMemoryConventionRepository } from "../../convention/adapters/InMemoryConventionRepository";
-import { PgConventionRepository } from "../../convention/adapters/PgConventionRepository";
 import { InMemoryUserRepository } from "../../core/authentication/connected-user/adapters/InMemoryUserRepository";
 import { PgUserRepository } from "../../core/authentication/connected-user/adapters/PgUserRepository";
 import { InMemoryPhoneRepository } from "../../core/phone-number/adapters/InMemoryPhoneRepository";
@@ -567,6 +564,43 @@ describe.each(
     });
   });
 
+  describe("deleteByIds", () => {
+    const agency1 = toAgencyWithRights(agency1builder.build(), {
+      [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
+    });
+    const agency2 = toAgencyWithRights(agency2builder.build(), {
+      [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
+    });
+
+    it("delete agencies if exist by ids", async () => {
+      await agencyRepository.insert(agency1);
+      await agencyRepository.insert(agency2);
+
+      expectToEqual((await agencyRepository.getAgencies({})).data, [
+        agency1,
+        agency2,
+      ]);
+
+      await agencyRepository.deleteByIds([agency1.id, agency2.id]);
+
+      expectToEqual((await agencyRepository.getAgencies({})).data, []);
+    });
+
+    it("throws on missing agency", async () => {
+      await agencyRepository.insert(agency1);
+
+      expectToEqual((await agencyRepository.getAgencies({})).data, [agency1]);
+
+      await expectPromiseToFailWithError(
+        agencyRepository.deleteByIds([agency1.id, agency2.id]),
+        errors.agencies.notFound({
+          missingAgencyIds: [agency2.id],
+          presentAgencyIds: [agency1.id],
+        }),
+      );
+    });
+  });
+
   describe("getById()", () => {
     const agency1 = toAgencyWithRights(agency1builder.build(), {
       [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
@@ -630,6 +664,7 @@ describe.each(
       expect(retrievedAgency?.delegationAgencyInfo).toEqual(delegationInfo);
     });
   });
+
   describe("getAllAgenciesWithUsersToReview()", () => {
     const agency1 = toAgencyWithRights(agency1builder.build(), {
       [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
@@ -682,6 +717,7 @@ describe.each(
       );
     });
   });
+
   describe("getBySafirAndActiveStatus()", () => {
     const agency1WithSafir = toAgencyWithRights(
       agency1builder.withCodeSafir(safirCode).build(),
@@ -1619,9 +1655,11 @@ describe.each(
   });
 
   describe("getAgencyIdsByFilters", () => {
+    const updateDate = new Date();
     const agencyPeActive = toAgencyWithRights(
       agency1builder
         .withId("00000000-0000-0000-0000-000000000001")
+        .withUpdatedAt(updateDate)
         .withAgencySiret("00000000000001")
         .withKind("france-travail")
         .withStatus("active")
@@ -1633,6 +1671,7 @@ describe.each(
     const agencyPeClosed = toAgencyWithRights(
       agency1builder
         .withId("00000000-0000-0000-0000-000000000002")
+        .withUpdatedAt(updateDate)
         .withAgencySiret("00000000000002")
         .withKind("france-travail")
         .withStatus("closed")
@@ -1643,7 +1682,11 @@ describe.each(
       },
     );
     const agencyMissionLocale = toAgencyWithRights(
-      agency2builder.withKind("mission-locale").withStatus("active").build(),
+      agency2builder
+        .withKind("mission-locale")
+        .withUpdatedAt(updateDate)
+        .withStatus("active")
+        .build(),
       {
         [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
       },
@@ -1690,6 +1733,38 @@ describe.each(
         }),
         [agencyPeActive.id, agencyMissionLocale.id],
       );
+    });
+
+    describe("updateDate filters", () => {
+      it("updateDate from", async () => {
+        expectToEqual(
+          await agencyRepository.getAgencyIdsByFilters({
+            updateDate: { from: updateDate },
+          }),
+          [agencyPeActive.id, agencyPeClosed.id, agencyMissionLocale.id],
+        );
+        expectToEqual(
+          await agencyRepository.getAgencyIdsByFilters({
+            updateDate: { from: addMilliseconds(updateDate, 1) },
+          }),
+          [],
+        );
+      });
+
+      it("updateDate to", async () => {
+        expectToEqual(
+          await agencyRepository.getAgencyIdsByFilters({
+            updateDate: { to: subMilliseconds(updateDate, 1) },
+          }),
+          [],
+        );
+        expectToEqual(
+          await agencyRepository.getAgencyIdsByFilters({
+            updateDate: { to: updateDate },
+          }),
+          [agencyPeActive.id, agencyPeClosed.id, agencyMissionLocale.id],
+        );
+      });
     });
 
     it("filters by kinds and statuses", async () => {
@@ -2007,264 +2082,5 @@ describe.each(
         await agencyRepository.getExistingActiveSirets(sirets);
       expect(existingSirets).toEqual([activeAgency.agencySiret]);
     });
-  });
-
-  describe("deleteOldAgenciesWithoutConventions", () => {
-    const threeMonthsAgo = subMonths(new Date(), 3);
-    const oldDate = subMonths(new Date(), 4).toISOString();
-    const recentDate = subDays(new Date(), 5).toISOString();
-
-    let conventionRepository:
-      | PgConventionRepository
-      | InMemoryConventionRepository;
-
-    beforeEach(() => {
-      conventionRepository =
-        adapterKind === "pg"
-          ? new PgConventionRepository(db)
-          : new InMemoryConventionRepository();
-    });
-
-    const closedAgency1 = toAgencyWithRights(
-      new AgencyDtoBuilder()
-        .withId("11111111-1111-4111-9111-111111111111")
-        .withStatus("closed")
-        .build(),
-      {
-        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-      },
-    );
-
-    const rejectedAgency = toAgencyWithRights(
-      new AgencyDtoBuilder()
-        .withId("22222222-2222-4222-9222-222222222222")
-        .withStatus("rejected")
-        .build(),
-      {
-        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-      },
-    );
-
-    const closedAgency2 = toAgencyWithRights(
-      new AgencyDtoBuilder()
-        .withId("33333333-3333-4333-9333-333333333333")
-        .withStatus("closed")
-        .build(),
-      {
-        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-      },
-    );
-
-    const activeAgency = toAgencyWithRights(
-      new AgencyDtoBuilder()
-        .withId("44444444-4444-4444-9444-444444444444")
-        .withStatus("active")
-        .build(),
-      {
-        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-      },
-    );
-
-    const closedAgency3 = toAgencyWithRights(
-      new AgencyDtoBuilder()
-        .withId("55555555-5555-4555-9555-555555555555")
-        .withStatus("closed")
-        .build(),
-      {
-        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-      },
-    );
-
-    if (adapterKind === "pg") {
-      it("deletes agencies with status closed or rejected, updated_at older than given date, and without conventions", async () => {
-        await Promise.all([
-          agencyRepository.insert(closedAgency1, oldDate),
-          agencyRepository.insert(rejectedAgency, oldDate),
-          agencyRepository.insert(closedAgency2, recentDate),
-          agencyRepository.insert(activeAgency, oldDate),
-          agencyRepository.insert(closedAgency3, oldDate),
-        ]);
-        const convention = new ConventionDtoBuilder()
-          .withId("cccccccc-cccc-4ccc-9ccc-cccccccccccc")
-          .withAgencyId(closedAgency3.id)
-          .build();
-
-        await conventionRepository.save(convention);
-
-        const deletedAgencyIds =
-          await agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-            updatedBefore: threeMonthsAgo,
-          });
-
-        expectArraysToEqualIgnoringOrder(deletedAgencyIds, [
-          closedAgency1.id,
-          rejectedAgency.id,
-        ]);
-
-        expect(
-          await agencyRepository.getById(closedAgency1.id),
-        ).toBeUndefined();
-        expect(
-          await agencyRepository.getById(rejectedAgency.id),
-        ).toBeUndefined();
-
-        const agenciesToKeep = await agencyRepository.getByIds([
-          closedAgency2.id,
-          activeAgency.id,
-          closedAgency3.id,
-        ]);
-
-        expectArraysToEqualIgnoringOrder(agenciesToKeep, [
-          closedAgency2,
-          activeAgency,
-          closedAgency3,
-        ]);
-      });
-
-      it("deletes agencies that refer to a deleted agency via refers_to_agency_id", async () => {
-        const agencyReferringToAgencyThatShouldBeDeleted = toAgencyWithRights(
-          new AgencyDtoBuilder()
-            .withId("bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb")
-            .withStatus("active")
-            .withRefersToAgencyInfo({
-              refersToAgencyId: closedAgency1.id,
-              refersToAgencyName: closedAgency1.name,
-              refersToAgencyContactEmail: closedAgency1.contactEmail,
-            })
-            .build(),
-          {
-            [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-          },
-        );
-
-        const agencyNotReferringToDeletedAgency = toAgencyWithRights(
-          new AgencyDtoBuilder()
-            .withId("cccccccc-cccc-4ccc-9ccc-cccccccccccc")
-            .withStatus("active")
-            .build(),
-          {
-            [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-          },
-        );
-
-        await agencyRepository.insert(closedAgency1, oldDate);
-        await Promise.all([
-          agencyRepository.insert(agencyReferringToAgencyThatShouldBeDeleted),
-          agencyRepository.insert(agencyNotReferringToDeletedAgency),
-        ]);
-
-        const deletedAgencyIds =
-          await agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-            updatedBefore: threeMonthsAgo,
-          });
-
-        expectArraysToEqualIgnoringOrder(deletedAgencyIds, [
-          closedAgency1.id,
-          agencyReferringToAgencyThatShouldBeDeleted.id,
-        ]);
-
-        const agenciesToKeep = await agencyRepository.getByIds([
-          agencyNotReferringToDeletedAgency.id,
-        ]);
-
-        expectArraysToEqualIgnoringOrder(agenciesToKeep, [
-          agencyNotReferringToDeletedAgency,
-        ]);
-      });
-
-      it("does not delete the agency to delete (nor its referring agencies) if at least one referring agency has conventions", async () => {
-        const agencyReferringToDeletedAgencyWithConvention = toAgencyWithRights(
-          new AgencyDtoBuilder()
-            .withId("dddddddd-dddd-4ddd-9ddd-dddddddddddd")
-            .withStatus("active")
-            .withRefersToAgencyInfo({
-              refersToAgencyId: closedAgency1.id,
-              refersToAgencyName: closedAgency1.name,
-              refersToAgencyContactEmail: closedAgency1.contactEmail,
-            })
-            .build(),
-          {
-            [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-          },
-        );
-        await agencyRepository.insert(closedAgency1, oldDate);
-
-        await agencyRepository.insert(
-          agencyReferringToDeletedAgencyWithConvention,
-        );
-
-        const convention = new ConventionDtoBuilder()
-          .withId("dddddddd-dddd-4ddd-9ddd-dddddddddddc")
-          .withAgencyId(agencyReferringToDeletedAgencyWithConvention.id)
-          .build();
-
-        await conventionRepository.save(convention);
-
-        const deletedAgencyIds =
-          await agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-            updatedBefore: threeMonthsAgo,
-          });
-
-        expectArraysToEqualIgnoringOrder(deletedAgencyIds, []);
-
-        expectToEqual(
-          await agencyRepository.getById(closedAgency1.id),
-          closedAgency1,
-        );
-
-        expectToEqual(
-          await agencyRepository.getById(
-            agencyReferringToDeletedAgencyWithConvention.id,
-          ),
-          agencyReferringToDeletedAgencyWithConvention,
-        );
-      });
-
-      it("deletes both agencies when a deletion candidate is referenced by another deletion candidate", async () => {
-        const oldClosedAgencyReferrer = toAgencyWithRights(
-          new AgencyDtoBuilder()
-            .withId("eeeeeeee-eeee-4eee-9eee-eeeeeeeeeeee")
-            .withStatus("closed")
-            .withRefersToAgencyInfo({
-              refersToAgencyId: closedAgency1.id,
-              refersToAgencyName: closedAgency1.name,
-              refersToAgencyContactEmail: closedAgency1.contactEmail,
-            })
-            .build(),
-          {
-            [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-          },
-        );
-
-        await agencyRepository.insert(closedAgency1, oldDate);
-        await agencyRepository.insert(oldClosedAgencyReferrer, oldDate);
-
-        const deletedAgencyIds =
-          await agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-            updatedBefore: threeMonthsAgo,
-          });
-
-        expectArraysToEqualIgnoringOrder(deletedAgencyIds, [
-          closedAgency1.id,
-          oldClosedAgencyReferrer.id,
-        ]);
-
-        expect(
-          await agencyRepository.getById(closedAgency1.id),
-        ).toBeUndefined();
-        expect(
-          await agencyRepository.getById(oldClosedAgencyReferrer.id),
-        ).toBeUndefined();
-      });
-    } else {
-      it("throw Not implemented", () => {
-        expectPromiseToFailWithError(
-          agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-            updatedBefore: threeMonthsAgo,
-          }),
-          new Error("Not implemented"),
-        );
-      });
-    }
   });
 });

--- a/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.integration.test.ts
@@ -572,6 +572,23 @@ describe.each(
       [validator1.id]: { isNotifiedByEmail: false, roles: ["validator"] },
     });
 
+    it("do nothing when no id provided", async () => {
+      await agencyRepository.insert(agency1);
+      await agencyRepository.insert(agency2);
+
+      expectToEqual((await agencyRepository.getAgencies({})).data, [
+        agency1,
+        agency2,
+      ]);
+
+      await agencyRepository.deleteByIds([]);
+
+      expectToEqual((await agencyRepository.getAgencies({})).data, [
+        agency1,
+        agency2,
+      ]);
+    });
+
     it("delete agencies if exist by ids", async () => {
       await agencyRepository.insert(agency1);
       await agencyRepository.insert(agency2);

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -100,7 +100,7 @@ export class PgAgencyRepository implements AgencyRepository {
         created_at: agency.createdAt
           ? sql<Date>`${agency.createdAt}::timestamp`
           : sql`now()`,
-        updated_at: agency.updatedAt,
+        updated_at: sql<Date>`${agency.updatedAt}::timestamp`,
       }))
       .execute()
       .catch((error) => {
@@ -115,6 +115,7 @@ export class PgAgencyRepository implements AgencyRepository {
   }
 
   public async deleteByIds(ids: AgencyId[]): Promise<AgencyId[]> {
+    if (ids.length === 0) return ids;
     return this.transaction
       .deleteFrom("agencies")
       .where("id", "in", ids)

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -15,6 +15,7 @@ import {
   calculatePaginationResult,
   type DataWithPagination,
   type DateString,
+  type DateTimeIsoString,
   type DelegationAgencyInfo,
   type DepartmentCode,
   errors,
@@ -58,18 +59,12 @@ const isUuid = (value: string) => guidSchema.safeParse(value.trim()).success;
 export class PgAgencyRepository implements AgencyRepository {
   constructor(private transaction: KyselyDb) {}
 
-  public async insert(
-    agency: AgencyWithUsersRights,
-    updatedAt?: DateString,
-  ): Promise<void> {
-    await this.insertAgency(agency, updatedAt);
+  public async insert(agency: AgencyWithUsersRights): Promise<void> {
+    await this.insertAgency(agency);
     await this.#saveAgencyRights(agency);
   }
 
-  private async insertAgency(
-    agency: AgencyWithUsersRights,
-    updatedAt?: DateString,
-  ) {
+  private async insertAgency(agency: AgencyWithUsersRights) {
     const phoneId = (
       await getOrCreatePhoneIds(this.transaction, [agency.phoneNumber])
     )[agency.phoneNumber];
@@ -105,7 +100,7 @@ export class PgAgencyRepository implements AgencyRepository {
         created_at: agency.createdAt
           ? sql<Date>`${agency.createdAt}::timestamp`
           : sql`now()`,
-        updated_at: updatedAt ?? sql`now()`,
+        updated_at: agency.updatedAt,
       }))
       .execute()
       .catch((error) => {
@@ -531,6 +526,7 @@ export class PgAgencyRepository implements AgencyRepository {
             ref("agencies.delegation_info"),
           ),
           createdAt: sql<DateString>`date_to_iso(agencies.created_at)`,
+          updatedAt: sql<DateTimeIsoString>`date_to_iso(agencies.updated_at)`,
           usersRights: fn.coalesce(
             fn
               .jsonAgg(

--- a/back/src/domains/agency/adapters/PgAgencyRepository.ts
+++ b/back/src/domains/agency/adapters/PgAgencyRepository.ts
@@ -114,6 +114,30 @@ export class PgAgencyRepository implements AgencyRepository {
       });
   }
 
+  public async deleteByIds(ids: AgencyId[]): Promise<AgencyId[]> {
+    return this.transaction
+      .deleteFrom("agencies")
+      .where("id", "in", ids)
+      .returning("id")
+      .execute()
+      .then((results) => {
+        const deletedIds = results.map(({ id }) => id);
+
+        const [presentAgencyIds, missingAgencyIds] = partition(
+          (IdsToDelete) => deletedIds.includes(IdsToDelete),
+          ids,
+        );
+
+        if (missingAgencyIds.length > 0)
+          throw errors.agencies.notFound({
+            missingAgencyIds,
+            presentAgencyIds,
+          });
+
+        return deletedIds;
+      });
+  }
+
   public async update(agency: PartialAgencyWithUsersRights): Promise<void> {
     const phoneId = agency.phoneNumber
       ? (await getOrCreatePhoneIds(this.transaction, [agency.phoneNumber]))[
@@ -145,7 +169,7 @@ export class PgAgencyRepository implements AgencyRepository {
           agency.coveredDepartments &&
           JSON.stringify(agency.coveredDepartments),
         refers_to_agency_id: agency.refersToAgencyId,
-        updated_at: sql`NOW()`,
+        updated_at: agency.updatedAt,
         status_justification: agency.statusJustification,
         phone_id: phoneId,
         delegation_info:
@@ -391,13 +415,21 @@ export class PgAgencyRepository implements AgencyRepository {
   public async getAgencyIdsByFilters(
     filters: GetAgencyIdsFilters,
   ): Promise<AgencyId[]> {
-    const { kinds, statuses, ...rest } = filters;
+    const { kinds, statuses, updateDate, ...rest } = filters;
     rest satisfies Record<string, never>;
 
     const results = await pipeWithValue(
       this.transaction.selectFrom("agencies").select("agencies.id"),
       (b) => (kinds ? b.where("agencies.kind", "in", kinds) : b),
       (b) => (statuses ? b.where("agencies.status", "in", statuses) : b),
+      (b) =>
+        updateDate?.to
+          ? b.where("agencies.updated_at", "<=", updateDate.to)
+          : b,
+      (b) =>
+        updateDate?.from
+          ? b.where("agencies.updated_at", ">=", updateDate.from)
+          : b,
     )
       .orderBy("agencies.id", "asc")
       .execute();
@@ -636,100 +668,5 @@ export class PgAgencyRepository implements AgencyRepository {
       .execute();
 
     return results.map(({ agency_siret }) => agency_siret);
-  }
-
-  async deleteOldClosedAgenciesWithoutConventions(params: {
-    updatedBefore: Date;
-  }): Promise<AgencyId[]> {
-    const { updatedBefore } = params;
-    const result = await this.transaction
-      .withRecursive("deletionCandidates", (qb) =>
-        qb
-          .selectFrom("agencies")
-          .select("agencies.id")
-          .where("status", "in", ["closed", "rejected"])
-          .where("updated_at", "<=", updatedBefore)
-          .where(({ eb }) =>
-            eb.not(
-              eb.exists(
-                eb
-                  .selectFrom("conventions")
-                  .select("id")
-                  .whereRef("conventions.agency_id", "=", "agencies.id"),
-              ),
-            ),
-          ),
-      )
-      .withRecursive("candidateSubtree", (qb) =>
-        qb
-          .selectFrom("deletionCandidates")
-          .select(({ ref }) => [
-            ref("deletionCandidates.id").as("root_id"),
-            ref("deletionCandidates.id").as("id"),
-          ])
-          .unionAll(
-            qb
-              .selectFrom("agencies")
-              .innerJoin(
-                "candidateSubtree",
-                "agencies.refers_to_agency_id",
-                "candidateSubtree.id",
-              )
-              .select(({ ref }) => [
-                ref("candidateSubtree.root_id").as("root_id"),
-                ref("agencies.id").as("id"),
-              ]),
-          ),
-      )
-      .withRecursive("agenciesToDelete", (qb) =>
-        qb
-          .selectFrom("deletionCandidates")
-          .select("deletionCandidates.id")
-          .where(({ eb }) =>
-            eb.not(
-              eb.exists(
-                eb
-                  .selectFrom("candidateSubtree")
-                  .innerJoin(
-                    "conventions",
-                    "conventions.agency_id",
-                    "candidateSubtree.id",
-                  )
-                  .select("conventions.id")
-                  .whereRef(
-                    "candidateSubtree.root_id",
-                    "=",
-                    "deletionCandidates.id",
-                  ),
-              ),
-            ),
-          )
-          .unionAll(
-            qb
-              .selectFrom("agencies")
-              .select("agencies.id")
-              .innerJoin(
-                "agenciesToDelete",
-                "agencies.refers_to_agency_id",
-                "agenciesToDelete.id",
-              )
-              .where(({ eb }) =>
-                eb.not(
-                  eb.exists(
-                    eb
-                      .selectFrom("conventions")
-                      .select("id")
-                      .whereRef("conventions.agency_id", "=", "agencies.id"),
-                  ),
-                ),
-              ),
-          ),
-      )
-      .deleteFrom("agencies")
-      .where("id", "in", (eb) => eb.selectFrom("agenciesToDelete").select("id"))
-      .returning("id")
-      .execute();
-
-    return result.map(({ id }) => id);
   }
 }

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -13,6 +13,7 @@ import {
   type DepartmentCode,
   errors,
   type OmitFromExistingKeys,
+  type OptionalDateRange,
   type PaginationQueryParams,
   type SiretDto,
   type UserId,
@@ -36,6 +37,7 @@ export type GetAgenciesFilters = {
 export type GetAgencyIdsFilters = {
   kinds?: AgencyKind[];
   statuses?: AgencyStatus[];
+  updateDate?: OptionalDateRange;
 };
 
 export type AgencyWithoutRights = Omit<
@@ -71,6 +73,7 @@ export const throwIfAgencyHasNoUsersWhileNotClosedOrRejected = ({
 export interface AgencyRepository {
   insert(agency: AgencyWithUsersRights): Promise<void>;
   update(partialAgency: PartialAgencyWithUsersRights): Promise<void>;
+  deleteByIds(ids: AgencyId[]): Promise<AgencyId[]>;
 
   getById(id: AgencyId): Promise<AgencyWithUsersRights | undefined>;
   getBySafirAndActiveStatus(
@@ -91,9 +94,6 @@ export interface AgencyRepository {
   ): Promise<UserId[]>;
   getAgenciesRightsByUserId(id: UserId): Promise<AgencyRightOfUser[]>;
   getExistingActiveSirets(sirets: SiretDto[]): Promise<SiretDto[]>;
-  deleteOldClosedAgenciesWithoutConventions(params: {
-    updatedBefore: Date;
-  }): Promise<AgencyId[]>;
 }
 
 export const updateAgencyRightsForUser = async (

--- a/back/src/domains/agency/ports/AgencyRepository.ts
+++ b/back/src/domains/agency/ports/AgencyRepository.ts
@@ -69,7 +69,7 @@ export const throwIfAgencyHasNoUsersWhileNotClosedOrRejected = ({
 };
 
 export interface AgencyRepository {
-  insert(agency: AgencyWithUsersRights, updatedAt?: DateString): Promise<void>;
+  insert(agency: AgencyWithUsersRights): Promise<void>;
   update(partialAgency: PartialAgencyWithUsersRights): Promise<void>;
 
   getById(id: AgencyId): Promise<AgencyWithUsersRights | undefined>;
@@ -100,12 +100,14 @@ export const updateAgencyRightsForUser = async (
   uow: UnitOfWork,
   userId: UserId,
   { agencyId, isNotifiedByEmail, roles }: AgencyRightOfUser,
+  now: Date,
 ): Promise<void> => {
   const agencyWithRights = await uow.agencyRepository.getById(agencyId);
   if (!agencyWithRights) throw errors.agency.notFound({ agencyId });
   return uow.agencyRepository.update({
     id: agencyId,
     status: agencyWithRights.status,
+    updatedAt: now.toISOString(),
     usersRights: {
       ...agencyWithRights.usersRights,
       [userId]: { isNotifiedByEmail, roles },
@@ -117,6 +119,7 @@ export const removeAgencyRightsForUser = async (
   uow: UnitOfWork,
   userId: UserId,
   { agencyId }: AgencyRightOfUser,
+  now: Date,
 ): Promise<void> => {
   const agencyWithRights = await uow.agencyRepository.getById(agencyId);
   if (!agencyWithRights) throw errors.agency.notFound({ agencyId });
@@ -125,5 +128,6 @@ export const removeAgencyRightsForUser = async (
     id: agencyId,
     status: agencyWithRights.status,
     usersRights: rightsToKeep,
+    updatedAt: now.toISOString(),
   });
 };

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.ts
@@ -2,7 +2,6 @@ import { flatten, keys, splitEvery, uniq, values } from "ramda";
 import {
   type AgencyRole,
   type AgencyUsersRights,
-  type AgencyWithUsersRights,
   type DepartmentCode,
   type Email,
   emailSchema,
@@ -120,6 +119,7 @@ export const makeAddAgenciesAndUsers = useCaseBuilder("AddAgenciesAndUsers")
       agencyRepository: uow.agencyRepository,
       userRepository: uow.userRepository,
       usecaseErrors,
+      now: deps.timeGateway.now(),
     });
 
     await createNewAgencies({
@@ -128,6 +128,7 @@ export const makeAddAgenciesAndUsers = useCaseBuilder("AddAgenciesAndUsers")
       userRepository: uow.userRepository,
       deps,
       usecaseErrors,
+      now: deps.timeGateway.now(),
     });
 
     await createNewAgenciesWithSuffix({
@@ -154,12 +155,14 @@ const linkUsersToExistingAgency = async ({
   agencyRepository,
   userRepository,
   usecaseErrors,
+  now,
 }: {
   siretsInIF: SiretDto[];
   importedAgencyAndUserRows: ImportedAgencyAndUserRow[];
   agencyRepository: AgencyRepository;
   userRepository: UserRepository;
   usecaseErrors: Record<string, Error>;
+  now: Date;
 }): Promise<void> => {
   const rowsWithSiretAlreadyInIF = importedAgencyAndUserRows.filter((row) =>
     siretsInIF.includes(row.SIRET),
@@ -228,6 +231,7 @@ const linkUsersToExistingAgency = async ({
       await agencyRepository.update({
         id: agencyIF.id,
         status: agencyIF.status,
+        updatedAt: now.toISOString(),
         usersRights: {
           ...agencyIF.usersRights,
           ...agencyUsersRights.reduce((acc, curr) => {
@@ -269,13 +273,14 @@ const createNewAgencies = async ({
   userRepository,
   deps,
   usecaseErrors,
+  now,
 }: {
   importedAgencyAndUserRows: ImportedAgencyAndUserRow[];
   agencyRepository: AgencyRepository;
   userRepository: UserRepository;
+  now: Date;
   deps: {
     uuidGenerator: UuidGenerator;
-    timeGateway: TimeGateway;
     addressGateway: AddressGateway;
   };
   usecaseErrors: Record<string, Error>;
@@ -295,9 +300,11 @@ const createNewAgencies = async ({
       row,
       addressGateway: deps.addressGateway,
     });
-    const agency: AgencyWithUsersRights = {
+
+    await agencyRepository.insert({
       id: deps.uuidGenerator.new(),
-      createdAt: deps.timeGateway.now().toISOString(),
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
       status: "active",
       agencySiret: row.SIRET,
       name: row["Nom structure"],
@@ -329,9 +336,7 @@ const createNewAgencies = async ({
       },
       codeSafir: null,
       statusJustification: null,
-    };
-
-    await agencyRepository.insert(agency);
+    });
   });
 };
 
@@ -459,6 +464,7 @@ const createNewAgenciesWithSuffix = async ({
     userRepository,
     deps,
     usecaseErrors,
+    now: deps.timeGateway.now(),
   });
 };
 

--- a/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgenciesAndUsers.unit.test.ts
@@ -108,8 +108,7 @@ describe("AddAgenciesAndUsers", () => {
       );
 
       await uow.userRepository.save(user1);
-      await uow.agencyRepository.insert(agency1);
-      await uow.agencyRepository.insert(agency2);
+      uow.agencyRepository.agencies = [agency1, agency2];
 
       const newUserId = "10000000-0000-0000-0000-000000000022";
       uuidGenerator.setNextUuids([newUserId, newUserId]);
@@ -126,6 +125,7 @@ describe("AddAgenciesAndUsers", () => {
       expect(uow.agencyRepository.agencies).toEqual([
         {
           ...agency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               isNotifiedByEmail: false,
@@ -135,6 +135,7 @@ describe("AddAgenciesAndUsers", () => {
         },
         {
           ...agency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...agency2.usersRights,
             [newUserId]: {
@@ -175,7 +176,7 @@ describe("AddAgenciesAndUsers", () => {
         },
       );
       await uow.userRepository.save(userAlreadyInDB);
-      await uow.agencyRepository.insert(agencyAlreadyInDB);
+      uow.agencyRepository.agencies = [agencyAlreadyInDB];
 
       const newUserId1 = "10000000-0000-0000-0000-000000000022";
       const newUserId2 = "10000000-0000-0000-0000-000000000023";
@@ -265,6 +266,7 @@ describe("AddAgenciesAndUsers", () => {
             .withName(row["Nom structure"])
             .withSignature("L'équipe")
             .withCreatedAt(timeGateway.now().toISOString())
+            .withUpdatedAt(timeGateway.now())
             .withAgencyContactEmail(row["Contact structure"])
             .build(),
           {
@@ -348,10 +350,12 @@ describe("AddAgenciesAndUsers", () => {
       expectArraysToMatch(uow.agencyRepository.agencies, [
         {
           ...agency1,
+          updatedAt: timeGateway.now().toISOString(),
           name: `${row["Nom structure"]} - ACI`,
         },
         {
           ...agency1,
+          updatedAt: timeGateway.now().toISOString(),
           id: newAgencyId2,
           name: `${row["Nom structure"]} - EI`,
           phoneNumber: rows[1].Téléphone,

--- a/back/src/domains/agency/use-cases/AddAgency.ts
+++ b/back/src/domains/agency/use-cases/AddAgency.ts
@@ -63,6 +63,7 @@ export const makeAddAgency = useCaseBuilder("AddAgency")
       status: "needsReview",
       codeSafir: null,
       statusJustification: null,
+      updatedAt: deps.timeGateway.now().toISOString(),
       usersRights: makeUserRights(
         validatorUserIdsForAgency,
         counsellorUserIdsForAgency,

--- a/back/src/domains/agency/use-cases/AddAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AddAgency.unit.test.ts
@@ -12,10 +12,7 @@ import {
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
 import { emptyName } from "../../core/authentication/connected-user/entities/user.helper";
-import {
-  type CreateNewEvent,
-  makeCreateNewEvent,
-} from "../../core/events/ports/EventBus";
+import { makeCreateNewEvent } from "../../core/events/ports/EventBus";
 import {
   InMemorySiretGateway,
   TEST_OPEN_ESTABLISHMENT_1,
@@ -97,7 +94,6 @@ describe("AddAgency use case", () => {
 
   let uow: InMemoryUnitOfWork;
   let addAgency: AddAgency;
-  let createNewEvent: CreateNewEvent;
   let siretGateway: InMemorySiretGateway;
   let timeGateway: CustomTimeGateway;
 
@@ -106,14 +102,13 @@ describe("AddAgency use case", () => {
     const uuidGenerator = new TestUuidGenerator();
     timeGateway = new CustomTimeGateway();
     siretGateway = new InMemorySiretGateway();
-    createNewEvent = makeCreateNewEvent({
-      timeGateway: timeGateway,
-      uuidGenerator: uuidGenerator,
-    });
     addAgency = makeAddAgency({
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
-        createNewEvent,
+        createNewEvent: makeCreateNewEvent({
+          timeGateway: timeGateway,
+          uuidGenerator: uuidGenerator,
+        }),
         siretGateway,
         timeGateway,
         uuidGenerator,
@@ -156,6 +151,7 @@ describe("AddAgency use case", () => {
           {
             ...createParisMissionLocaleParams,
             status: "needsReview",
+            updatedAt: timeGateway.now().toISOString(),
             statusJustification: null,
             codeSafir: null,
             counsellorEmails: [],
@@ -203,6 +199,7 @@ describe("AddAgency use case", () => {
         toAgencyWithRights(
           {
             ...createParisMissionLocaleParams,
+            updatedAt: timeGateway.now().toISOString(),
             status: "needsReview",
             statusJustification: null,
             codeSafir: null,
@@ -234,6 +231,7 @@ describe("AddAgency use case", () => {
         toAgencyWithRights(
           {
             ...createParisMissionLocaleParams,
+            updatedAt: timeGateway.now().toISOString(),
             status: "needsReview",
             statusJustification: null,
             codeSafir: null,
@@ -275,6 +273,7 @@ describe("AddAgency use case", () => {
         .withEmail("validator2@mail.com")
         .buildUser();
       const existingMiloAgency: AgencyDto = {
+        updatedAt: timeGateway.now().toISOString(),
         ...createParisMissionLocaleParams,
         counsellorEmails: [],
         validatorEmails: [],
@@ -323,6 +322,7 @@ describe("AddAgency use case", () => {
         toAgencyWithRights(
           {
             ...createAgencyWithRefersToParams,
+            updatedAt: timeGateway.now().toISOString(),
             status: "needsReview",
             codeSafir: null,
             statusJustification: null,
@@ -372,6 +372,7 @@ describe("AddAgency use case", () => {
         toAgencyWithRights(
           {
             ...newAgency,
+            updatedAt: timeGateway.now().toISOString(),
             status: "needsReview",
             statusJustification: null,
             codeSafir: null,

--- a/back/src/domains/agency/use-cases/AssignAgencyViewerRoleToUsers.ts
+++ b/back/src/domains/agency/use-cases/AssignAgencyViewerRoleToUsers.ts
@@ -1,6 +1,7 @@
 import type { AgencyKind, UserId } from "shared";
 import { agencyKindSchema, executeInSequence, userIdSchema } from "shared";
 import { z } from "zod";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 type AssignAgencyViewerRoleInput = {
@@ -28,7 +29,8 @@ export const makeAssignAgencyViewerRole = useCaseBuilder(
 )
   .withInput<AssignAgencyViewerRoleInput>(assignAgencyViewerRoleInputSchema)
   .withOutput<AssignAgencyViewerRoleOutput>()
-  .build(async ({ inputParams: { agencyKinds, userIds }, uow }) => {
+  .withDeps<{ timeGateway: TimeGateway }>()
+  .build(async ({ inputParams: { agencyKinds, userIds }, uow, deps }) => {
     const users = await uow.userRepository.getByIds(userIds);
 
     if (users.length === 0) {
@@ -80,6 +82,7 @@ export const makeAssignAgencyViewerRole = useCaseBuilder(
             id: agency.id,
             status: agency.status,
             usersRights: updatedUsersRights,
+            updatedAt: deps.timeGateway.now().toISOString(),
           })
           .then(() => {
             agenciesSuccessfullyUpdated++;

--- a/back/src/domains/agency/use-cases/AssignAgencyViewerRoleToUsers.unit.test.ts
+++ b/back/src/domains/agency/use-cases/AssignAgencyViewerRoleToUsers.unit.test.ts
@@ -6,6 +6,7 @@ import {
   expectToEqual,
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
   type InMemoryUnitOfWork,
@@ -17,9 +18,6 @@ import {
 } from "./AssignAgencyViewerRoleToUsers";
 
 describe("AssignAgencyViewerRoleToUsers", () => {
-  let uow: InMemoryUnitOfWork;
-  let assignAgencyViewerRole: AssignAgencyViewerRole;
-
   const user1 = new ConnectedUserBuilder()
     .withId("user1")
     .withEmail("user1@example.com")
@@ -133,10 +131,16 @@ describe("AssignAgencyViewerRoleToUsers", () => {
     },
   };
 
+  let uow: InMemoryUnitOfWork;
+  let assignAgencyViewerRole: AssignAgencyViewerRole;
+  let timeGateway: CustomTimeGateway;
+
   beforeEach(() => {
     uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
     assignAgencyViewerRole = makeAssignAgencyViewerRole({
       uowPerformer: new InMemoryUowPerformer(uow),
+      deps: { timeGateway: timeGateway },
     });
 
     uow.agencyRepository.agencies = [
@@ -170,6 +174,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         {
           ...ftAgency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...user1ViewerRights,
             ...user2ViewerRights,
@@ -177,6 +182,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...user1ViewerRights,
             ...user2ViewerRights,
@@ -184,6 +190,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...capEmploiAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...user1ViewerRights,
             ...user2ViewerRights,
@@ -193,6 +200,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         inactiveAgency,
         {
           ...fromApiPEAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...user1ViewerRights,
             ...user2ViewerRights,
@@ -200,6 +208,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1ViewerRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             ...user1ViewerRights,
             ...user2ViewerRights,
@@ -207,6 +216,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1AdminRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               roles: ["agency-admin", "agency-viewer"],
@@ -233,10 +243,12 @@ describe("AssignAgencyViewerRoleToUsers", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         {
           ...ftAgency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...ftAgency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         capEmploiAgency,
@@ -244,6 +256,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         inactiveAgency,
         {
           ...fromApiPEAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
@@ -252,6 +265,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1AdminRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               roles: ["agency-admin", "agency-viewer"],
@@ -277,10 +291,12 @@ describe("AssignAgencyViewerRoleToUsers", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         {
           ...ftAgency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...ftAgency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         capEmploiAgency,
@@ -288,6 +304,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         inactiveAgency,
         {
           ...fromApiPEAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
@@ -296,6 +313,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1AdminRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               roles: ["agency-admin", "agency-viewer"],
@@ -321,10 +339,12 @@ describe("AssignAgencyViewerRoleToUsers", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         {
           ...ftAgency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...ftAgency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         capEmploiAgency,
@@ -332,6 +352,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         inactiveAgency,
         {
           ...fromApiPEAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
@@ -340,6 +361,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1AdminRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               roles: ["agency-admin", "agency-viewer"],
@@ -365,23 +387,28 @@ describe("AssignAgencyViewerRoleToUsers", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         {
           ...ftAgency1,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...ftAgency2,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...capEmploiAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
           ...conseilDepartementalAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         inactiveAgency,
         {
           ...fromApiPEAgency,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: user1ViewerRights,
         },
         {
@@ -390,6 +417,7 @@ describe("AssignAgencyViewerRoleToUsers", () => {
         },
         {
           ...ftAgencyWithUser1AdminRole,
+          updatedAt: timeGateway.now().toISOString(),
           usersRights: {
             [user1.id]: {
               roles: ["agency-admin", "agency-viewer"],

--- a/back/src/domains/agency/use-cases/CloseAgencyAndTransferConventions.ts
+++ b/back/src/domains/agency/use-cases/CloseAgencyAndTransferConventions.ts
@@ -10,6 +10,7 @@ import { throwErrorIfAgencyNotFound } from "../../../utils/agency";
 import { throwIfNotAdmin } from "../../connected-users/helpers/authorization.helper";
 import type { TriggeredBy } from "../../core/events/events";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 export type CloseAgencyAndTransferConventions = ReturnType<
@@ -21,7 +22,7 @@ export const makeCloseAgencyAndTransferConventions = useCaseBuilder(
 )
   .withInput(closeAgencyAndTransferConventionsRequestSchema)
   .withCurrentUser<ConnectedUser>()
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(async ({ uow, deps, inputParams, currentUser }) => {
     throwIfNotAdmin(currentUser);
 
@@ -84,6 +85,8 @@ export const makeCloseAgencyAndTransferConventions = useCaseBuilder(
       );
     });
 
+    const now = deps.timeGateway.now().toISOString();
+
     await executeInSequence(
       await uow.agencyRepository.getAgenciesRelatedToAgency(
         inputParams.agencyToCloseId,
@@ -95,6 +98,7 @@ export const makeCloseAgencyAndTransferConventions = useCaseBuilder(
           refersToAgencyId: inputParams.agencyToTransferConventionsToId,
           refersToAgencyName: agencyToTransferTo.name,
           refersToAgencyContactEmail: agencyToTransferTo.contactEmail,
+          updatedAt: now,
         }),
     );
 
@@ -102,5 +106,6 @@ export const makeCloseAgencyAndTransferConventions = useCaseBuilder(
       id: inputParams.agencyToCloseId,
       status: "closed",
       statusJustification: "Agence fermée suite à un transfert de convention",
+      updatedAt: now,
     });
   });

--- a/back/src/domains/agency/use-cases/CloseAgencyAndTransferConventions.unit.test.ts
+++ b/back/src/domains/agency/use-cases/CloseAgencyAndTransferConventions.unit.test.ts
@@ -67,17 +67,20 @@ describe("CloseAgencyAndTransfertConventions", () => {
 
   let uow: InMemoryUnitOfWork;
   let useCase: CloseAgencyAndTransferConventions;
+  let timeGateway: CustomTimeGateway;
 
   beforeEach(() => {
     uow = createInMemoryUow();
-    const uuidGenerator = new TestUuidGenerator(["event-id-1", "event-id-2"]);
-    const createNewEvent = makeCreateNewEvent({
-      timeGateway: new CustomTimeGateway(),
-      uuidGenerator,
-    });
+    timeGateway = new CustomTimeGateway();
     useCase = makeCloseAgencyAndTransferConventions({
       uowPerformer: new InMemoryUowPerformer(uow),
-      deps: { createNewEvent },
+      deps: {
+        timeGateway,
+        createNewEvent: makeCreateNewEvent({
+          timeGateway,
+          uuidGenerator: new TestUuidGenerator(["event-id-1", "event-id-2"]),
+        }),
+      },
     });
   });
 
@@ -220,6 +223,7 @@ describe("CloseAgencyAndTransfertConventions", () => {
     const closedAgency = await uow.agencyRepository.getById(agencyToClose.id);
     expectToEqual(closedAgency, {
       ...agencyToClose,
+      updatedAt: timeGateway.now().toISOString(),
       status: "closed",
       statusJustification: "Agence fermée suite à un transfert de convention",
     });
@@ -229,6 +233,7 @@ describe("CloseAgencyAndTransfertConventions", () => {
     );
     expectToEqual(updatedReferringAgency, {
       ...referringAgency,
+      updatedAt: timeGateway.now().toISOString(),
       refersToAgencyId: agencyToTransferTo.id,
       refersToAgencyName: agencyToTransferTo.name,
       refersToAgencyContactEmail: agencyToTransferTo.contactEmail,

--- a/back/src/domains/agency/use-cases/CloseInactiveAgenciesWithoutRecentConventions.ts
+++ b/back/src/domains/agency/use-cases/CloseInactiveAgenciesWithoutRecentConventions.ts
@@ -106,6 +106,7 @@ export const makeCloseInactiveAgenciesWithoutRecentConventions = useCaseBuilder(
             status: "closed",
             statusJustification:
               "Agence fermée automatiquement pour inactivité",
+            updatedAt: now.toISOString(),
           }),
         );
 

--- a/back/src/domains/agency/use-cases/CloseInactiveAgenciesWithoutRecentConventions.unit.test.ts
+++ b/back/src/domains/agency/use-cases/CloseInactiveAgenciesWithoutRecentConventions.unit.test.ts
@@ -211,11 +211,13 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
           ...agency1WithRights,
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
+          updatedAt: timeGateway.now().toISOString(),
         },
         {
           ...agency2WithRights,
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
+          updatedAt: timeGateway.now().toISOString(),
         },
       ]);
 
@@ -280,6 +282,7 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
         agency1WithRights,
         {
           ...agency2WithRights,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },
@@ -365,6 +368,7 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
         referringAgencyWithRights,
         {
           ...agency3WithRights,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },
@@ -469,6 +473,7 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
         recentlyCreatedAgencyWithRights,
         {
           ...oldAgencyWithRights,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },
@@ -550,11 +555,13 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
         agency1WithRights,
         {
           ...agencyToClose1,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },
         {
           ...agencyToClose2,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },
@@ -622,6 +629,7 @@ describe("CloseInactiveAgenciesWithoutRecentConventions", () => {
         poleEmploiAgencyWithRights,
         {
           ...agency1WithRights,
+          updatedAt: timeGateway.now().toISOString(),
           status: "closed",
           statusJustification: "Agence fermée automatiquement pour inactivité",
         },

--- a/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.ts
+++ b/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.ts
@@ -1,0 +1,58 @@
+import { subMonths } from "date-fns";
+import { uniq } from "ramda";
+import { type AgencyId, errors, executeInSequence, isTruthy } from "shared";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
+import { useCaseBuilder } from "../../core/useCaseBuilder";
+
+export type DeleteOldClosedAgenciesWithoutConventions = ReturnType<
+  typeof makeDeleteOldClosedAgenciesWithoutConventions
+>;
+
+export const numberOfMonthsBeforeDeletion = 3;
+
+export const makeDeleteOldClosedAgenciesWithoutConventions = useCaseBuilder(
+  "DeleteOldClosedAgenciesWithoutConventions",
+)
+  .withOutput<{ deletedAgencies: AgencyId[] }>()
+  .withDeps<{ timeGateway: TimeGateway }>()
+  .build(async ({ uow, deps: { timeGateway } }) => {
+    const updatedBefore = subMonths(
+      timeGateway.now(),
+      numberOfMonthsBeforeDeletion,
+    );
+
+    const candidateAgencyIds = await uow.agencyRepository.getAgencyIdsByFilters(
+      {
+        statuses: ["closed", "rejected"],
+        updateDate: { to: updatedBefore },
+      },
+    );
+
+    const agenciesToDelete: AgencyId[] = await executeInSequence<
+      AgencyId,
+      AgencyId[] | null
+    >(candidateAgencyIds, async (agencyId) => {
+      const agency = await uow.agencyRepository.getById(agencyId);
+      if (!agency) throw errors.agency.notFound({ agencyId });
+
+      const relatedAgencies =
+        await uow.agencyRepository.getAgenciesRelatedToAgency(agencyId);
+
+      const agencyIds = [agency?.id, ...relatedAgencies.map(({ id }) => id)];
+      // Quid si on a une relatedAgency qui n'est pas closed/rejected ?
+
+      const conventionIds =
+        await uow.conventionQueries.getConventionIdsByFilters({
+          filters: {
+            withAgencyIds: agencyIds,
+          },
+        });
+
+      return conventionIds.length === 0 ? agencyIds : null;
+    }).then((results) => uniq(results.filter(isTruthy).flat()));
+
+    const deletedAgencies =
+      await uow.agencyRepository.deleteByIds(agenciesToDelete);
+
+    return { deletedAgencies };
+  });

--- a/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.ts
+++ b/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.ts
@@ -1,6 +1,6 @@
 import { subMonths } from "date-fns";
 import { uniq } from "ramda";
-import { type AgencyId, errors, executeInSequence, isTruthy } from "shared";
+import { type AgencyId, executeInSequence, isTruthy } from "shared";
 import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
@@ -32,23 +32,23 @@ export const makeDeleteOldClosedAgenciesWithoutConventions = useCaseBuilder(
       AgencyId,
       AgencyId[] | null
     >(candidateAgencyIds, async (agencyId) => {
-      const agency = await uow.agencyRepository.getById(agencyId);
-      if (!agency) throw errors.agency.notFound({ agencyId });
-
       const relatedAgencies =
         await uow.agencyRepository.getAgenciesRelatedToAgency(agencyId);
 
-      const agencyIds = [agency?.id, ...relatedAgencies.map(({ id }) => id)];
-      // Quid si on a une relatedAgency qui n'est pas closed/rejected ?
+      const candidateAndRelatedAgencyIds = [
+        agencyId,
+        ...relatedAgencies.map(({ id }) => id),
+      ];
 
       const conventionIds =
         await uow.conventionQueries.getConventionIdsByFilters({
           filters: {
-            withAgencyIds: agencyIds,
+            withAgencyIds: candidateAndRelatedAgencyIds,
           },
+          limit: 1,
         });
 
-      return conventionIds.length === 0 ? agencyIds : null;
+      return conventionIds.length === 0 ? candidateAndRelatedAgencyIds : null;
     }).then((results) => uniq(results.filter(isTruthy).flat()));
 
     const deletedAgencies =

--- a/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.unit.test.ts
+++ b/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.unit.test.ts
@@ -1,0 +1,264 @@
+import { subDays, subMonths } from "date-fns";
+import {
+  AgencyDtoBuilder,
+  ConnectedUserBuilder,
+  ConventionDtoBuilder,
+  expectToEqual,
+} from "shared";
+import { v4 as uuid } from "uuid";
+import { toAgencyWithRights } from "../../../utils/agency";
+import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
+import {
+  createInMemoryUow,
+  type InMemoryUnitOfWork,
+} from "../../core/unit-of-work/adapters/createInMemoryUow";
+import { InMemoryUowPerformer } from "../../core/unit-of-work/adapters/InMemoryUowPerformer";
+import {
+  type DeleteOldClosedAgenciesWithoutConventions,
+  makeDeleteOldClosedAgenciesWithoutConventions,
+} from "./DeleteOldClosedAgenciesWithoutConventions";
+
+describe("DeleteOldClosedAgenciesWithoutConventions", () => {
+  const validator1 = new ConnectedUserBuilder()
+    .withId("10000000-0000-0000-0000-000000000003")
+    .withEmail("validator1@agency1.fr")
+    .withProConnectInfos({ externalId: uuid(), siret: "00000000000000" })
+    .buildUser();
+
+  let uow: InMemoryUnitOfWork;
+  let timeGateway: CustomTimeGateway;
+  let deleteOldClosedAgenciesWithoutConventions: DeleteOldClosedAgenciesWithoutConventions;
+
+  const now = new Date();
+
+  beforeEach(() => {
+    timeGateway = new CustomTimeGateway(now);
+    uow = createInMemoryUow();
+    deleteOldClosedAgenciesWithoutConventions =
+      makeDeleteOldClosedAgenciesWithoutConventions({
+        uowPerformer: new InMemoryUowPerformer(uow),
+        deps: {
+          timeGateway,
+        },
+      });
+  });
+
+  const oldDate = subMonths(now, 4);
+  const recentDate = subDays(now, 5);
+
+  const closedAgency1_old = toAgencyWithRights(
+    new AgencyDtoBuilder()
+      .withId("11111111-1111-4111-9111-111111111111")
+      .withStatus("closed")
+      .withUpdatedAt(oldDate)
+      .build(),
+    {
+      [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+    },
+  );
+
+  const rejectedAgency_old = toAgencyWithRights(
+    new AgencyDtoBuilder()
+      .withId("22222222-2222-4222-9222-222222222222")
+      .withStatus("rejected")
+      .withUpdatedAt(oldDate)
+      .build(),
+    {
+      [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+    },
+  );
+
+  const closedAgency2_recent = toAgencyWithRights(
+    new AgencyDtoBuilder()
+      .withId("33333333-3333-4333-9333-333333333333")
+      .withStatus("closed")
+      .withUpdatedAt(recentDate)
+      .build(),
+    {
+      [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+    },
+  );
+
+  const activeAgency_old = toAgencyWithRights(
+    new AgencyDtoBuilder()
+      .withId("44444444-4444-4444-9444-444444444444")
+      .withStatus("active")
+      .withUpdatedAt(oldDate)
+      .build(),
+    {
+      [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+    },
+  );
+
+  const closedAgency3_old = toAgencyWithRights(
+    new AgencyDtoBuilder()
+      .withId("55555555-5555-4555-9555-555555555555")
+      .withStatus("closed")
+      .withUpdatedAt(oldDate)
+      .build(),
+    {
+      [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+    },
+  );
+
+  it("deletes agencies with status closed or rejected, updated_at older than given date, and without conventions", async () => {
+    uow.agencyRepository.agencies = [
+      closedAgency1_old,
+      closedAgency2_recent,
+      closedAgency3_old,
+      rejectedAgency_old,
+      activeAgency_old,
+    ];
+
+    const convention = new ConventionDtoBuilder()
+      .withId("cccccccc-cccc-4ccc-9ccc-cccccccccccc")
+      .withAgencyId(closedAgency3_old.id)
+      .build();
+
+    uow.conventionRepository.setConventions([convention]);
+
+    const result = await deleteOldClosedAgenciesWithoutConventions.execute();
+
+    expectToEqual(result, {
+      deletedAgencies: [closedAgency1_old.id, rejectedAgency_old.id],
+    });
+
+    expectToEqual(uow.agencyRepository.agencies, [
+      closedAgency2_recent,
+      closedAgency3_old,
+      activeAgency_old,
+    ]);
+  });
+
+  it("deletes agencies that refer to a deleted agency via refers_to_agency_id", async () => {
+    const activeAgencyReferringToAgencyThatShouldBeDeleted = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("bbbbbbbb-bbbb-4bbb-9bbb-bbbbbbbbbbbb")
+        .withStatus("active")
+        .withRefersToAgencyInfo({
+          refersToAgencyId: closedAgency1_old.id,
+          refersToAgencyName: closedAgency1_old.name,
+          refersToAgencyContactEmail: closedAgency1_old.contactEmail,
+        })
+        .build(),
+      {
+        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    const activeAgencyNotReferringToDeletedAgency = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("cccccccc-cccc-4ccc-9ccc-cccccccccccc")
+        .withStatus("active")
+        .build(),
+      {
+        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    uow.agencyRepository.agencies = [
+      closedAgency1_old,
+      activeAgencyReferringToAgencyThatShouldBeDeleted,
+      activeAgencyNotReferringToDeletedAgency,
+    ];
+
+    const result = await deleteOldClosedAgenciesWithoutConventions.execute();
+
+    expectToEqual(result, {
+      deletedAgencies: [
+        closedAgency1_old.id,
+        activeAgencyReferringToAgencyThatShouldBeDeleted.id,
+      ],
+    });
+
+    expectToEqual(uow.agencyRepository.agencies, [
+      activeAgencyNotReferringToDeletedAgency,
+    ]);
+  });
+
+  it("does not delete the agency to delete (nor its referring agencies) if at least one referring agency has conventions", async () => {
+    const agencyReferringToDeletedAgencyWithConvention = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("dddddddd-dddd-4ddd-9ddd-dddddddddddd")
+        .withStatus("active")
+        .withRefersToAgencyInfo({
+          refersToAgencyId: closedAgency1_old.id,
+          refersToAgencyName: closedAgency1_old.name,
+          refersToAgencyContactEmail: closedAgency1_old.contactEmail,
+        })
+        .build(),
+      {
+        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    const agencyReferringToDeletedAgencyWithoutConvention = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("dddddddd-dddd-4ddd-ffff-dddddddddddd")
+        .withStatus("active")
+        .withRefersToAgencyInfo({
+          refersToAgencyId: closedAgency1_old.id,
+          refersToAgencyName: closedAgency1_old.name,
+          refersToAgencyContactEmail: closedAgency1_old.contactEmail,
+        })
+        .build(),
+      {
+        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    uow.agencyRepository.agencies = [
+      closedAgency1_old,
+      agencyReferringToDeletedAgencyWithConvention,
+      agencyReferringToDeletedAgencyWithoutConvention,
+    ];
+
+    const convention = new ConventionDtoBuilder()
+      .withId("dddddddd-dddd-4ddd-9ddd-dddddddddddc")
+      .withAgencyId(agencyReferringToDeletedAgencyWithConvention.id)
+      .build();
+
+    await uow.conventionRepository.save(convention);
+
+    const deletedAgencyIds =
+      await deleteOldClosedAgenciesWithoutConventions.execute();
+
+    expectToEqual(deletedAgencyIds, { deletedAgencies: [] });
+    expectToEqual(uow.agencyRepository.agencies, [
+      closedAgency1_old,
+      agencyReferringToDeletedAgencyWithConvention,
+      agencyReferringToDeletedAgencyWithoutConvention,
+    ]);
+  });
+
+  // Doublon ?
+  it("deletes both agencies when a deletion candidate is referenced by another deletion candidate", async () => {
+    const oldClosedAgencyReferrer = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("eeeeeeee-eeee-4eee-9eee-eeeeeeeeeeee")
+        .withStatus("closed")
+        .withRefersToAgencyInfo({
+          refersToAgencyId: closedAgency1_old.id,
+          refersToAgencyName: closedAgency1_old.name,
+          refersToAgencyContactEmail: closedAgency1_old.contactEmail,
+        })
+        .build(),
+      {
+        [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    uow.agencyRepository.agencies = [
+      closedAgency1_old,
+      oldClosedAgencyReferrer,
+    ];
+
+    const result = await deleteOldClosedAgenciesWithoutConventions.execute();
+
+    expectToEqual(result, {
+      deletedAgencies: [closedAgency1_old.id, oldClosedAgencyReferrer.id],
+    });
+
+    expectToEqual(uow.agencyRepository.agencies, []);
+  });
+});

--- a/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.unit.test.ts
+++ b/back/src/domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions.unit.test.ts
@@ -101,6 +101,28 @@ describe("DeleteOldClosedAgenciesWithoutConventions", () => {
     },
   );
 
+  it("do nothing on recent closed agencies and old rejected agencies with conventions", async () => {
+    uow.agencyRepository.agencies = [rejectedAgency_old, closedAgency2_recent];
+
+    const convention = new ConventionDtoBuilder()
+      .withId("cccccccc-cccc-4ccc-9ccc-cccccccccccc")
+      .withAgencyId(rejectedAgency_old.id)
+      .build();
+
+    uow.conventionRepository.setConventions([convention]);
+
+    const result = await deleteOldClosedAgenciesWithoutConventions.execute();
+
+    expectToEqual(result, {
+      deletedAgencies: [],
+    });
+
+    expectToEqual(uow.agencyRepository.agencies, [
+      rejectedAgency_old,
+      closedAgency2_recent,
+    ]);
+  });
+
   it("deletes agencies with status closed or rejected, updated_at older than given date, and without conventions", async () => {
     uow.agencyRepository.agencies = [
       closedAgency1_old,
@@ -231,8 +253,7 @@ describe("DeleteOldClosedAgenciesWithoutConventions", () => {
     ]);
   });
 
-  // Doublon ?
-  it("deletes both agencies when a deletion candidate is referenced by another deletion candidate", async () => {
+  it("deletes both closed agencies when one refers to the other", async () => {
     const oldClosedAgencyReferrer = toAgencyWithRights(
       new AgencyDtoBuilder()
         .withId("eeeeeeee-eeee-4eee-9eee-eeeeeeeeeeee")

--- a/back/src/domains/agency/use-cases/RegisterAgencyToConnectedUser.ts
+++ b/back/src/domains/agency/use-cases/RegisterAgencyToConnectedUser.ts
@@ -5,6 +5,7 @@ import {
   executeInSequence,
 } from "shared";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 import { isFTUser } from "../entities/Agency";
 
@@ -16,7 +17,7 @@ export const makeRegisterAgencyToConnectedUser = useCaseBuilder(
 )
   .withInput(agencyIdsSchema)
   .withCurrentUser<ConnectedUser>()
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(async ({ uow, currentUser, deps, inputParams: agencyIds }) => {
     const agencyRights = await uow.agencyRepository.getAgenciesRightsByUserId(
       currentUser.id,
@@ -52,6 +53,7 @@ export const makeRegisterAgencyToConnectedUser = useCaseBuilder(
             roles: ["to-review"],
           },
         },
+        updatedAt: deps.timeGateway.now().toISOString(),
       }),
     );
     await uow.outboxRepository.save(

--- a/back/src/domains/agency/use-cases/RegisterAgencyToConnectedUser.unit.test.ts
+++ b/back/src/domains/agency/use-cases/RegisterAgencyToConnectedUser.unit.test.ts
@@ -62,14 +62,16 @@ describe("RegisterAgencyToConnectedUser use case", () => {
 
   let registerAgencyToConnectedUser: RegisterAgencyToConnectedUser;
   let uow: InMemoryUnitOfWork;
-
+  let timeGateway: CustomTimeGateway;
   beforeEach(() => {
     uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
     registerAgencyToConnectedUser = makeRegisterAgencyToConnectedUser({
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
+        timeGateway,
         createNewEvent: makeCreateNewEvent({
-          timeGateway: new CustomTimeGateway(),
+          timeGateway,
           uuidGenerator: new TestUuidGenerator(),
         }),
       },
@@ -126,9 +128,14 @@ describe("RegisterAgencyToConnectedUser use case", () => {
 
       expectToEqual(uow.userRepository.users, [notFtUser, ftUser]);
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency1, {
-          [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency1)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
+          },
+        ),
         toAgencyWithRights(agency2, {}),
         toAgencyWithRights(agencyFt, {}),
       ]);
@@ -159,9 +166,14 @@ describe("RegisterAgencyToConnectedUser use case", () => {
         toAgencyWithRights(agency1, {
           [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
         }),
-        toAgencyWithRights(agency2, {
-          [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency2)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
+          },
+        ),
       ]);
       expectArraysToMatch(uow.outboxRepository.events, [
         {
@@ -183,12 +195,22 @@ describe("RegisterAgencyToConnectedUser use case", () => {
 
       expectToEqual(uow.userRepository.users, [notFtUser, ftUser]);
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency1, {
-          [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
-        }),
-        toAgencyWithRights(agency2, {
-          [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency1)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
+          },
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency2)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [notFtUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
+          },
+        ),
         toAgencyWithRights(agencyFt, {}),
       ]);
       expectObjectInArrayToMatch(uow.outboxRepository.events, [
@@ -210,9 +232,14 @@ describe("RegisterAgencyToConnectedUser use case", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         toAgencyWithRights(agency1, {}),
         toAgencyWithRights(agency2, {}),
-        toAgencyWithRights(agencyFt, {
-          [ftUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agencyFt)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [ftUser.id]: { roles: ["to-review"], isNotifiedByEmail: false },
+          },
+        ),
       ]);
       expectArraysToMatch(uow.outboxRepository.events, [
         {

--- a/back/src/domains/agency/use-cases/RemoveUserFromAgency.ts
+++ b/back/src/domains/agency/use-cases/RemoveUserFromAgency.ts
@@ -10,6 +10,7 @@ import {
 } from "../../connected-users/helpers/agencyRights.helper";
 import { throwIfNotAgencyAdminOrBackofficeAdmin } from "../../connected-users/helpers/authorization.helper";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 export type RemoveUserFromAgency = ReturnType<typeof makeRemoveUserFromAgency>;
@@ -17,7 +18,7 @@ export type RemoveUserFromAgency = ReturnType<typeof makeRemoveUserFromAgency>;
 export const makeRemoveUserFromAgency = useCaseBuilder("RemoveUserFromAgency")
   .withInput<WithAgencyIdAndUserId>(withAgencyIdAndUserIdSchema)
   .withCurrentUser<ConnectedUser>()
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(
     async ({ currentUser, uow, inputParams: { agencyId, userId }, deps }) => {
       const isUserHimself = currentUser.id === userId;
@@ -50,6 +51,7 @@ export const makeRemoveUserFromAgency = useCaseBuilder("RemoveUserFromAgency")
         id: agency.id,
         status: agency.status,
         usersRights,
+        updatedAt: deps.timeGateway.now().toISOString(),
       });
 
       await uow.outboxRepository.save(

--- a/back/src/domains/agency/use-cases/RemoveUserFromAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/RemoveUserFromAgency.unit.test.ts
@@ -63,15 +63,18 @@ describe("RemoveUserFromAgency", () => {
 
   let uow: InMemoryUnitOfWork;
   let removeUserFromAgency: RemoveUserFromAgency;
+  let timeGateway: CustomTimeGateway;
 
   beforeEach(() => {
     uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
     removeUserFromAgency = makeRemoveUserFromAgency({
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
+        timeGateway,
         createNewEvent: makeCreateNewEvent({
           uuidGenerator: new TestUuidGenerator(),
-          timeGateway: new CustomTimeGateway(),
+          timeGateway,
         }),
       },
     });
@@ -327,12 +330,17 @@ describe("RemoveUserFromAgency", () => {
         await removeUserFromAgency.execute(inputParams, notAdmin);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [otherUserWithRightOnAgencies.id]: {
-              roles: ["validator"],
-              isNotifiedByEmail: true,
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [otherUserWithRightOnAgencies.id]: {
+                roles: ["validator"],
+                isNotifiedByEmail: true,
+              },
             },
-          }),
+          ),
           toAgencyWithRights(agency2, {
             [notAdminUser.id]: {
               roles: ["validator"],
@@ -410,12 +418,17 @@ describe("RemoveUserFromAgency", () => {
         await removeUserFromAgency.execute(inputParams, user);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [otherUserWithRightOnAgencies.id]: {
-              roles: ["validator"],
-              isNotifiedByEmail: true,
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [otherUserWithRightOnAgencies.id]: {
+                roles: ["validator"],
+                isNotifiedByEmail: true,
+              },
             },
-          }),
+          ),
           toAgencyWithRights(agency2, {
             [notAdminUser.id]: {
               roles: ["validator"],

--- a/back/src/domains/agency/use-cases/UpdateAgency.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgency.ts
@@ -14,7 +14,9 @@ import {
   throwIfNotAgencyAdminOrBackofficeAdmin,
 } from "../../connected-users/helpers/authorization.helper";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
+import type { PartialAgencyWithUsersRights } from "../ports/AgencyRepository";
 
 const hasAgencyAdmin = (usersRights: AgencyUsersRights): boolean =>
   Object.values(usersRights).some((right) =>
@@ -37,7 +39,10 @@ const getStatusChangedEventTopic = (
     ? undefined
     : statusChangedEventTopicByStatus[nextStatus];
 
-const toAgencyForRepositoryUpdate = (agency: AgencyDto) => {
+const toAgencyForRepositoryUpdate = (
+  agency: AgencyDto,
+  now: Date,
+): PartialAgencyWithUsersRights => {
   const {
     validatorEmails: _,
     counsellorEmails: __,
@@ -49,6 +54,7 @@ const toAgencyForRepositoryUpdate = (agency: AgencyDto) => {
     statusJustification: closedOrRejectedAgencyStatuses.includes(agency.status)
       ? agency.statusJustification
       : null,
+    updatedAt: now.toISOString(),
   };
 };
 
@@ -56,7 +62,7 @@ export type UpdateAgency = ReturnType<typeof makeUpdateAgency>;
 export const makeUpdateAgency = useCaseBuilder("UpdateAgency")
   .withInput(agencySchema)
   .withCurrentUser<ConnectedUser>()
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(async ({ uow, currentUser, deps, inputParams: agency }) => {
     const existingAgency = await uow.agencyRepository.getById(agency.id);
     if (!existingAgency) throw errors.agency.notFound({ agencyId: agency.id });
@@ -94,7 +100,9 @@ export const makeUpdateAgency = useCaseBuilder("UpdateAgency")
       );
     }
 
-    await uow.agencyRepository.update(toAgencyForRepositoryUpdate(agency));
+    await uow.agencyRepository.update(
+      toAgencyForRepositoryUpdate(agency, deps.timeGateway.now()),
+    );
 
     const triggeredBy = {
       kind: "connected-user" as const,

--- a/back/src/domains/agency/use-cases/UpdateAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgency.unit.test.ts
@@ -55,15 +55,17 @@ describe("Update agency", () => {
 
   let uow: InMemoryUnitOfWork;
   let updateAgency: UpdateAgency;
+  let timeGateway: CustomTimeGateway;
 
   beforeEach(() => {
+    timeGateway = new CustomTimeGateway();
     uow = createInMemoryUow();
-    uow.userRepository.users = [admin, notAdmin];
     updateAgency = makeUpdateAgency({
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
+        timeGateway,
         createNewEvent: makeCreateNewEvent({
-          timeGateway: new CustomTimeGateway(),
+          timeGateway,
           uuidGenerator: new TestUuidGenerator([
             "event-uuid-1",
             "event-uuid-2",
@@ -72,6 +74,8 @@ describe("Update agency", () => {
         }),
       },
     });
+
+    uow.userRepository.users = [admin, notAdmin];
   });
 
   describe("Wrong path", () => {
@@ -185,6 +189,7 @@ describe("Update agency", () => {
       toAgencyWithRights(
         new AgencyDtoBuilder(initialAgencyInRepo)
           .withName("L'agence modifié")
+          .withUpdatedAt(timeGateway.now())
           .build(),
         {},
       ),
@@ -348,7 +353,10 @@ describe("Update agency", () => {
       );
 
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(closedAgency, usersRightsWithAdmin),
+        toAgencyWithRights(
+          { ...closedAgency, updatedAt: timeGateway.now().toISOString() },
+          usersRightsWithAdmin,
+        ),
       ]);
       expectArraysToMatch(uow.outboxRepository.events, [
         {
@@ -468,7 +476,10 @@ describe("Update agency", () => {
     );
 
     expectToEqual(uow.agencyRepository.agencies, [
-      toAgencyWithRights(updatedAgency, {}),
+      toAgencyWithRights(
+        { ...updatedAgency, updatedAt: timeGateway.now().toISOString() },
+        {},
+      ),
     ]);
   });
 });

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.ts
@@ -8,6 +8,7 @@ import {
   withAgencyIdSchema,
 } from "shared";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 
 export type UpdateAgencyReferringToUpdatedAgency = ReturnType<
@@ -17,7 +18,7 @@ export const makeUpdateAgencyReferringToUpdatedAgency = useCaseBuilder(
   "UpdateAgencyReferringToUpdatedAgency",
 )
   .withInput(withAgencyIdSchema)
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(async ({ uow, deps, inputParams }) => {
     const updatedAgency = await uow.agencyRepository.getById(
       inputParams.agencyId,
@@ -35,6 +36,7 @@ export const makeUpdateAgencyReferringToUpdatedAgency = useCaseBuilder(
           id,
           status,
           usersRights: updateRights(usersRights, updatedAgency),
+          updatedAt: deps.timeGateway.now().toISOString(),
         });
         await uow.outboxRepository.save(
           deps.createNewEvent({

--- a/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.unit.test.ts
+++ b/back/src/domains/agency/use-cases/UpdateAgencyReferringToUpdatedAgency.unit.test.ts
@@ -2,14 +2,12 @@ import {
   AgencyDtoBuilder,
   ConnectedUserBuilder,
   errors,
+  expectObjectInArrayToMatch,
   expectPromiseToFailWithError,
   expectToEqual,
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
-import {
-  type CreateNewEvent,
-  makeCreateNewEvent,
-} from "../../core/events/ports/EventBus";
+import { makeCreateNewEvent } from "../../core/events/ports/EventBus";
 import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
@@ -70,21 +68,22 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
 
   let uow: InMemoryUnitOfWork;
   let updateAgencyReferringToUpdatedAgency: UpdateAgencyReferringToUpdatedAgency;
-  let createNewEvent: CreateNewEvent;
   let uuidGenerator: TestUuidGenerator;
+  let timeGateway: CustomTimeGateway;
 
   beforeEach(() => {
     uow = createInMemoryUow();
     uuidGenerator = new TestUuidGenerator();
-    createNewEvent = makeCreateNewEvent({
-      timeGateway: new CustomTimeGateway(),
-      uuidGenerator,
-    });
+    timeGateway = new CustomTimeGateway();
     updateAgencyReferringToUpdatedAgency =
       makeUpdateAgencyReferringToUpdatedAgency({
         uowPerformer: new InMemoryUowPerformer(uow),
         deps: {
-          createNewEvent,
+          timeGateway,
+          createNewEvent: makeCreateNewEvent({
+            timeGateway,
+            uuidGenerator,
+          }),
         },
       });
   });
@@ -143,45 +142,53 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
             isNotifiedByEmail: false,
           },
         }),
-        toAgencyWithRights(agency2RefersToUpdatedAgency, {
-          [updatedUser.id]: { roles: ["validator"], isNotifiedByEmail: true },
-          [notUpdatedUser.id]: {
-            roles: ["counsellor", "validator"],
-            isNotifiedByEmail: false,
+        toAgencyWithRights(
+          {
+            ...agency2RefersToUpdatedAgency,
+            updatedAt: timeGateway.now().toISOString(),
           },
-        }),
-        toAgencyWithRights(agency3RefersToUpdatedAgency, {
-          [updatedUser.id]: { roles: ["validator"], isNotifiedByEmail: true },
-          [notUpdatedUser.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: false,
+          {
+            [updatedUser.id]: { roles: ["validator"], isNotifiedByEmail: true },
+            [notUpdatedUser.id]: {
+              roles: ["counsellor", "validator"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
+        ),
+        toAgencyWithRights(
+          {
+            ...agency3RefersToUpdatedAgency,
+            updatedAt: timeGateway.now().toISOString(),
+          },
+          {
+            [updatedUser.id]: { roles: ["validator"], isNotifiedByEmail: true },
+            [notUpdatedUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
+          },
+        ),
       ]);
 
-      expectToEqual(uow.outboxRepository.events, [
+      expectObjectInArrayToMatch(uow.outboxRepository.events, [
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency2RefersToUpdatedAgency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency2RefersToUpdatedAgency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
+          },
           id: "event1",
         },
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency3RefersToUpdatedAgency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency3RefersToUpdatedAgency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
+          },
           id: "event2",
         },
       ]);
@@ -225,49 +232,60 @@ describe("UpdateAgencyReferingToUpdatedAgency", () => {
           [updatedUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
         }),
         toAgencyWithRights(updatedAgency, {
-          [updatedUser.id]: { roles: ["counsellor"], isNotifiedByEmail: true },
+          [updatedUser.id]: {
+            roles: ["counsellor"],
+            isNotifiedByEmail: true,
+          },
           [notUpdatedUser.id]: {
             roles: ["validator"],
             isNotifiedByEmail: false,
           },
         }),
-        toAgencyWithRights(agency2RefersToUpdatedAgency, {
-          [notUpdatedUser.id]: {
-            roles: ["counsellor", "validator"],
-            isNotifiedByEmail: false,
+        toAgencyWithRights(
+          {
+            ...agency2RefersToUpdatedAgency,
+            updatedAt: timeGateway.now().toISOString(),
           },
-        }),
-        toAgencyWithRights(agency3RefersToUpdatedAgency, {
-          [notUpdatedUser.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: false,
+          {
+            [notUpdatedUser.id]: {
+              roles: ["counsellor", "validator"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
+        ),
+        toAgencyWithRights(
+          {
+            ...agency3RefersToUpdatedAgency,
+            updatedAt: timeGateway.now().toISOString(),
+          },
+          {
+            [notUpdatedUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
+          },
+        ),
       ]);
 
-      expectToEqual(uow.outboxRepository.events, [
+      expectObjectInArrayToMatch(uow.outboxRepository.events, [
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency2RefersToUpdatedAgency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency2RefersToUpdatedAgency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
+          },
           id: "event1",
         },
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency3RefersToUpdatedAgency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency3RefersToUpdatedAgency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
+          },
           id: "event2",
         },
       ]);

--- a/back/src/domains/connected-users/use-cases/CreateUserForAgency.ts
+++ b/back/src/domains/connected-users/use-cases/CreateUserForAgency.ts
@@ -80,6 +80,7 @@ export const makeCreateUserForAgency = useCaseBuilder("CreateUserForAgency")
       id: agency.id,
       status: agency.status,
       usersRights: updatedAgencyRights,
+      updatedAt: deps.timeGateway.now().toISOString(),
     });
     await uow.outboxRepository.save(
       deps.createNewEvent({

--- a/back/src/domains/connected-users/use-cases/CreateUserForAgency.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/CreateUserForAgency.unit.test.ts
@@ -305,17 +305,22 @@ describe("CreateUserForAgency", () => {
       },
     ]);
     expectToEqual(uow.agencyRepository.agencies, [
-      toAgencyWithRights(agencyWithCounsellor, {
-        [validator.id]: {
-          isNotifiedByEmail: true,
-          roles: ["validator"],
+      toAgencyWithRights(
+        new AgencyDtoBuilder(agencyWithCounsellor)
+          .withUpdatedAt(timeGateway.now())
+          .build(),
+        {
+          [validator.id]: {
+            isNotifiedByEmail: true,
+            roles: ["validator"],
+          },
+          [counsellor.id]: {
+            isNotifiedByEmail: true,
+            roles: ["counsellor"],
+          },
+          [newUserId]: { isNotifiedByEmail: false, roles: ["counsellor"] },
         },
-        [counsellor.id]: {
-          isNotifiedByEmail: true,
-          roles: ["counsellor"],
-        },
-        [newUserId]: { isNotifiedByEmail: false, roles: ["counsellor"] },
-      }),
+      ),
     ]);
 
     expectToEqual(uow.outboxRepository.events, [
@@ -390,17 +395,22 @@ describe("CreateUserForAgency", () => {
     await createUserForAgency.execute(userForAgency, triggeredByUser);
 
     expectToEqual(uow.agencyRepository.agencies, [
-      toAgencyWithRights(agencyWithCounsellor, {
-        [counsellor.id]: { isNotifiedByEmail: true, roles: ["counsellor"] },
-        [connectedAgencyAdminUser.id]: {
-          isNotifiedByEmail: true,
-          roles: ["agency-admin", "validator"],
+      toAgencyWithRights(
+        new AgencyDtoBuilder(agencyWithCounsellor)
+          .withUpdatedAt(timeGateway.now())
+          .build(),
+        {
+          [counsellor.id]: { isNotifiedByEmail: true, roles: ["counsellor"] },
+          [connectedAgencyAdminUser.id]: {
+            isNotifiedByEmail: true,
+            roles: ["agency-admin", "validator"],
+          },
+          [validator.id]: {
+            isNotifiedByEmail: userForAgency.isNotifiedByEmail,
+            roles: userForAgency.roles,
+          },
         },
-        [validator.id]: {
-          isNotifiedByEmail: userForAgency.isNotifiedByEmail,
-          roles: userForAgency.roles,
-        },
-      }),
+      ),
       toAgencyWithRights(anotherAgency, {
         [counsellor.id]: { isNotifiedByEmail: false, roles: ["counsellor"] },
         [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },

--- a/back/src/domains/connected-users/use-cases/DeleteUser.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.ts
@@ -54,6 +54,8 @@ export const makeDeleteUser = useCaseBuilder("DeleteUser")
   .withInput(deleteUserInputSchema)
   .build(
     async ({ uow, deps: { createNewEvent, timeGateway }, inputParams }) => {
+      const now = timeGateway.now();
+
       if (inputParams.triggeredBy?.kind !== "crawler")
         throw errors.user.forbiddenNotTriggeredByCrawler();
 
@@ -85,11 +87,14 @@ export const makeDeleteUser = useCaseBuilder("DeleteUser")
       await executeInSequence(updatedEstablishments, (establishment) =>
         uow.establishmentAggregateRepository.updateEstablishmentAggregate(
           establishment,
-          timeGateway.now(),
+          now,
         ),
       );
       await executeInSequence(updatedAgencies, (agency) =>
-        uow.agencyRepository.update(agency),
+        uow.agencyRepository.update({
+          ...agency,
+          updatedAt: now.toISOString(),
+        }),
       );
       await uow.userRepository.delete(userToDelete.id);
       await uow.outboxRepository.saveNewEventsBatch(

--- a/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/DeleteUser.unit.test.ts
@@ -442,10 +442,21 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin1.id]: { isNotifiedByEmail: false, roles: ["agency-admin"] },
-            [validator1.id]: { isNotifiedByEmail: true, roles: ["validator"] },
-          }),
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin1.id]: {
+                isNotifiedByEmail: false,
+                roles: ["agency-admin"],
+              },
+              [validator1.id]: {
+                isNotifiedByEmail: true,
+                roles: ["validator"],
+              },
+            },
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -489,13 +500,21 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin1.id]: { isNotifiedByEmail: false, roles: ["agency-admin"] },
-            [validator2.id]: {
-              isNotifiedByEmail: true,
-              roles: ["validator"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin1.id]: {
+                isNotifiedByEmail: false,
+                roles: ["agency-admin"],
+              },
+              [validator2.id]: {
+                isNotifiedByEmail: true,
+                roles: ["validator"],
+              },
             },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -539,13 +558,21 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin1.id]: { isNotifiedByEmail: false, roles: ["agency-admin"] },
-            [validator2.id]: {
-              isNotifiedByEmail: true,
-              roles: ["validator"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin1.id]: {
+                isNotifiedByEmail: false,
+                roles: ["agency-admin"],
+              },
+              [validator2.id]: {
+                isNotifiedByEmail: true,
+                roles: ["validator"],
+              },
             },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -585,12 +612,17 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin1.id]: {
-              isNotifiedByEmail: true,
-              roles: ["agency-admin", "validator"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin1.id]: {
+                isNotifiedByEmail: true,
+                roles: ["agency-admin", "validator"],
+              },
             },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -637,6 +669,7 @@ describe("DeleteUser", () => {
             new AgencyDtoBuilder(agency)
               .withStatus("rejected")
               .withStatusJustification("Aucun utilisateur actif")
+              .withUpdatedAt(timeGateway.now())
               .build(),
             {
               [readOnlyAndCounsellor.id]: {
@@ -698,16 +731,21 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin2.id]: {
-              isNotifiedByEmail: false,
-              roles: ["agency-admin"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin2.id]: {
+                isNotifiedByEmail: false,
+                roles: ["agency-admin"],
+              },
+              [validator1.id]: {
+                isNotifiedByEmail: true,
+                roles: ["validator"],
+              },
             },
-            [validator1.id]: {
-              isNotifiedByEmail: true,
-              roles: ["validator"],
-            },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -750,12 +788,17 @@ describe("DeleteUser", () => {
         ]);
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [validator1.id]: {
-              isNotifiedByEmail: true,
-              roles: ["validator", "agency-admin"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [validator1.id]: {
+                isNotifiedByEmail: true,
+                roles: ["validator", "agency-admin"],
+              },
             },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [
@@ -801,6 +844,7 @@ describe("DeleteUser", () => {
             new AgencyDtoBuilder(agency)
               .withStatus("rejected")
               .withStatusJustification("Aucun utilisateur actif")
+              .withUpdatedAt(timeGateway.now())
               .build(),
             {
               [readOnlyAndCounsellor.id]: {
@@ -858,6 +902,7 @@ describe("DeleteUser", () => {
             new AgencyDtoBuilder(agency)
               .withStatus("closed")
               .withStatusJustification("Aucun utilisateur actif")
+              .withUpdatedAt(timeGateway.now())
               .build(),
             {},
           ),
@@ -913,6 +958,7 @@ describe("DeleteUser", () => {
             new AgencyDtoBuilder(agency)
               .withStatus("closed")
               .withStatusJustification("Aucun utilisateur actif")
+              .withUpdatedAt(timeGateway.now())
               .build(),
             {
               [readOnlyAndCounsellor.id]: {
@@ -974,6 +1020,7 @@ describe("DeleteUser", () => {
           toAgencyWithRights(
             {
               ...rejectedAgency,
+              updatedAt: timeGateway.now().toISOString(),
               statusJustification: "Aucun utilisateur actif",
             },
             {},
@@ -1062,12 +1109,17 @@ describe("DeleteUser", () => {
         );
 
         expectToEqual(uow.agencyRepository.agencies, [
-          toAgencyWithRights(agency, {
-            [admin1.id]: {
-              isNotifiedByEmail: true,
-              roles: ["agency-admin", "validator"],
+          toAgencyWithRights(
+            new AgencyDtoBuilder(agency)
+              .withUpdatedAt(timeGateway.now())
+              .build(),
+            {
+              [admin1.id]: {
+                isNotifiedByEmail: true,
+                roles: ["agency-admin", "validator"],
+              },
             },
-          }),
+          ),
         ]);
 
         expectArraysToMatch(uow.outboxRepository.events, [

--- a/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.ts
+++ b/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.ts
@@ -16,6 +16,7 @@ import {
   updateRightsOnMultipleAgenciesForUser,
 } from "../../../utils/agency";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 import { getUserWithRights } from "../helpers/userRights.helper";
@@ -41,6 +42,7 @@ export const makeLinkFranceTravailUsersToTheirAgencies = useCaseBuilder(
   .withOutput<void>()
   .withDeps<{
     createNewEvent: CreateNewEvent;
+    timeGateway: TimeGateway;
   }>()
   .build(async ({ uow, deps, inputParams: { userId, codeSafir } }) => {
     if (!codeSafir) return;
@@ -49,6 +51,7 @@ export const makeLinkFranceTravailUsersToTheirAgencies = useCaseBuilder(
 
     const agenciesWithSafir =
       await uow.agencyRepository.getBySafirAndActiveStatus(codeSafir);
+    const now = deps.timeGateway.now();
 
     if (agenciesWithSafir.length) {
       await executeInSequence(agenciesWithSafir, (agencyWithSafir) =>
@@ -57,6 +60,7 @@ export const makeLinkFranceTravailUsersToTheirAgencies = useCaseBuilder(
           agencyWithSafir,
           userId,
           deps.createNewEvent,
+          now,
         ),
       );
       return;
@@ -64,7 +68,8 @@ export const makeLinkFranceTravailUsersToTheirAgencies = useCaseBuilder(
 
     const groupWithSafir =
       await uow.agencyGroupRepository.getByCodeSafir(codeSafir);
-    if (groupWithSafir) return updateAgenciesOfGroup(uow, groupWithSafir, user);
+    if (groupWithSafir)
+      return updateAgenciesOfGroup(uow, groupWithSafir, user, now);
   });
 
 const isIcUserAlreadyHasValidRight = (
@@ -81,6 +86,7 @@ const updateActiveAgencyWithSafir = async (
   agencyWithSafir: AgencyWithUsersRights,
   userId: string,
   createNewEvent: CreateNewEvent,
+  now: Date,
 ): Promise<void> => {
   await uow.agencyRepository.update({
     id: agencyWithSafir.id,
@@ -89,6 +95,7 @@ const updateActiveAgencyWithSafir = async (
       ...agencyWithSafir.usersRights,
       [userId]: { roles: ["validator"], isNotifiedByEmail: false },
     },
+    updatedAt: now.toISOString(),
   });
   await uow.outboxRepository.save(
     createNewEvent({
@@ -107,6 +114,7 @@ const updateAgenciesOfGroup = async (
   uow: UnitOfWork,
   agencyGroupWithSafir: AgencyGroup,
   user: UserWithRights,
+  now: Date,
 ): Promise<void> => {
   const agenciesRelatedToGroup = await uow.agencyRepository.getByIds(
     agencyGroupWithSafir.agencyIds,
@@ -156,5 +164,6 @@ const updateAgenciesOfGroup = async (
     uow,
     userId: user.id,
     agenciesRightForUser: agencyRightsForUser,
+    now,
   });
 };

--- a/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/LinkFranceTravailUsersToTheirAgencies.unit.test.ts
@@ -2,14 +2,12 @@ import {
   AgencyDtoBuilder,
   type AgencyGroup,
   defaultProConnectInfos,
+  expectObjectInArrayToMatch,
   expectToEqual,
   type User,
 } from "shared";
 import { toAgencyWithRights } from "../../../utils/agency";
-import {
-  type CreateNewEvent,
-  makeCreateNewEvent,
-} from "../../core/events/ports/EventBus";
+import { makeCreateNewEvent } from "../../core/events/ports/EventBus";
 import { CustomTimeGateway } from "../../core/time-gateway/adapters/CustomTimeGateway";
 import {
   createInMemoryUow,
@@ -63,23 +61,24 @@ describe("LinkFranceTravailUsersToTheirAgencies", () => {
     createdAt: new Date().toISOString(),
   };
 
-  let createNewEvent: CreateNewEvent;
   let uow: InMemoryUnitOfWork;
   let linkFranceTravailUsersToTheirAgencies: LinkFranceTravailUsersToTheirAgencies;
+  let timeGateway: CustomTimeGateway;
 
   beforeEach(() => {
     uow = createInMemoryUow();
+    timeGateway = new CustomTimeGateway();
     const uuidGenerator = new TestUuidGenerator();
     uuidGenerator.setNextUuids(["event-uuid-1", "event-uuid-2"]);
-    createNewEvent = makeCreateNewEvent({
-      timeGateway: new CustomTimeGateway(),
-      uuidGenerator,
-    });
     linkFranceTravailUsersToTheirAgencies =
       makeLinkFranceTravailUsersToTheirAgencies({
         uowPerformer: new InMemoryUowPerformer(uow),
         deps: {
-          createNewEvent,
+          createNewEvent: makeCreateNewEvent({
+            timeGateway: timeGateway,
+            uuidGenerator: uuidGenerator,
+          }),
+          timeGateway,
         },
       });
     uow.userRepository.users = [defaultUser];
@@ -111,40 +110,48 @@ describe("LinkFranceTravailUsersToTheirAgencies", () => {
       });
 
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [defaultUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
-        }),
-        toAgencyWithRights(agencyWithSameSafir, {
-          [defaultUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [defaultUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
+          },
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agencyWithSameSafir)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
+          },
+        ),
         toAgencyWithRights(agency1InGroup),
         toAgencyWithRights(agency2InGroup),
         toAgencyWithRights(agency3InGroup),
       ]);
-      expectToEqual(uow.outboxRepository.events, [
+      expectObjectInArrayToMatch(uow.outboxRepository.events, [
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
-          id: "event-uuid-1",
+          },
         },
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agencyWithSameSafir.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agencyWithSameSafir.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
-          id: "event-uuid-2",
+          },
         },
       ]);
     });
@@ -221,46 +228,48 @@ describe("LinkFranceTravailUsersToTheirAgencies", () => {
 
       expectToEqual(uow.userRepository.users, [defaultUser]);
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [defaultUser.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: false,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [defaultUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
-        toAgencyWithRights(agencyWithSameSafir, {
-          [defaultUser.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: false,
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agencyWithSameSafir)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
+        ),
         toAgencyWithRights(agency1InGroup),
         toAgencyWithRights(agency2InGroup),
         toAgencyWithRights(agency3InGroup),
       ]);
-      expectToEqual(uow.outboxRepository.events, [
+      expectObjectInArrayToMatch(uow.outboxRepository.events, [
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agency.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agency.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
-          id: "event-uuid-1",
+          },
         },
         {
-          ...createNewEvent({
-            topic: "AgencyUpdated",
-            payload: {
-              agencyId: agencyWithSameSafir.id,
-              triggeredBy: {
-                kind: "crawler",
-              },
+          topic: "AgencyUpdated",
+          payload: {
+            agencyId: agencyWithSameSafir.id,
+            triggeredBy: {
+              kind: "crawler",
             },
-          }),
-          id: "event-uuid-2",
+          },
         },
       ]);
     });
@@ -342,24 +351,39 @@ describe("LinkFranceTravailUsersToTheirAgencies", () => {
       expectToEqual(uow.agencyRepository.agencies, [
         toAgencyWithRights(agency),
         toAgencyWithRights(agencyWithSameSafir),
-        toAgencyWithRights(agency1InGroup, {
-          [defaultUser.id]: {
-            roles: ["agency-viewer"],
-            isNotifiedByEmail: false,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency1InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["agency-viewer"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
-        toAgencyWithRights(agency2InGroup, {
-          [defaultUser.id]: {
-            roles: ["agency-viewer"],
-            isNotifiedByEmail: false,
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency2InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["agency-viewer"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
-        toAgencyWithRights(agency3InGroup, {
-          [defaultUser.id]: {
-            roles: ["agency-viewer"],
-            isNotifiedByEmail: false,
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency3InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["agency-viewer"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
+        ),
       ]);
     });
 
@@ -390,24 +414,39 @@ describe("LinkFranceTravailUsersToTheirAgencies", () => {
 
       expectToEqual(uow.agencyRepository.agencies, [
         toAgencyWithRights(agency),
-        toAgencyWithRights(agency1InGroup, {
-          [defaultUser.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: false,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency1InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
-        toAgencyWithRights(agency2InGroup, {
-          [defaultUser.id]: {
-            roles: ["agency-viewer"],
-            isNotifiedByEmail: false,
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency2InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["agency-viewer"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
-        toAgencyWithRights(agency3InGroup, {
-          [defaultUser.id]: {
-            roles: ["agency-viewer"],
-            isNotifiedByEmail: false,
+        ),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency3InGroup)
+            .withUpdatedAt(timeGateway.now())
+            .build(),
+          {
+            [defaultUser.id]: {
+              roles: ["agency-viewer"],
+              isNotifiedByEmail: false,
+            },
           },
-        }),
+        ),
       ]);
     });
 

--- a/back/src/domains/connected-users/use-cases/RejectUserForAgency.ts
+++ b/back/src/domains/connected-users/use-cases/RejectUserForAgency.ts
@@ -4,6 +4,7 @@ import {
   rejectIcUserRoleForAgencyParamsSchema,
 } from "shared";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 import { throwIfNotAgencyAdminOrBackofficeAdmin } from "../helpers/authorization.helper";
 
@@ -14,6 +15,7 @@ export const makeRejectUserForAgency = useCaseBuilder("RejectUserForAgency")
   .withCurrentUser<ConnectedUser>()
   .withDeps<{
     createNewEvent: CreateNewEvent;
+    timeGateway: TimeGateway;
   }>()
   .build(async ({ uow, currentUser, deps, inputParams }) => {
     throwIfNotAgencyAdminOrBackofficeAdmin({
@@ -36,6 +38,7 @@ export const makeRejectUserForAgency = useCaseBuilder("RejectUserForAgency")
       id: agency.id,
       status: agency.status,
       usersRights: updatedUserRights,
+      updatedAt: deps.timeGateway.now().toISOString(),
     });
     await uow.outboxRepository.save(
       deps.createNewEvent({

--- a/back/src/domains/connected-users/use-cases/RejectUserForAgency.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/RejectUserForAgency.unit.test.ts
@@ -83,6 +83,7 @@ describe("RejectUserForAgency", () => {
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
         createNewEvent: makeCreateNewEvent({ timeGateway, uuidGenerator }),
+        timeGateway,
       },
     });
 
@@ -196,9 +197,6 @@ describe("RejectUserForAgency", () => {
     currentUser,
     usersInRepo,
   }) => {
-    const now = new Date("2023-11-07");
-    timeGateway.setNextDate(now);
-
     uow.agencyRepository.agencies = [
       toAgencyWithRights(agency1, {
         [user.id]: { roles: ["to-review"], isNotifiedByEmail: false },
@@ -221,9 +219,12 @@ describe("RejectUserForAgency", () => {
     );
 
     expectToEqual(uow.agencyRepository.agencies, [
-      toAgencyWithRights(agency1, {
-        [notAdmin.id]: { roles: ["validator"], isNotifiedByEmail: false },
-      }),
+      toAgencyWithRights(
+        new AgencyDtoBuilder(agency1).withUpdatedAt(timeGateway.now()).build(),
+        {
+          [notAdmin.id]: { roles: ["validator"], isNotifiedByEmail: false },
+        },
+      ),
       toAgencyWithRights(agency2, {
         [user.id]: { roles: ["to-review"], isNotifiedByEmail: false },
       }),
@@ -232,7 +233,7 @@ describe("RejectUserForAgency", () => {
     expectToEqual(uow.outboxRepository.events, [
       {
         id: uuidGenerator.new(),
-        occurredAt: now.toISOString(),
+        occurredAt: timeGateway.now().toISOString(),
         topic: "ConnectedUserAgencyRightRejected",
         payload: {
           userId: user.id,

--- a/back/src/domains/connected-users/use-cases/UpdateUserForAgency.ts
+++ b/back/src/domains/connected-users/use-cases/UpdateUserForAgency.ts
@@ -12,6 +12,7 @@ import {
 import { throwErrorIfAttemptToAddCounsellorRoleToFTAgency } from "../../../utils/agency";
 import type { UserRepository } from "../../core/authentication/connected-user/port/UserRepository";
 import type { CreateNewEvent } from "../../core/events/ports/EventBus";
+import type { TimeGateway } from "../../core/time-gateway/ports/TimeGateway";
 import type { UnitOfWork } from "../../core/unit-of-work/ports/UnitOfWork";
 import { useCaseBuilder } from "../../core/useCaseBuilder";
 import {
@@ -25,7 +26,7 @@ export type UpdateUserForAgency = ReturnType<typeof makeUpdateUserForAgency>;
 export const makeUpdateUserForAgency = useCaseBuilder("UpdateUserForAgency")
   .withInput(userParamsForAgencySchema)
   .withCurrentUser<ConnectedUser>()
-  .withDeps<{ createNewEvent: CreateNewEvent }>()
+  .withDeps<{ createNewEvent: CreateNewEvent; timeGateway: TimeGateway }>()
   .build(async ({ uow, currentUser, deps, inputParams }) => {
     const { isBackOfficeOrAgencyAdmin } = throwIfUserHasNoRightOnAgency(
       currentUser,
@@ -91,6 +92,7 @@ export const makeUpdateUserForAgency = useCaseBuilder("UpdateUserForAgency")
       id: agency.id,
       status: agency.status,
       usersRights: updatedRights,
+      updatedAt: deps.timeGateway.now().toISOString(),
     });
     await updateIfUserEmailChanged(
       userToUpdate,

--- a/back/src/domains/connected-users/use-cases/UpdateUserForAgency.unit.test.ts
+++ b/back/src/domains/connected-users/use-cases/UpdateUserForAgency.unit.test.ts
@@ -75,6 +75,7 @@ describe("UpdateUserForAgency", () => {
       uowPerformer: new InMemoryUowPerformer(uow),
       deps: {
         createNewEvent,
+        timeGateway,
       },
     });
   });
@@ -468,14 +469,20 @@ describe("UpdateUserForAgency", () => {
         counsellor,
       ]);
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [notAdminUser.id]: {
-            roles: userRoleForAgency.roles,
-            isNotifiedByEmail: userRoleForAgency.isNotifiedByEmail,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [notAdminUser.id]: {
+              roles: userRoleForAgency.roles,
+              isNotifiedByEmail: userRoleForAgency.isNotifiedByEmail,
+            },
+            [validator.id]: { roles: ["validator"], isNotifiedByEmail: true },
+            [counsellor.id]: {
+              roles: ["counsellor"],
+              isNotifiedByEmail: false,
+            },
           },
-          [validator.id]: { roles: ["validator"], isNotifiedByEmail: true },
-          [counsellor.id]: { roles: ["counsellor"], isNotifiedByEmail: false },
-        }),
+        ),
       ]);
       expectToEqual(uow.outboxRepository.events, [
         createNewEvent({
@@ -576,14 +583,20 @@ describe("UpdateUserForAgency", () => {
         notAdminUser,
       ]);
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [notAdminUser.id]: { isNotifiedByEmail: true, roles: ["counsellor"] },
-          [userWithNotif.id]: {
-            roles: ["validator"],
-            isNotifiedByEmail: true,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [notAdminUser.id]: {
+              isNotifiedByEmail: true,
+              roles: ["counsellor"],
+            },
+            [userWithNotif.id]: {
+              roles: ["validator"],
+              isNotifiedByEmail: true,
+            },
+            [userToUpdate.id]: { roles: [newRole], isNotifiedByEmail: false },
           },
-          [userToUpdate.id]: { roles: [newRole], isNotifiedByEmail: false },
-        }),
+        ),
       ]);
     });
 
@@ -634,16 +647,19 @@ describe("UpdateUserForAgency", () => {
         agencyAdminUser,
       ]);
       expectArraysToEqualIgnoringOrder(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [userToUpdate.id]: {
-            roles: [newRole, "validator"],
-            isNotifiedByEmail: true,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [userToUpdate.id]: {
+              roles: [newRole, "validator"],
+              isNotifiedByEmail: true,
+            },
+            [agencyAdminUser.id]: {
+              roles: ["agency-admin"],
+              isNotifiedByEmail: false,
+            },
           },
-          [agencyAdminUser.id]: {
-            roles: ["agency-admin"],
-            isNotifiedByEmail: false,
-          },
-        }),
+        ),
       ]);
     });
 
@@ -865,14 +881,22 @@ describe("UpdateUserForAgency", () => {
           );
 
           expectToEqual(uow.agencyRepository.agencies, [
-            toAgencyWithRights(agency, {
-              [user.id]: { roles: ["counsellor"], isNotifiedByEmail: false },
-              [counsellor.id]: {
-                roles: ["counsellor"],
-                isNotifiedByEmail: true,
+            toAgencyWithRights(
+              new AgencyDtoBuilder(agency)
+                .withUpdatedAt(timeGateway.now())
+                .build(),
+              {
+                [user.id]: { roles: ["counsellor"], isNotifiedByEmail: false },
+                [counsellor.id]: {
+                  roles: ["counsellor"],
+                  isNotifiedByEmail: true,
+                },
+                [validator.id]: {
+                  roles: ["validator"],
+                  isNotifiedByEmail: true,
+                },
               },
-              [validator.id]: { roles: ["validator"], isNotifiedByEmail: true },
-            }),
+            ),
           ]);
         });
       });
@@ -900,10 +924,21 @@ describe("UpdateUserForAgency", () => {
           );
 
           expectToEqual(uow.agencyRepository.agencies, [
-            toAgencyWithRights(agency, {
-              [user.id]: { roles: ["agency-viewer"], isNotifiedByEmail: false },
-              [validator.id]: { roles: ["validator"], isNotifiedByEmail: true },
-            }),
+            toAgencyWithRights(
+              new AgencyDtoBuilder(agency)
+                .withUpdatedAt(timeGateway.now())
+                .build(),
+              {
+                [user.id]: {
+                  roles: ["agency-viewer"],
+                  isNotifiedByEmail: false,
+                },
+                [validator.id]: {
+                  roles: ["validator"],
+                  isNotifiedByEmail: true,
+                },
+              },
+            ),
           ]);
         });
 
@@ -1102,10 +1137,13 @@ describe("UpdateUserForAgency", () => {
       );
 
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [nonIcUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
-          [admin.id]: { roles: ["validator"], isNotifiedByEmail: true },
-        }),
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [nonIcUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
+            [admin.id]: { roles: ["validator"], isNotifiedByEmail: true },
+          },
+        ),
       ]);
     });
 
@@ -1146,13 +1184,16 @@ describe("UpdateUserForAgency", () => {
       );
 
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [nonIcUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
-          [agencyAdmin.id]: {
-            roles: ["agency-admin", "validator"],
-            isNotifiedByEmail: true,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [nonIcUser.id]: { roles: ["validator"], isNotifiedByEmail: false },
+            [agencyAdmin.id]: {
+              roles: ["agency-admin", "validator"],
+              isNotifiedByEmail: true,
+            },
           },
-        }),
+        ),
       ]);
     });
 
@@ -1189,13 +1230,16 @@ describe("UpdateUserForAgency", () => {
       );
 
       expectToEqual(uow.agencyRepository.agencies, [
-        toAgencyWithRights(agency, {
-          [notAdmin.id]: { roles: ["validator"], isNotifiedByEmail: false },
-          [agencyAdmin.id]: {
-            roles: ["agency-admin", "validator"],
-            isNotifiedByEmail: true,
+        toAgencyWithRights(
+          new AgencyDtoBuilder(agency).withUpdatedAt(timeGateway.now()).build(),
+          {
+            [notAdmin.id]: { roles: ["validator"], isNotifiedByEmail: false },
+            [agencyAdmin.id]: {
+              roles: ["agency-admin", "validator"],
+              isNotifiedByEmail: true,
+            },
           },
-        }),
+        ),
       ]);
     });
   });

--- a/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
+++ b/back/src/domains/convention/use-cases/UpdateConventionStatus.unit.test.ts
@@ -264,7 +264,8 @@ describe("UpdateConventionStatus", () => {
           .build();
 
         uow.userRepository.users = [user];
-        await uow.agencyRepository.insert(agency);
+        uow.agencyRepository.agencies = [agency];
+
         uow.conventionRepository.setConventions([convention]);
 
         const validatorJwtPayload = createConventionMagicLinkPayload({

--- a/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompleted.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompleted.unit.test.ts
@@ -133,7 +133,7 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompl
       .withId("validator2")
       .buildUser();
     uow.userRepository.users = [validator, validator2];
-    await uow.agencyRepository.insert(
+    uow.agencyRepository.agencies = [
       toAgencyWithRights(agency, {
         [validator.id]: {
           isNotifiedByEmail: true,
@@ -141,7 +141,8 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompl
         },
         [validator2.id]: { isNotifiedByEmail: true, roles: ["validator"] },
       }),
-    );
+    ];
+
     await uow.conventionRepository.save(convention);
     await uow.assessmentRepository.save(
       createAssessmentEntity(signedAssessment, convention),
@@ -220,11 +221,12 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompl
   it("Do not send an email when assessment is not signed", async () => {
     uow.userRepository.users = [validator];
     await uow.conventionRepository.save(convention);
-    await uow.agencyRepository.insert(
+    uow.agencyRepository.agencies = [
       toAgencyWithRights(agency, {
         [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
       }),
-    );
+    ];
+
     const assessmentNotSigned: AssessmentDto = {
       ...signedAssessment,
       signedAt: null,
@@ -241,11 +243,11 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompl
   it("Do not send an email when assessment status is DID_NOT_SHOW", async () => {
     uow.userRepository.users = [validator];
     await uow.conventionRepository.save(convention);
-    await uow.agencyRepository.insert(
+    uow.agencyRepository.agencies = [
       toAgencyWithRights(agency, {
         [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
       }),
-    );
+    ];
     const assessmentDidNotShow: AssessmentDto = {
       conventionId: convention.id,
       status: "DID_NOT_SHOW",
@@ -295,11 +297,12 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusCompletedOrPartiallyCompl
 
     it("When beneficiary did the immersion, send an email to the advisor (and not to other agency users)", async () => {
       uow.userRepository.users = [validator];
-      await uow.agencyRepository.insert(
+      uow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
+
       await uow.conventionRepository.save(convention);
       await uow.assessmentRepository.save(
         createAssessmentEntity(signedAssessment, convention),

--- a/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow.unit.test.ts
+++ b/back/src/domains/convention/use-cases/notifications/NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow.unit.test.ts
@@ -116,7 +116,7 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow", () => {
         .withId("validator2")
         .buildUser();
       uow.userRepository.users = [validator, validator2];
-      await uow.agencyRepository.insert(
+      uow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: {
             isNotifiedByEmail: true,
@@ -124,7 +124,8 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow", () => {
           },
           [validator2.id]: { isNotifiedByEmail: false, roles: ["validator"] },
         }),
-      );
+      ];
+
       await uow.conventionRepository.save(convention);
 
       await notifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow.execute({
@@ -160,11 +161,12 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow", () => {
 
     it("Do not send an email when assessment status is not DID_NOT_SHOW", async () => {
       uow.userRepository.users = [validator];
-      await uow.agencyRepository.insert(
+      uow.agencyRepository.agencies = [
         toAgencyWithRights(agency, {
           [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
         }),
-      );
+      ];
+
       await uow.conventionRepository.save(convention);
 
       await notifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow.execute({
@@ -209,11 +211,12 @@ describe("NotifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow", () => {
 
       it("Send an email to the advisor (and not to other agency users)", async () => {
         uow.userRepository.users = [validator];
-        await uow.agencyRepository.insert(
+        uow.agencyRepository.agencies = [
           toAgencyWithRights(agency, {
             [validator.id]: { isNotifiedByEmail: true, roles: ["validator"] },
           }),
-        );
+        ];
+
         await uow.conventionRepository.save(convention);
 
         await notifyAgencyThatAssessmentIsCreatedWithStatusDidNotShow.execute({

--- a/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.ts
@@ -408,6 +408,7 @@ const makeNewOrUpdatedProConnectedUser = async ({
   if (conflictingUserFound) {
     await resolveConflictingUsers({
       uow,
+      now: deps.timeGateway.now(),
       userToKeepId: existingUserByExternalId.id,
       userToDeleteId: existingUserByEmail.id,
     });
@@ -436,10 +437,12 @@ const resolveConflictingUsers = async ({
   uow,
   userToKeepId,
   userToDeleteId,
+  now,
 }: {
   uow: UnitOfWork;
   userToKeepId: UserId;
   userToDeleteId: UserId;
+  now: Date;
 }): Promise<void> => {
   const userToDeleteAgencyRights =
     await uow.agencyRepository.getAgenciesRightsByUserId(userToDeleteId);
@@ -470,11 +473,11 @@ const resolveConflictingUsers = async ({
   }, []);
 
   await executeInSequence(newAgenciesRightForUser, (agencyRightsForUser) =>
-    updateAgencyRightsForUser(uow, userToKeepId, agencyRightsForUser),
+    updateAgencyRightsForUser(uow, userToKeepId, agencyRightsForUser, now),
   );
 
   await executeInSequence(userToDeleteAgencyRights, (agencyRightsForUser) =>
-    removeAgencyRightsForUser(uow, userToDeleteId, agencyRightsForUser),
+    removeAgencyRightsForUser(uow, userToDeleteId, agencyRightsForUser, now),
   );
 
   await uow.userRepository.delete(userToDeleteId);

--- a/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.unit.test.ts
+++ b/back/src/domains/core/authentication/connected-user/use-cases/AfterOAuthSuccess.unit.test.ts
@@ -323,6 +323,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
           expectToEqual(uow.agencyRepository.agencies, [
             {
               ...agency1,
+              updatedAt: timeGateway.now().toISOString(),
               usersRights: {
                 [initialUser.id]: {
                   isNotifiedByEmail: true,
@@ -332,6 +333,7 @@ describe("AfterOAuthSuccessRedirection use case", () => {
             },
             {
               ...agency2,
+              updatedAt: timeGateway.now().toISOString(),
               usersRights: {
                 [initialUser.id]: {
                   isNotifiedByEmail: true,

--- a/back/src/scripts/scheduledScripts/deleteOldClosedAgenciesWithoutConventions.ts
+++ b/back/src/scripts/scheduledScripts/deleteOldClosedAgenciesWithoutConventions.ts
@@ -1,31 +1,27 @@
-import { subMonths } from "date-fns";
 import { AppConfig } from "../../config/bootstrap/appConfig";
-import { makeKyselyDb } from "../../config/pg/kysely/kyselyUtils";
-import { createMakeScriptPgPool } from "../../config/pg/pgPool";
-import { PgAgencyRepository } from "../../domains/agency/adapters/PgAgencyRepository";
+import { createMakeProductionPgPool } from "../../config/pg/pgPool";
+import {
+  makeDeleteOldClosedAgenciesWithoutConventions,
+  numberOfMonthsBeforeDeletion,
+} from "../../domains/agency/use-cases/DeleteOldClosedAgenciesWithoutConventions";
+import { RealTimeGateway } from "../../domains/core/time-gateway/adapters/RealTimeGateway";
+import { createDbRelatedSystems } from "../../domains/core/unit-of-work/adapters/createDbRelatedSystems";
 import { createLogger } from "../../utils/logger";
 import { handleCRONScript } from "../handleCRONScript";
-import { monitoredAsUseCase } from "../utils";
 
 const logger = createLogger(__filename);
 const config = AppConfig.createFromEnv();
-const numberOfMonthsBeforeDeletion = 3;
 
 const deleteOldClosedAgenciesWithoutConventions = async () => {
-  const pool = createMakeScriptPgPool(config)();
-  const db = makeKyselyDb(pool);
-  const agencyRepository = new PgAgencyRepository(db);
+  const { uowPerformer } = createDbRelatedSystems(
+    config,
+    createMakeProductionPgPool(config),
+  );
 
-  const updatedBefore = subMonths(new Date(), numberOfMonthsBeforeDeletion);
-
-  const deletedAgencyIds =
-    await agencyRepository.deleteOldClosedAgenciesWithoutConventions({
-      updatedBefore,
-    });
-
-  const numberOfAgenciesDeleted = deletedAgencyIds.length;
-
-  return { numberOfAgenciesDeleted };
+  return makeDeleteOldClosedAgenciesWithoutConventions({
+    uowPerformer,
+    deps: { timeGateway: new RealTimeGateway() },
+  }).execute();
 };
 
 export const triggerDeleteOldClosedAgenciesWithoutConventions = ({
@@ -36,12 +32,9 @@ export const triggerDeleteOldClosedAgenciesWithoutConventions = ({
   handleCRONScript({
     name: "triggerDeleteOldClosedAgenciesWithoutConventions",
     config,
-    script: monitoredAsUseCase({
-      name: "DeleteOldClosedAgenciesWithoutConventions",
-      cb: deleteOldClosedAgenciesWithoutConventions,
-    }),
-    handleResults: ({ numberOfAgenciesDeleted }) =>
-      `${numberOfAgenciesDeleted} agencies were deleted, because they were more than ${numberOfMonthsBeforeDeletion} months old, had status closed or rejected, and had no conventions`,
+    script: deleteOldClosedAgenciesWithoutConventions,
+    handleResults: ({ deletedAgencies }) =>
+      `${deletedAgencies.length} agencies were deleted, because they were more than ${numberOfMonthsBeforeDeletion} months old, had status closed or rejected, and had no conventions`,
     logger,
     exitOnFinish,
   });

--- a/back/src/scripts/triggerAssignAgencyViewerRoleToUsers.ts
+++ b/back/src/scripts/triggerAssignAgencyViewerRoleToUsers.ts
@@ -3,6 +3,7 @@ import type { UserId } from "shared";
 import { AppConfig } from "../config/bootstrap/appConfig";
 import { createMakeProductionPgPool } from "../config/pg/pgPool";
 import { makeAssignAgencyViewerRole } from "../domains/agency/use-cases/AssignAgencyViewerRoleToUsers";
+import { RealTimeGateway } from "../domains/core/time-gateway/adapters/RealTimeGateway";
 import { createDbRelatedSystems } from "../domains/core/unit-of-work/adapters/createDbRelatedSystems";
 import { createLogger } from "../utils/logger";
 import { handleCRONScript } from "./handleCRONScript";
@@ -49,6 +50,7 @@ const executeAssignAgencyViewerRole = async () => {
 
   const assignAgencyViewerRoleUseCase = makeAssignAgencyViewerRole({
     uowPerformer,
+    deps: { timeGateway: new RealTimeGateway() },
   });
 
   return assignAgencyViewerRoleUseCase.execute({

--- a/back/src/utils/agency.ts
+++ b/back/src/utils/agency.ts
@@ -129,10 +129,12 @@ export const updateRightsOnMultipleAgenciesForUser = async ({
   uow,
   userId,
   agenciesRightForUser,
+  now,
 }: {
   uow: UnitOfWork;
   userId: UserId;
   agenciesRightForUser: AgencyRight[];
+  now: Date;
 }): Promise<void> => {
   await Promise.all(
     agenciesRightForUser.map(
@@ -141,6 +143,7 @@ export const updateRightsOnMultipleAgenciesForUser = async ({
         if (!agency) throw errors.agency.notFound({ agencyId: id });
         return uow.agencyRepository.update({
           id: agency.id,
+          updatedAt: now.toISOString(),
           status,
           usersRights: {
             ...agency.usersRights,

--- a/front/src/core-logic/adapters/AgencyGateway/SimulatedAgencyGateway.ts
+++ b/front/src/core-logic/adapters/AgencyGateway/SimulatedAgencyGateway.ts
@@ -95,6 +95,7 @@ export class SimulatedAgencyGateway implements AgencyGateway {
   public async addAgency(createAgencyDto: CreateAgencyDto) {
     this.#agencies[createAgencyDto.id] = {
       ...createAgencyDto,
+      updatedAt: new Date().toISOString(),
       status: "needsReview",
       codeSafir: null,
       statusJustification: null,

--- a/shared/src/agency/AgencyDtoBuilder.ts
+++ b/shared/src/agency/AgencyDtoBuilder.ts
@@ -32,6 +32,7 @@ const emptyAgency: AgencyDto = {
   id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
   name: "empty-name",
   createdAt: DATE_CREATION,
+  updatedAt: DATE_CREATION,
   status: "active",
   kind: "autre",
   counsellorEmails: [],
@@ -94,6 +95,13 @@ export class AgencyDtoBuilder implements Builder<AgencyDto> {
     return new AgencyDtoBuilder({
       ...this.#agency,
       createdAt,
+    });
+  }
+
+  public withUpdatedAt(updatedAt: Date) {
+    return new AgencyDtoBuilder({
+      ...this.#agency,
+      updatedAt: updatedAt.toISOString(),
     });
   }
 

--- a/shared/src/agency/agency.dto.ts
+++ b/shared/src/agency/agency.dto.ts
@@ -11,7 +11,7 @@ import type { SiretDto } from "../siret/siret";
 import type { Flavor } from "../typeFlavors";
 import type { UserId } from "../user/user.dto";
 import type { ExtractFromExisting, OmitFromExistingKeys } from "../utils";
-import type { DateString } from "../utils/date";
+import type { DateString, DateTimeIsoString } from "../utils/date";
 
 export type CodeSafir = Flavor<string, "CodeSafir">;
 export type AgencyStatus = (typeof allAgencyStatuses)[number];
@@ -68,7 +68,8 @@ export type AgencyDtoSensitiveFields = {
 export type WithAgencyDto = {
   agency: AgencyDto;
 };
-export type AgencyDto = CreateAgencyDto & AgencyDtoSensitiveFields;
+export type AgencyDto = CreateAgencyDto &
+  AgencyDtoSensitiveFields & { updatedAt: DateTimeIsoString };
 
 export type AgencyUserRight = {
   roles: AgencyRole[];

--- a/shared/src/agency/agency.schema.ts
+++ b/shared/src/agency/agency.schema.ts
@@ -9,7 +9,7 @@ import { phoneNumberSchema } from "../phone/phone.schema";
 import { allAgencyRoles } from "../role/role.dto";
 import { searchTextAlphaNumericSchema } from "../search/searchText.schema";
 import { siretSchema } from "../siret/siret.schema";
-import { makeDateStringSchema } from "../utils/date";
+import { dateTimeIsoStringSchema, makeDateStringSchema } from "../utils/date";
 import {
   stringWithMaxLength255,
   zStringMinLength1Max1024,
@@ -241,6 +241,7 @@ export const editAgencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
   .and(withCounsellorsAndValidatorsEmailsSchema)
   .and(
     z.object({
+      updatedAt: dateTimeIsoStringSchema,
       status: agencyStatusSchema,
       codeSafir: zStringMinLength1Max1024.or(z.null()),
       refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
@@ -272,6 +273,7 @@ export const agencyDtoForAgencyUsersAndAdminsSchema: ZodSchemaWithInputMatchingO
     .merge(
       z.object({
         agencySiret: siretSchema,
+        updatedAt: dateTimeIsoStringSchema,
         status: agencyStatusSchema,
         codeSafir: zStringMinLength1Max1024.or(z.null()),
         refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
@@ -289,6 +291,7 @@ export const agencySchema: ZodSchemaWithInputMatchingOutput<AgencyDto> = z
   .extend({
     agencySiret: siretSchema,
     status: agencyStatusSchema,
+    updatedAt: dateTimeIsoStringSchema,
     codeSafir: zStringMinLength1Max1024.or(z.null()),
     refersToAgencyId: refersToAgencyIdSchema.or(z.null()),
     refersToAgencyName: zStringMinLength1Max1024.or(z.null()),


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Un commit préparatoire pour ajouter la date d'update d'agence dans AgencyDto et s'assurer qu'on met bien à jour la date d'update à chaque modif d'agence.
Puis le commit qui retirer deleteoldclosedagencieswithoutconventions 
