### PR TITLE
#5321 - Le prescripteur ne voit plus les conventions non pré-validées par la structure d'accompagnement

### DIFF
--- a/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionQueries.ts
@@ -720,6 +720,7 @@ const makeApplyPaginatedFiltersToConventions =
     search,
     statuses,
     agencyIds,
+    omitStatusesForAgencies,
     dateStart,
     dateEnd,
     dateSubmission,
@@ -744,6 +745,15 @@ const makeApplyPaginatedFiltersToConventions =
         ({ agencyId }) =>
           agencyIds && agencyIds.length > 0
             ? agencyIds.includes(agencyId)
+            : true,
+        ({ agencyId, status }) =>
+          omitStatusesForAgencies &&
+          omitStatusesForAgencies.agencyIds.length > 0 &&
+          omitStatusesForAgencies.statuses.length > 0
+            ? !(
+                omitStatusesForAgencies.agencyIds.includes(agencyId) &&
+                omitStatusesForAgencies.statuses.includes(status)
+              )
             : true,
       ] satisfies Array<(convention: ConventionDto) => boolean>
     ).every((filter) => filter(convention));

--- a/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.integration.test.ts
@@ -979,7 +979,6 @@ describe("Pg implementation of ConventionQueries", () => {
         streetNumberAndAddress: "Rue de la République",
       })
       .build();
