### PR TITLE
#5599 - Correction de la requête sur les templates de convention (entreprises bannies)

### DIFF
--- a/back/src/domains/convention/adapters/PgConventionTemplateQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionTemplateQueries.integration.test.ts
@@ -87,7 +87,7 @@ describe("PgConventionTemplateQueries", () => {
         userId: validator.id,
         siret: bannedEstablishmentSiret,
       };
-      pgConventionTemplateQueries.upsert(
+      await pgConventionTemplateQueries.upsert(
         conventionTemplateForBannedEstablishment,
         now,
       );
@@ -104,6 +104,31 @@ describe("PgConventionTemplateQueries", () => {
       });
 
       expectToEqual(result, []);
+    });
+
+    it("returns convention templates even if no siret on convention", async () => {
+      const bannedEstablishmentSiret: SiretDto = "78000403200019";
+
+      await new PgBannedEstablishmentRepository(db).banEstablishment({
+        siret: bannedEstablishmentSiret,
+        establishmentBannishmentJustification: "whatever",
+      });
+      const conventionTemplateId = uuid();
+      const conventionTemplateWithoutSiret: ConventionTemplate = {
+        id: conventionTemplateId,
+        name: "Template without siret",
+        userId: validator.id,
+        internshipKind: "immersion",
+      };
+      await pgConventionTemplateQueries.upsert(
+        conventionTemplateWithoutSiret,
+        now,
+      );
+      const result = await pgConventionTemplateQueries.get({
+        ids: [conventionTemplateId],
+      });
+
+      expect(result).toHaveLength(1);
     });
 
     it("returns only templates for the given ids", async () => {

--- a/back/src/domains/convention/adapters/PgConventionTemplateQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionTemplateQueries.ts
@@ -38,16 +38,19 @@ export class PgConventionTemplateQueries implements ConventionTemplateQueries {
           "public_romes_data.code_rome",
           "public_appellations_data.code_rome",
         )
+        .leftJoin(
+          "banned_establishments",
+          "banned_establishments.siret",
+          "convention_templates.siret",
+        )
         .selectAll("convention_templates")
         .select([
           "public_appellations_data.ogr_appellation",
           "public_appellations_data.libelle_appellation_long",
           "public_appellations_data.code_rome",
           "public_romes_data.libelle_rome",
-        ])
-        .where("convention_templates.siret", "not in", (eb) =>
-          eb.selectFrom("banned_establishments").select("siret"),
-        ),
+        ]),
+      (qb) => qb.where("banned_establishments.siret", "is", null),
       (qb) =>
         params.ids?.length
           ? qb.where("convention_templates.id", "in", params.ids)


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
