### PR TITLE
#5536 - Motif unique et compréhensible dans le mail de convention obsolète

### DIFF
--- a/back/src/domains/convention/adapters/InMemoryConventionRepository.ts
+++ b/back/src/domains/convention/adapters/InMemoryConventionRepository.ts
@@ -18,6 +18,7 @@ export class InMemoryConventionRepository implements ConventionRepository {
 
   public async deprecateConventionsWithoutDefinitiveStatusEndedSince(
     endedSince: Date,
+    statusJustification: string,
   ): Promise<ConventionId[]> {
     const conventionsToDeprecate = await Promise.all(
       values(this.#conventions)
@@ -35,7 +36,7 @@ export class InMemoryConventionRepository implements ConventionRepository {
           this.update({
             ...convention,
             status: "DEPRECATED",
-            statusJustification: `Devenu obsolète car le statut était ${convention.status} alors que la date de fin est dépassée depuis longtemps`,
+            statusJustification,
           }),
         ),
     );

--- a/back/src/domains/convention/adapters/PgConventionRepository.integration.test.ts
+++ b/back/src/domains/convention/adapters/PgConventionRepository.integration.test.ts
@@ -1202,11 +1202,13 @@ describe("PgConventionRepository", () => {
         ),
       ]);
 
+      const statusJustification = "test-deprecation-justification";
       const updatedAt = timeGateway.now().toISOString();
 
       const numberOfUpdatedConventions =
         await conventionRepository.deprecateConventionsWithoutDefinitiveStatusEndedSince(
           dateSince,
+          statusJustification,
           updatedAt,
         );
 
@@ -1220,18 +1222,22 @@ describe("PgConventionRepository", () => {
       await expectConventionInRepoToBeDeprecated(
         convention1ToMarkAsDeprecated,
         updatedAt,
+        statusJustification,
       );
       await expectConventionInRepoToBeDeprecated(
         convention7ToMarkAsDeprecated,
         updatedAt,
+        statusJustification,
       );
       await expectConventionInRepoToBeDeprecated(
         convention8ToMarkAsDeprecated,
         updatedAt,
+        statusJustification,
       );
       await expectConventionInRepoToBeDeprecated(
         convention9ToMarkAsDeprecated,
         updatedAt,
+        statusJustification,
       );
       await expectConventionInRepoToEqual(convention2ToKeepAsIs);
       await expectConventionInRepoToEqual(convention3ToKeepAsIs);
@@ -1421,11 +1427,12 @@ describe("PgConventionRepository", () => {
   const expectConventionInRepoToBeDeprecated = async (
     convention: ConventionDto,
     updatedAt: DateString,
+    statusJustification: string,
   ) => {
     expectToEqual(await conventionRepository.getById(convention.id), {
       ...convention,
       status: "DEPRECATED",
-      statusJustification: `Devenu obsolète car le statut était ${convention.status} alors que la date de fin est dépassée depuis longtemps`,
+      statusJustification,
       updatedAt,
     });
   };

--- a/back/src/domains/convention/adapters/PgConventionRepository.ts
+++ b/back/src/domains/convention/adapters/PgConventionRepository.ts
@@ -26,13 +26,14 @@ export class PgConventionRepository implements ConventionRepository {
 
   public async deprecateConventionsWithoutDefinitiveStatusEndedSince(
     endedSince: Date,
+    statusJustification: string,
     now?: DateString,
   ) {
     const result = await this.transaction
       .updateTable("conventions")
       .set({
         status: "DEPRECATED",
-        status_justification: sql`'Devenu obsolète car le statut était ' || status || ' alors que la date de fin est dépassée depuis longtemps'`,
+        status_justification: statusJustification,
         updated_at: now ?? sql`now()`,
       })
       .where("date_end", "<=", endedSince)

--- a/back/src/domains/convention/ports/ConventionRepository.ts
+++ b/back/src/domains/convention/ports/ConventionRepository.ts
@@ -9,6 +9,7 @@ export interface ConventionRepository {
   ) => Promise<ConventionId | undefined>;
   deprecateConventionsWithoutDefinitiveStatusEndedSince: (
     endedSince: Date,
+    statusJustification: string,
     now?: DateString,
   ) => Promise<ConventionId[]>;
   deleteOldConventions: (params: {

--- a/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.test.ts
+++ b/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.test.ts
@@ -64,7 +64,7 @@ describe("MarkOldConventionAsDeprecated", () => {
       ...conventionToDeprecate,
       status: "DEPRECATED" as const,
       statusJustification:
-        "Devenu obsolète car le statut était PARTIALLY_SIGNED alors que la date de fin est dépassée depuis longtemps",
+        "La convention n'a jamais été validée, et la date de fin d'immersion indiquée est dépassée depuis un mois.",
     };
 
     expectToEqual(uow.conventionRepository.conventions, [

--- a/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.ts
+++ b/back/src/domains/convention/use-cases/MarkOldConventionAsDeprecated.ts
@@ -23,6 +23,7 @@ export const makeMarkOldConventionAsDeprecated = useCaseBuilder(
     const updatedConventionsIds =
       await uow.conventionRepository.deprecateConventionsWithoutDefinitiveStatusEndedSince(
         inputParams.deprecateSince,
+        "La convention n'a jamais été validée, et la date de fin d'immersion indiquée est dépassée depuis un mois.",
       );
 
     const conventions = await uow.conventionQueries.getConventions({


### PR DESCRIPTION
Fixes #5536

## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