-
     const conventionA = new ConventionDtoBuilder()
       .withId("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
       .withSiret("12345678901235")
@@ -1849,6 +1848,172 @@ describe("Pg implementation of ConventionQueries", () => {
       });
 
       expectToEqual(result.data, [conventionA]);
+    });
+
+    describe("when omitting statuses for some agencies", () => {
+      const omittedStatuses = [
+        "READY_TO_SIGN",
+        "PARTIALLY_SIGNED",
+        "IN_REVIEW",
+      ] as const;
+      const conventionInReview = new ConventionDtoBuilder()
+        .withId("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+        .withAgencyId(differentAgencyId)
+        .withStatus("IN_REVIEW")
+        .withDateStart(new Date("2023-05-15").toISOString())
+        .withDateEnd(new Date("2023-05-20").toISOString())
+        .withDateSubmission(new Date("2023-05-10").toISOString())
+        .withUpdatedAt(anyConventionUpdatedAt)
+        .build();
+      const conventionAcceptedByCounsellor = new ConventionDtoBuilder()
+        .withId("ffffffff-ffff-4fff-8fff-ffffffffffff")
+        .withAgencyId(differentAgencyId)
+        .withStatus("ACCEPTED_BY_COUNSELLOR")
+        .withDateStart(new Date("2023-06-15").toISOString())
+        .withDateEnd(new Date("2023-06-20").toISOString())
+        .withDateSubmission(new Date("2023-06-10").toISOString())
+        .withUpdatedAt(anyConventionUpdatedAt)
+        .build();
+
+      it("should keep all statuses for agencies not in omit and hide omitted statuses for omitted agencies", async () => {
+        await Promise.all([
+          conventionRepository.save(conventionInReview, anyConventionUpdatedAt),
+          conventionRepository.save(
+            conventionAcceptedByCounsellor,
+            anyConventionUpdatedAt,
+          ),
+        ]);
+
+        const result = await conventionQueries.getPaginatedConventions({
+          pagination: { page: 1, perPage: 10 },
+          filters: {
+            agencyIds: [agencyId, differentAgencyId],
+            omitStatusesForAgencies: {
+              agencyIds: [differentAgencyId],
+              statuses: [...omittedStatuses],
+            },
+          },
+          sort: {
+            by: "dateSubmission",
+            direction: "desc",
+          },
+        });
+
+        expectToEqual(result.data, [
+          conventionAcceptedByCounsellor,
+          conventionC,
+          conventionB,
+          conventionA,
+        ]);
+        expectToEqual(result.pagination.totalRecords, 4);
+      });
+
+      it("should hide omitted statuses when the agency is both in agencyIds and omit", async () => {
+        const conventionPartiallySigned = new ConventionDtoBuilder()
+          .withId("99999999-9999-4999-8999-999999999999")
+          .withAgencyId(agencyId)
+          .withStatus("PARTIALLY_SIGNED")
+          .withDateStart(new Date("2023-05-15").toISOString())
+          .withDateEnd(new Date("2023-05-20").toISOString())
+          .withDateSubmission(new Date("2023-05-10").toISOString())
+          .withUpdatedAt(anyConventionUpdatedAt)
+          .build();
+
+        await conventionRepository.save(
+          conventionPartiallySigned,
+          anyConventionUpdatedAt,
+        );
+
+        const result = await conventionQueries.getPaginatedConventions({
+          pagination: { page: 1, perPage: 10 },
+          filters: {
+            agencyIds: [agencyId],
+            omitStatusesForAgencies: {
+              agencyIds: [agencyId],
+              statuses: [...omittedStatuses],
+            },
+          },
+          sort: {
+            by: "dateSubmission",
+            direction: "desc",
+          },
+        });
+
+        expectToEqual(result.data, [conventionC]);
+      });
+
+      it("should return IN_REVIEW only from agencies that are not omitted", async () => {
+        await conventionRepository.save(
+          conventionInReview,
+          anyConventionUpdatedAt,
+        );
+
+        const result = await conventionQueries.getPaginatedConventions({
+          pagination: { page: 1, perPage: 10 },
+          filters: {
+            agencyIds: [agencyId, differentAgencyId],
+            omitStatusesForAgencies: {
+              agencyIds: [differentAgencyId],
+              statuses: [...omittedStatuses],
+            },
+            statuses: ["IN_REVIEW"],
+          },
+          sort: {
+            by: "dateSubmission",
+            direction: "desc",
+          },
+        });
+
+        expectToEqual(result.data, [conventionB]);
+      });
+
+      it("should paginate with totalRecords that ignore omitted conventions", async () => {
+        const resultPage1 = await conventionQueries.getPaginatedConventions({
+          pagination: { page: 1, perPage: 2 },
+          filters: {
+            agencyIds: [agencyId, differentAgencyId],
+            omitStatusesForAgencies: {
+              agencyIds: [differentAgencyId],
+              statuses: [...omittedStatuses],
+            },
+          },
+          sort: {
+            by: "dateSubmission",
+            direction: "desc",
+          },
+        });
+
+        expectToEqual(resultPage1.data, [conventionC, conventionB]);
+        expectToEqual(resultPage1.pagination, {
+          currentPage: 1,
+          totalPages: 2,
+          numberPerPage: 2,
+          totalRecords: 3,
+        });
+
+        const resultPage2 = await conventionQueries.getPaginatedConventions({
+          pagination: { page: 2, perPage: 2 },
+          filters: {
+            agencyIds: [agencyId, differentAgencyId],
+            omitStatusesForAgencies: {
+              agencyIds: [differentAgencyId],
+              statuses: [...omittedStatuses],
+            },
+          },
+          sort: {
+            by: "dateSubmission",
+            direction: "desc",
+          },
+        });
+
+        expectToEqual(resultPage2.data, [conventionA]);
+        expectToEqual(resultPage2.pagination, {
+          currentPage: 2,
+          totalPages: 2,
+          numberPerPage: 2,
+          totalRecords: 3,
+        });
+      });
     });
   });
 

--- a/back/src/domains/convention/adapters/PgConventionQueries.ts
+++ b/back/src/domains/convention/adapters/PgConventionQueries.ts
@@ -52,6 +52,7 @@ import type {
   GetConventionsParams,
   GetConventionsSortBy,
   GetPaginatedConventionsParams,
+  OmitStatusesForAgenciesFilter,
 } from "../ports/ConventionQueries";
 import {
   type BroadcastFeedbackBaseQueryBuilder,
@@ -285,6 +286,7 @@ export class PgConventionQueries implements ConventionQueries {
       search,
       statuses,
       agencyIds,
+      omitStatusesForAgencies,
       dateStart,
       dateEnd,
       dateSubmission,
@@ -310,6 +312,7 @@ export class PgConventionQueries implements ConventionQueries {
         transaction: this.transaction,
       }),
       filterByAgencyIds(agencyIds),
+      filterOmitStatusesForAgencies(omitStatusesForAgencies),
       filterSearch(trimmedSearch),
       filterDate("date_start", dateStart),
       filterDate("date_end", dateEnd),
@@ -638,6 +641,26 @@ const filterByAgencyIds =
           sql<boolean>`conventions.agency_id = ANY(${agencyIds}::uuid[])`,
         )
       : builder;
