### PR TITLE
#5542 - Fix des retours en arrière sur la recherche

### DIFF
--- a/front/src/app/components/search/SearchListResults.tsx
+++ b/front/src/app/components/search/SearchListResults.tsx
@@ -70,7 +70,7 @@ export const SearchListResults = ({
   ) => void;
   useNaturalLanguageForAppellations?: boolean;
 }) => {
-  const { triggerSearch } = useSearch(route);
+  const { navigateToSearch } = useSearch(route);
   const { data: searchResults, pagination } = useAppSelector(
     searchSelectors.searchResultsWithPagination,
   );
@@ -79,7 +79,7 @@ export const SearchListResults = ({
   const { enableSearchByScore } = useAppSelector(
     featureFlagSelectors.featureFlagState,
   );
-  const { getValues, register, reset } = useFormContext<SearchPageParams>();
+  const { getValues, register } = useFormContext<SearchPageParams>();
   const formValues = getValues();
   const searchParams = useAppSelector(searchSelectors.searchParams);
   const [isPanelOpened, setIsPanelOpened] = useState(false);
@@ -416,17 +416,10 @@ export const SearchListResults = ({
                       title: `Résultats de recherche, page : ${pageNumber}`,
                       onClick: (event) => {
                         event.preventDefault();
-                        reset({
+                        navigateToSearch({
                           ...searchParams,
                           page: pageNumber,
                         });
-                        triggerSearch(
-                          {
-                            ...searchParams,
-                            page: pageNumber,
-                          },
-                          isExternal,
-                        );
                       },
                       href: "#", // TODO : PR vers react-dsfr pour gérer pagination full front
                       key: `pagination-link-${pageNumber}`,
@@ -453,13 +446,10 @@ export const SearchListResults = ({
                       id: domElementIds.search.resultPerPageDropdown,
                       onChange: (event) => {
                         const value = event.currentTarget.value;
-                        triggerSearch(
-                          {
-                            ...searchParams,
-                            perPage: Number.parseInt(value, 10),
-                          },
-                          isExternal,
-                        );
+                        navigateToSearch({
+                          ...searchParams,
+                          perPage: Number.parseInt(value, 10),
+                        });
                       },
                       value: numberPerPage.toString() as ResultsPerPageOption,
                       "aria-label": "Nombre de résultats par page",

--- a/front/src/app/hooks/search.hooks.ts
+++ b/front/src/app/hooks/search.hooks.ts
@@ -1,4 +1,3 @@
-import { useDispatch } from "react-redux";
 import {
   type AcquisitionParams,
   acquisitionParams,
@@ -12,10 +11,7 @@ import {
   getUrlParameters,
   isKeyInObjectAndValueNotUndefinedNorEmpty,
 } from "src/app/utils/url.utils";
-import {
-  type SearchPageParams,
-  searchSlice,
-} from "src/core-logic/domain/search/search.slice";
+import type { SearchPageParams } from "src/core-logic/domain/search/search.slice";
 import type { Route } from "type-route";
 
 export const encodedSearchUriParams = [
@@ -58,31 +54,15 @@ const filterUrlsParamsAndUpdateUrl = ({
       return acc;
     }, filteredUrlParams),
   };
-  frontRoutes[routeName](encodedUrlParams).replace();
+  frontRoutes[routeName](encodedUrlParams).push();
 };
 
-export const useSearch = ({ name }: SearchRoute) => {
-  const dispatch = useDispatch();
-  return {
-    triggerSearch: (params: SearchPageParams, isExternal: boolean) => {
-      dispatch(
-        searchSlice.actions.getOffersRequested({
-          ...params,
-          isExternal,
-        }),
-      );
-      filterUrlsParamsAndUpdateUrl({
-        values: params,
-        urlParams: getUrlParameters(window.location),
-        routeName: name,
-      });
-    },
-    changeCurrentPage: (values: SearchPageParams) => {
-      filterUrlsParamsAndUpdateUrl({
-        values,
-        urlParams: getUrlParameters(window.location),
-        routeName: name,
-      });
-    },
-  };
-};
+export const useSearch = ({ name }: SearchRoute) => ({
+  navigateToSearch: (params: SearchPageParams) => {
+    filterUrlsParamsAndUpdateUrl({
+      values: params,
+      urlParams: getUrlParameters(window.location),
+      routeName: name,
+    });
+  },
+});

--- a/front/src/app/pages/search/SearchPage.tsx
+++ b/front/src/app/pages/search/SearchPage.tsx
@@ -21,11 +21,7 @@ import {
 } from "react-design-system";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useDispatch } from "react-redux";
-import {
-  defaultPerPageInWebPagination,
-  domElementIds,
-  type ValueOf,
-} from "shared";
+import { domElementIds, type ValueOf } from "shared";
 import { Breadcrumbs } from "src/app/components/Breadcrumbs";
 import { AppellationAutocomplete } from "src/app/components/forms/autocomplete/AppellationAutocomplete";
 import { PlaceAutocomplete } from "src/app/components/forms/autocomplete/PlaceAutocomplete";
@@ -173,7 +169,7 @@ export const SearchPage = ({
       nafCodes: undefined,
       nafLabel: undefined,
       page: 1,
-      perPage: defaultPerPageInWebPagination,
+      perPage: 24,
       appellations: isExternal
         ? defaultValuesForExternalSearch.appellations
         : undefined,

--- a/front/src/app/pages/search/SearchPage.tsx
+++ b/front/src/app/pages/search/SearchPage.tsx
@@ -6,6 +6,7 @@ import {
   type ElementRef,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -47,7 +48,10 @@ import { featureFlagSelectors } from "src/core-logic/domain/featureFlags/feature
 import { geosearchSlice } from "src/core-logic/domain/geosearch/geosearch.slice";
 import { nafSlice } from "src/core-logic/domain/naf/naf.slice";
 import { searchSelectors } from "src/core-logic/domain/search/search.selectors";
-import type { SearchPageParams } from "src/core-logic/domain/search/search.slice";
+import {
+  type SearchPageParams,
+  searchSlice,
+} from "src/core-logic/domain/search/search.slice";
 import { useStyles } from "tss-react/dsfr";
 import "./SearchPage.scss";
 import {
@@ -144,7 +148,7 @@ export const SearchPage = ({
     searchSelectors.searchResultsWithPagination,
   );
   const isLoading = useAppSelector(searchSelectors.isLoading);
-  const { triggerSearch } = useSearch(route);
+  const { navigateToSearch } = useSearch(route);
   const [searchMade, setSearchMade] = useState<SearchPageParams | null>(null);
   const searchResultsWrapper = useRef<ElementRef<"div">>(null);
   const innerSearchResultWrapper = useRef<ElementRef<"div">>(null);
@@ -152,34 +156,39 @@ export const SearchPage = ({
   const { enableSearchByScore } = useAppSelector(
     featureFlagSelectors.featureFlagState,
   );
-  const initialValues: SearchPageParams = {
-    sortBy: enableSearchByScore ? "score" : "date",
-    sortOrder: "desc",
-    distanceKm: isExternal
-      ? defaultValuesForExternalSearch.distanceKm
-      : undefined,
-    latitude: isExternal ? defaultValuesForExternalSearch.latitude : undefined,
-    longitude: isExternal
-      ? defaultValuesForExternalSearch.longitude
-      : undefined,
-    fitForDisabledWorkers: undefined,
-    nafCodes: undefined,
-    nafLabel: undefined,
-    page: 1,
-    perPage: defaultPerPageInWebPagination,
-    appellations: isExternal
-      ? defaultValuesForExternalSearch.appellations
-      : undefined,
-    place: isExternal ? defaultValuesForExternalSearch.place : undefined,
-    appellationCodes: isExternal
-      ? defaultValuesForExternalSearch.appellations.map(
-          (appellation) => appellation.appellationCode,
-        )
-      : undefined,
-    remoteWorkModes: undefined,
-    showOnlyAvailableOffers: true,
-    ...acquisitionParams,
-  };
+  const initialValues: SearchPageParams = useMemo(
+    () => ({
+      sortBy: enableSearchByScore ? "score" : "date",
+      sortOrder: "desc",
+      distanceKm: isExternal
+        ? defaultValuesForExternalSearch.distanceKm
+        : undefined,
+      latitude: isExternal
+        ? defaultValuesForExternalSearch.latitude
+        : undefined,
+      longitude: isExternal
+        ? defaultValuesForExternalSearch.longitude
+        : undefined,
+      fitForDisabledWorkers: undefined,
+      nafCodes: undefined,
+      nafLabel: undefined,
+      page: 1,
+      perPage: defaultPerPageInWebPagination,
+      appellations: isExternal
+        ? defaultValuesForExternalSearch.appellations
+        : undefined,
+      place: isExternal ? defaultValuesForExternalSearch.place : undefined,
+      appellationCodes: isExternal
+        ? defaultValuesForExternalSearch.appellations.map(
+            (appellation) => appellation.appellationCode,
+          )
+        : undefined,
+      remoteWorkModes: undefined,
+      showOnlyAvailableOffers: true,
+      ...acquisitionParams,
+    }),
+    [enableSearchByScore, isExternal, acquisitionParams],
+  );
 
   const [tempValue, setTempValue] = useState<SearchPageParams>(initialValues);
   const filterFormValues = useCallback((values: SearchPageParams) => {
@@ -195,18 +204,23 @@ export const SearchPage = ({
     }, {} as SearchPageParams);
   }, []);
   const routeParams = route.params as Partial<SearchPageParams>;
+  const buildValuesFromRouteParams = useCallback(
+    (paramsFromRoute: Partial<SearchPageParams>): SearchPageParams =>
+      keys(initialValues).reduce(
+        (acc, currentKey) => ({
+          ...acc,
+          [currentKey]: getSearchRouteParam(
+            currentKey,
+            paramsFromRoute[currentKey],
+            initialValues[currentKey],
+          ),
+        }),
+        initialValues,
+      ),
+    [initialValues],
+  );
   const methods = useForm<SearchPageParams>({
-    defaultValues: keys(initialValues).reduce(
-      (acc, currentKey) => ({
-        ...acc,
-        [currentKey]: getSearchRouteParam(
-          currentKey,
-          routeParams[currentKey],
-          initialValues[currentKey],
-        ),
-      }),
-      {},
-    ),
+    defaultValues: buildValuesFromRouteParams(routeParams),
     mode: "onTouched",
   });
   const { handleSubmit, setValue, control, getValues, reset } = methods;
@@ -218,46 +232,34 @@ export const SearchPage = ({
 
   const searchHasBeenMade = searchMade !== null;
 
-  const internalSearchIsAvailableForInitialSearchRequest =
-    !isExternal &&
-    !searchHasBeenMade &&
-    keys(routeParams).length &&
-    lat !== 0 &&
-    lon !== 0;
-
-  const externalSearchIsAvailableForInitialSearchRequest =
-    isExternal &&
-    !searchHasBeenMade &&
-    keys(routeParams).length &&
-    lat !== 0 &&
-    lon !== 0 &&
-    distanceKm !== 0;
-  routeParams.appellationCodes && routeParams.appellationCodes.length > 0;
-
   const onSearchFormSubmit = useCallback(
     (updatedValues: SearchPageParams) => {
-      setSearchMade(updatedValues);
-      reset(updatedValues);
-      triggerSearch(filterFormValues(updatedValues), isExternal);
+      navigateToSearch(filterFormValues(updatedValues));
     },
-    [triggerSearch, filterFormValues, isExternal],
+    [navigateToSearch, filterFormValues],
   );
 
   useScrollTo(pagination?.currentPage ?? 1);
 
   useEffect(() => {
-    if (
-      internalSearchIsAvailableForInitialSearchRequest ||
-      externalSearchIsAvailableForInitialSearchRequest
-    ) {
-      onSearchFormSubmit(filterFormValues(formValues));
-    }
+    if (keys(routeParams).length === 0) return;
+    const valuesFromUrl = buildValuesFromRouteParams(routeParams);
+    if (!canSubmitSearch(valuesFromUrl)) return;
+    setSearchMade(valuesFromUrl);
+    reset(valuesFromUrl);
+    dispatch(
+      searchSlice.actions.getOffersRequested({
+        ...filterFormValues(valuesFromUrl),
+        isExternal,
+      }),
+    );
   }, [
-    internalSearchIsAvailableForInitialSearchRequest,
-    externalSearchIsAvailableForInitialSearchRequest,
-    onSearchFormSubmit,
+    routeParams,
+    buildValuesFromRouteParams,
     filterFormValues,
-    formValues,
+    reset,
+    dispatch,
+    isExternal,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Checklist avant RfR

### Revue du code (self-review)
- [x] Commits propres (pas de WIP, squash si nécessaire)
- [x] Relecture complète du diff effectuée
- [x] Pas de `console.log`, `TODO` ou code de debug restant

### État de la PR
- [x] Le titre respecte la convention : `#ID_ISSUE - Message clair et en français, compréhensible par quelqu'un du métier`
- [x] Auteurs assignés sur la PR et l'issue liée
- [x] Description du travail commentée sur l'issue (cf. `/document-issue`)
- [x] L'issue est en **RfR** dans le [projet GitHub](https://github.com/orgs/Immersion-Facilitee/projects/1?query=sort%3Aupdated-desc+is%3Aopen)

## Points d'attention pour le reviewer

Un simple push() à chaque modification de filtre/page ne suffisait pas, il a fallu extraire le dispatch qui récupère les nouveaux résultats dans un useEffect plutôt que dans le search hooks. désormais le flow est :

modif de filtre/page --> push le changement d'url dans le search hook --> déclanchement du useEffect qui dispatch et refetch