+
+const filterOmitStatusesForAgencies =
+  (omitStatusesForAgencies: OmitStatusesForAgenciesFilter | undefined) =>
+  (builder: ConventionBaseQueryBuilder): ConventionBaseQueryBuilder => {
+    if (
+      !omitStatusesForAgencies ||
+      omitStatusesForAgencies.agencyIds.length === 0 ||
+      omitStatusesForAgencies.statuses.length === 0
+    )
+      return builder;
+
+    return builder.where((eb) =>
+      eb.not(
+        eb.and([
+          sql<boolean>`conventions.agency_id = ANY(${omitStatusesForAgencies.agencyIds}::uuid[])`,
+          eb("conventions.status", "in", omitStatusesForAgencies.statuses),
+        ]),
+      ),
+    );
+  };
 
 const filterByAssessmentCompletionStatus =
   (

--- a/back/src/domains/convention/ports/ConventionQueries.ts
+++ b/back/src/domains/convention/ports/ConventionQueries.ts
@@ -48,10 +48,16 @@ export type GetConventionsParams = {
   limit?: number;
 };
 
+export type OmitStatusesForAgenciesFilter = {
+  agencyIds: AgencyId[];
+  statuses: ConventionStatus[];
+};
+
 export type GetPaginatedConventionsFilters = {
   search?: string;
   statuses?: ConventionStatus[];
   agencyIds?: AgencyId[];
+  omitStatusesForAgencies?: OmitStatusesForAgenciesFilter;
   dateStart?: DateFilter;
   dateEnd?: DateFilter;
   dateSubmission?: DateFilter;

--- a/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.ts
+++ b/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.ts
@@ -1,5 +1,6 @@
 import { subMonths } from "date-fns";
 import {
+  type AgencyRight,
   type AgencyRole,
   type AgencyUserConventionListDto,
   type ConnectedUser,
@@ -49,7 +50,7 @@ export const makeGetConventionsForAgencyUser = useCaseBuilder(
 
     const user = await getUserWithRights(uow, currentUser.id);
 
-    const agencyIdsUserHasValidRightsOn = user.agencyRights
+    const agencyRightsInScope = user.agencyRights
       .filter(({ roles }) =>
         roles.some((role) => agencyRolesWithConventionAccess.includes(role)),
       )
@@ -58,19 +59,29 @@ export const makeGetConventionsForAgencyUser = useCaseBuilder(
           !departmentCodesFilter?.length ||
           departmentCodesFilter.includes(agency.address.departmentCode),
       )
-      .map(({ agency }) => agency.id);
+      .filter(
+        ({ agency }) =>
+          !agencyIdsFilter?.length || agencyIdsFilter.includes(agency.id),
+      );
 
-    const agencyIds = agencyIdsFilter?.length
-      ? agencyIdsUserHasValidRightsOn.filter((id) =>
-          agencyIdsFilter.includes(id),
-        )
-      : agencyIdsUserHasValidRightsOn;
+    const agencyIds = agencyRightsInScope.map(({ agency }) => agency.id);
+    const agencyIdsWithRefersToUserIsValidatorOn = agencyRightsInScope
+      .filter(isValidatorOfAgencyRefersTo)
+      .map(({ agency }) => agency.id);
 
     const paginated = await uow.conventionQueries.getPaginatedConventions({
       ...withSort,
       filters: {
         ...restFilters,
         agencyIds,
+        ...(agencyIdsWithRefersToUserIsValidatorOn.length > 0
+          ? {
+              omitStatusesForAgencies: {
+                agencyIds: agencyIdsWithRefersToUserIsValidatorOn,
+                statuses: ["READY_TO_SIGN", "PARTIALLY_SIGNED", "IN_REVIEW"],
+              },
+            }
+          : {}),
         dateEnd: {
           ...restFilters.dateEnd,
           from: shouldUseDefaultDateEndFrom(restFilters.dateEnd?.from, now)
@@ -101,6 +112,12 @@ const agencyRolesWithConventionAccess: AgencyRole[] = [
   "agency-admin",
   "agency-viewer",
 ];
+
+const isValidatorOfAgencyRefersTo = ({ agency, roles }: AgencyRight) =>
+  !!agency.refersToAgencyId &&
+  !roles.includes("counsellor") &&
+  !roles.includes("agency-admin") &&
+  !roles.includes("agency-viewer");
 
 const shouldUseDefaultDateEndFrom = (
   dateEndFrom: DateString | undefined,

--- a/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.unit.test.ts
@@ -430,4 +430,164 @@ describe("GetConventionsForAgencyUser", () => {
       );
     });
   });
+
+  describe("Agency with refersTo", () => {
+    const agencyWithRefersTo = toAgencyWithRights(
+      new AgencyDtoBuilder()
+        .withId("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        .withName("Structure d'accompagnement")
+        .withRefersToAgencyInfo({
+          refersToAgencyId: agency.id,
+          refersToAgencyName: agency.name,
+          refersToAgencyContactEmail: agency.contactEmail,
+        })
+        .build(),
+      {
+        [agencyUserId]: { isNotifiedByEmail: true, roles: ["validator"] },
+      },
+    );
+
+    const conventionInReviewOnAgency = new ConventionDtoBuilder()
+      .withId("convention-in-review-on-agency")
+      .withAgencyId(agency.id)
+      .withStatus("IN_REVIEW")
+      .build();
+    const conventionInReviewOnAgencyWithRefersTo = new ConventionDtoBuilder()
+      .withId("convention-in-review-on-agency-with-refers-to")
+      .withAgencyId(agencyWithRefersTo.id)
+      .withStatus("IN_REVIEW")
+      .build();
+    const conventionReadyToSignOnAgencyWithRefersTo = new ConventionDtoBuilder()
+      .withId("convention-ready-to-sign-on-agency-with-refers-to")
+      .withAgencyId(agencyWithRefersTo.id)
+      .withStatus("READY_TO_SIGN")
+      .build();
+    const conventionPartiallySignedOnAgencyWithRefersTo =
+      new ConventionDtoBuilder()
+        .withId("convention-partially-signed-on-agency-with-refers-to")
+        .withAgencyId(agencyWithRefersTo.id)
+        .withStatus("PARTIALLY_SIGNED")
+        .build();
+    const conventionAcceptedByCounsellorOnAgencyWithRefersTo =
+      new ConventionDtoBuilder()
+        .withId("convention-accepted-by-counsellor-on-agency-with-refers-to")
+        .withAgencyId(agencyWithRefersTo.id)
+        .withStatus("ACCEPTED_BY_COUNSELLOR")
+        .build();
+    const conventionRejectedOnAgencyWithRefersTo = new ConventionDtoBuilder()
+      .withId("convention-rejected-on-agency-with-refers-to")
+      .withAgencyId(agencyWithRefersTo.id)
+      .withStatus("REJECTED")
+      .build();
+    const conventionDeprecatedOnAgencyWithRefersTo = new ConventionDtoBuilder()
+      .withId("convention-deprecated-on-agency-with-refers-to")
+      .withAgencyId(agencyWithRefersTo.id)
+      .withStatus("DEPRECATED")
+      .build();
+
+    beforeEach(() => {
+      uow.agencyRepository.agencies = [agency, agencyWithRefersTo];
+      uow.conventionRepository.setConventions([
+        conventionInReviewOnAgency,
+        conventionInReviewOnAgencyWithRefersTo,
+        conventionReadyToSignOnAgencyWithRefersTo,
+        conventionPartiallySignedOnAgencyWithRefersTo,
+        conventionAcceptedByCounsellorOnAgencyWithRefersTo,
+        conventionRejectedOnAgencyWithRefersTo,
+        conventionDeprecatedOnAgencyWithRefersTo,
+      ]);
+    });
+
+    it("should not return READY_TO_SIGN, PARTIALLY_SIGNED or IN_REVIEW of an agency with refersTo when user is validator, and still return IN_REVIEW of the agency without refersTo", async () => {
+      const result = await getConventionsForAgencyUser.execute(
+        { pagination: { page: 1, perPage: 10 } },
+        currentUser,
+      );
+
+      expectArraysToEqualIgnoringOrder(
+        result.data.map(({ id }) => id),
+        [
+          conventionInReviewOnAgency.id,
+          conventionAcceptedByCounsellorOnAgencyWithRefersTo.id,
+          conventionRejectedOnAgencyWithRefersTo.id,
+          conventionDeprecatedOnAgencyWithRefersTo.id,
+        ],
+      );
+    });
+
+    it.each([
+      {
+        roles: ["counsellor"] satisfies AgencyRole[],
+        case: "counsellor",
+      },
+      {
+        roles: ["counsellor", "validator"] satisfies AgencyRole[],
+        case: "counsellor and validator",
+      },
+    ])("should return READY_TO_SIGN, PARTIALLY_SIGNED and IN_REVIEW of an agency with refersTo when user is $case", async ({
+      roles,
+    }) => {
+      uow.agencyRepository.agencies = [
+        agency,
+        {
+          ...agencyWithRefersTo,
+          usersRights: {
+            [agencyUserId]: { isNotifiedByEmail: true, roles },
+          },
+        },
+      ];
+
+      const result = await getConventionsForAgencyUser.execute(
+        { pagination: { page: 1, perPage: 10 } },
+        currentUser,
+      );
+
+      expectArraysToEqualIgnoringOrder(
+        result.data.map(({ id }) => id),
+        [
+          conventionInReviewOnAgency.id,
+          conventionInReviewOnAgencyWithRefersTo.id,
+          conventionReadyToSignOnAgencyWithRefersTo.id,
+          conventionPartiallySignedOnAgencyWithRefersTo.id,
+          conventionAcceptedByCounsellorOnAgencyWithRefersTo.id,
+          conventionRejectedOnAgencyWithRefersTo.id,
+          conventionDeprecatedOnAgencyWithRefersTo.id,
+        ],
+      );
+    });
+
+    it("should not return IN_REVIEW of an agency with refersTo when filtering by status IN_REVIEW", async () => {
+      const result = await getConventionsForAgencyUser.execute(
+        {
+          filters: { statuses: ["IN_REVIEW"] },
+          pagination: { page: 1, perPage: 10 },
+        },
+        currentUser,
+      );
+
+      expectToEqual(
+        result.data.map(({ id }) => id),
+        [conventionInReviewOnAgency.id],
+      );
+    });
+
+    it("should not return IN_REVIEW of an agency with refersTo when filtering by that agency id", async () => {
+      const result = await getConventionsForAgencyUser.execute(
+        {
+          filters: { agencyIds: [agencyWithRefersTo.id] },
+          pagination: { page: 1, perPage: 10 },
+        },
+        currentUser,
+      );
+
+      expectArraysToEqualIgnoringOrder(
+        result.data.map(({ id }) => id),
+        [
+          conventionAcceptedByCounsellorOnAgencyWithRefersTo.id,
+          conventionRejectedOnAgencyWithRefersTo.id,
+          conventionDeprecatedOnAgencyWithRefersTo.id,
+        ],
+      );
+    });
+  });
 });

--- a/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.unit.test.ts
+++ b/back/src/domains/convention/use-cases/GetConventionsForAgencyUser.unit.test.ts
@@ -524,6 +524,14 @@ describe("GetConventionsForAgencyUser", () => {
         roles: ["counsellor", "validator"] satisfies AgencyRole[],
         case: "counsellor and validator",
       },
+      {
+        roles: ["agency-admin"] satisfies AgencyRole[],
+        case: "agency-admin",
+      },
+      {
+        roles: ["agency-viewer"] satisfies AgencyRole[],
+        case: "agency-viewer",
+      },
     ])("should return READY_TO_SIGN, PARTIALLY_SIGNED and IN_REVIEW of an agency with refersTo when user is $case", async ({
       roles,
     }) => {


### PR DESCRIPTION
Fixes #5321

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)
